### PR TITLE
[QA-100] Combining k6.checks into one metric

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -21,6 +21,11 @@ processors:
         - action: add_label
           new_label: build_id
           new_value: "{ID}"
+    - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
+      match_type: regexp
+      action: combine
+      new_name: k6.checks
+      submatch_case: lower
 
 exporters:
   otlphttp:


### PR DESCRIPTION
## QA-100

Metrics for k6 checks are currently being split by check name and result, with individual metrics for each combination such as:
- `k6.check.is_status_200.fail`
- `k6.check.is_status_200.pass`
- `k6.check.verify_page_content.fail`
- `k6.check.verify_page_content.pass`

This PR uses the `metricstransform` processor to [combine](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor#combine-metrics) all these metrics into one `k6.checks` metric with `name` and `result` tags to differentiate the statistics.

Also removed the `hostmetrics` process receiver as this was not currently working.
