### PR TITLE
PLAT-913 A sample template containing Performance tester role

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,11 @@
+### performance-tester-permissions.yaml ###
+This is a sample CloudFormation template file based on common infra [roles-for-engineers](https://github.com/alphagov/di-ipv-core-common-infra/blob/main/cloudformation/roles-for-engineers/template.yaml) infrastructure template.
+
+It shows the permissions given to the testers along with:
+[arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess](https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#developer-access-policy)
+
+IAM roles to be used by engineers. Each environment has four roles consisting Readonly, Support, PerformanceTester and Admin. Populate the environments
+mappings with real account ids and replace dummy values.
+
+A role can only be assumed if the principal has permission to do so and is connected via the office network or VPN.
+To grant an engineer access add their gds-users IAM arn to the appropriate entry in the Mappings section.

--- a/deploy/performance-tester-permissions.yaml
+++ b/deploy/performance-tester-permissions.yaml
@@ -1,0 +1,143 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  This infra template is intentionally incomplete, to be used as a reference
+
+  IAM roles to be used by engineers. Each environment has four roles consisting
+  Readonly, Support, PerformanceTester and Admin. A role can only be assumed if the principal has
+  permission to do so and is connected via the office network or VPN.
+  To grant an engineer access add their gds-users IAM arn to the appropriate
+  entry in the Mappings section below.
+
+Mappings:
+  allEnvironments:
+    officeIpAddresses:
+    # The IP address blocks below should be referenced from here:
+    # https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-gds/gds-internal-it/gds-internal-it-network-public-ip-addresses
+      ipAddresses:
+      - "0.0.0.0/32" # list allowed ip addresses here
+  
+  # Principals who can assume each role keyed by the AWS account
+  "333333333333": # sample aws account id
+    readonly:
+      principals:
+      - "arn:aws:iam::<gds_users_account_id_goes_here>:user/example.readonlyuser@example.gov.uk"
+    performancetester:
+      principals:
+      - "arn:aws:iam::<gds_users_account_id_goes_here>:user/example.performancetester@example.gov.uk"
+    support:
+      principals:
+      - "arn:aws:iam::<gds_users_account_id_goes_here>:user/example.support@example.gov.uk"
+    admin:
+      principals:
+      - "arn:aws:iam::<gds_users_account_id_goes_here>:user/example.admin@example.gov.uk"
+
+Conditions:
+  IsBuildOrStaging:
+    Fn::Or:
+    - Fn::Equals [ !Ref AWS::AccountId, "222222222222" ] # staging
+    - Fn::Equals [ !Ref AWS::AccountId, "333333333333" ] # build
+
+Resources:
+  PerformanceRolePolicy:
+    Condition: IsBuildOrStaging
+    Type: AWS::IAM::ManagedPolicy
+    #checkov:skip=CKV_AWS_111: Dev environment pipeline execution allowed
+    Properties:
+      Description: Allows permissions to some more resources for performance testers.
+      # This is also referenced in tech-ops-private/reliability-engineering/terraform/deployments/di-ipv-core-prod/account/site.tf
+      # and tech-ops-private/reliability-engineering/terraform/deployments/di-ipv-core-integration/account/site.tf
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:DescribeLogGroups
+              - logs:DescribeLogStreams
+              - logs:PutLogEvents
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*"
+            Sid: AllowPerfTesterLogCreation
+          - Effect: "Allow"
+            Action:
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:BatchGetImage"
+              - "ecr:GetDownloadUrlForLayer"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:ecr:${AWS::Region}:*:repository/*"
+            Sid: AllowPerfTesterEcrRepoAccess
+          - Effect: "Allow"
+            Action:
+              - "ecr:GetAuthorizationToken"
+            Resource:
+              - "*"
+            Sid: AllowPerfTesterEcrTokenAccess
+          - Effect: Allow
+            Action:
+              - ecs:RegisterTaskDefinition
+            Resource: "*"
+            Sid: AllowPerfTesterEcsTaskDefn
+          - Effect: "Allow"
+            Action:
+              - "cloudformation:DescribeStacks"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*/*"
+            Sid: AllowPerfTesterDescStacks
+          - Effect: "Allow"
+            Action:
+              - "ssm:GetParameters"
+              - "ssm:GetParametersByPath"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/perfTest/*" #To fetch the value of the SSM parameter created under this path
+            Sid: AllowPerfTesterGetParams
+          - Effect: "Allow"
+            Action:
+              - "secretsmanager:GetSecretValue" #pragma: allowlist secret
+            Resource:
+              - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/perfTest/*" # To fetch the value of the secret with this name #pragma: allowlist secret
+            Sid: AllowPerfTesterGetSecret #pragma: allowlist secret
+          - Effect: "Allow"
+            Action:
+              - "cloudwatch:GetMetricData"
+              - "cloudwatch:GetDashboard"
+              - "cloudwatch:GetMetricStatistics"
+              - "cloudwatch:ListMetrics"
+              - "cloudwatch:ListMetricStreams"
+            Resource: "*"
+            Sid: AllowPerfTesterCloudwatch
+          - Effect: "Allow"
+            Action:
+              - "logs:FilterLogEvents"
+              - "logs:DescribeQueryDefinitions"
+            Resource: "*"
+            Sid: AllowPerfTesterLogQueries
+
+  PerformanceTester:
+    Condition: IsBuildOrStaging
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: "sts:AssumeRole"
+            Principal:
+              AWS: !FindInMap [ !Ref AWS::AccountId, performancetester, principals ]
+            Condition:
+              Bool:
+                aws:MultiFactorAuthPresent: true
+              IpAddress:
+                - aws:SourceIp: !FindInMap [ allEnvironments, officeIpAddresses, ipAddresses ]
+      ManagedPolicyArns:
+        - !Ref PerformanceRolePolicy
+        - arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess
+
+Outputs:
+  PerformanceRoleArn:
+    Condition: IsBuildOrStaging
+    Description: "The RoleArn for performance testers to trigger CodeBuild tests."
+    Value: !GetAtt PerformanceTester.Arn
+ 


### PR DESCRIPTION
This is a sample CloudFormation template file based on common infra [roles-for-engineers](https://github.com/alphagov/di-ipv-core-common-infra/blob/main/cloudformation/roles-for-engineers/template.yaml) infrastructure template.

This infra template is intentionally incomplete, full of placeholder data and to be used as a reference

Issue: PLAT-913
Co-authored-by: