### PR TITLE
Removing trailing slash from CFN env variables

### DIFF
--- a/deploy/scripts/src/devplatform-test.ts
+++ b/deploy/scripts/src/devplatform-test.ts
@@ -72,8 +72,8 @@ export function setup (): void {
 }
 
 const env = {
-  FE_URL: __ENV.CFN_HelloWorldApi, // Output from demoNodeApp
-  BE_URL: __ENV.CFN_ApiGatewayEndpoint // Output from demoNodeApp
+  FE_URL: __ENV.CFN_HelloWorldApi.replace(/\/$/, ''), // Output from demoNodeApp
+  BE_URL: __ENV.CFN_ApiGatewayEndpoint.replace(/\/$/, '') // Output from demoNodeApp
 }
 
 export function demoSamApp (): void {


### PR DESCRIPTION
Sometimes the CloudFormation stack URL output has a trailing forward slash, so in the `devplatform-test.ts` script this is now being removed with a `.replace` function call. To fix issue #34