### PR TITLE
[QA-125] Updating CodeBuild timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -159,6 +159,7 @@ Resources:
         Image: "CONTAINER-IMAGE-PLACEHOLDER" # Replace this with the ECR repo for this SAM container pipeline.
         ImagePullCredentialsType: "SERVICE_ROLE"
         Type: "LINUX_CONTAINER"
+      TimeoutInMinutes: 480
       Source:
         Type: "NO_SOURCE"
         BuildSpec: !Sub |


### PR DESCRIPTION
## QA-125

Adding a parameter to the CodeBuild definition in the CloudFormation template to set the build timeout to 8 hours. Previously this was undefined and so was set to the default of 1 hour. Increasing this will enable performance tests longer than one hour to execute.