### PR TITLE
Dynatrace k6 extension repository reference update in Docker image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,7 +19,7 @@ FROM golang:1.18-alpine as k6-build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
-RUN xk6 build v0.40.0 --with github.com/henrikrexed/xk6-output-dynatrace@latest --output /k6
+RUN xk6 build v0.40.0 --with github.com/Dynatrace/xk6-output-dynatrace@latest --output /k6
 
 # ---
 # Run


### PR DESCRIPTION
Creating a new PR to replace https://github.com/alphagov/di-lime-performance/pull/4 and fix issue #27 