### PR TITLE
PLAT-412 S3 ListAllMyBuckets limited access

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -125,6 +125,16 @@ Resources:
             Action:
               - iam:PassRole
             Resource: !GetAtt CodeBuildServiceRole.Arn
+          - Effect: "Allow"
+            Action:
+              - "s3:ListAllMyBuckets"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::*"
+              - !Sub "arn:${AWS::Partition}:s3:::*/*"
+            Condition:
+              StringEquals:
+                "s3:ResourceAccount":
+                  - !Sub "${AWS::AccountId}"
 
   LoadTestCodeBuildProject:
     Type: AWS::CodeBuild::Project


### PR DESCRIPTION
Required permission for Start build with overrides when assuming perf tester role. Online documentation: https://repost.aws/questions/QUxATL4vuIRrGLroE6l2ONtA/access-denied-when-starting-build-with-overrides

Issue: PLAT-412
Co-authored-by: