### PR TITLE
Add tags to k6 metrics

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -185,20 +185,14 @@ Resources:
                 - mkdir -p "$TEST_REPORT_DIR"
             build:
               commands:
-                - |
-                  echo "Importing output from $BACKEND_STACK_NAME"
-                - |
-                  aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --region "${AWS::Region}" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
-                - |
-                  eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
-                - |
-                  echo "Importing output from $FRONTEND_STACK_NAME"
-                - |
-                  aws cloudformation describe-stacks --stack-name "$FRONTEND_STACK_NAME" --region "${AWS::Region}" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
-                - |
-                  eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
-                - echo Run performance test
-                - k6 run $WORK_DIR/$TEST_SCRIPT --out json=$TEST_REPORT_DIR/report.json --out output-dynatrace
+                - echo "Importing output from $BACKEND_STACK_NAME"
+                - aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --region "${AWS::Region}" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
+                - eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+                - echo "Importing output from $FRONTEND_STACK_NAME"
+                - aws cloudformation describe-stacks --stack-name "$FRONTEND_STACK_NAME" --region "${AWS::Region}" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
+                - eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+                - echo "Run performance test"
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out output-dynatrace
             post_build:
               commands:
                 - echo Performance test complete


### PR DESCRIPTION
### Updated
- [`deploy/template.yaml`](deploy/template.yaml) - Inlined multiline commands and added tags for the test script and account ID to the k6 CLI command