### PR TITLE
[PLAT-495] Dynatrace Dashboard Link

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -198,7 +198,8 @@ Resources:
                 - echo "Run performance test"
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --tag build_id=$CODEBUILD_BUILD_ID --out output-dynatrace
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
-                - echo "${K6_DYNATRACE_URL}/#dashboard;gtf=${start}%20to%20${end};id=${K6_DYNATRACE_DASHBOARD_ID};gf=all;es=CUSTOM_DIMENSION-build_id:${CODEBUILD_BUILD_ID}"
+                - |
+                  echo Dashboard link: "$K6_DYNATRACE_URL"/#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID"
             post_build:
               commands:
                 - echo Performance test complete


### PR DESCRIPTION
Adding a link to the dynatrace dashboard with the correct timeframe and filter for the current build ID.
PLAT-495


