### PR TITLE
[QA-113] Fix Dynatrace dashboard link logging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -200,11 +200,11 @@ Resources:
                 - eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
                 - echo "Run performance test"
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
+            post_build:
+              commands:
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |
                   echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID
-            post_build:
-              commands:
                 - echo Performance test complete
 
       Tags:


### PR DESCRIPTION
##  QA-113


Moving dashboard link output to post_build commands to resolve #40 

