### PR TITLE
[QA-126] Limit OpenTelemetry batch sizes

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -11,6 +11,7 @@ receivers:
 
 processors:
   batch:
+    send_batch_max_size: 16384
 
   metricstransform:
     transforms:


### PR DESCRIPTION
## QA-126

Add a limit in the OpenTelemetry config to limit the batch size to double the default `send_batch_size` of `8,192`.
Limits max batch size to `16,384`. This will split up larger batches to avoid HTTP 413 responses from Dynatrace.

Batch processor documentation [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md).