### PR TITLE
Keep empty directory deploy/scripts

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           node ./build.js
           cp -R ./dist/. ../deploy/scripts/
+          ls -l ../deploy/scripts/
 
       - name: Deploy SAM app to ECR
         uses: alphagov/di-devplatform-upload-action-ecr@1.0.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,12 +1,8 @@
 name: Unit Test
 
 on:
-  push:
-    branches:
-    - main
   pull_request:
-    branches:
-    - main
+    types: [opened, synchronize, reopened]
 
 jobs:
   k6_unit_test:

--- a/.gitignore
+++ b/.gitignore
@@ -436,5 +436,3 @@ node_modules
 */node_modules
 scripts/dist
 deploy/scripts
-
-!/**/.gitkeep


### PR DESCRIPTION
This will ignore the content of deploy/scripts, but not the directory itself.

Issue: PLAT-400
Co-authored-by: