### PR TITLE
[QA-142] Bump OpenTelemetry Collector version to v0.74.0

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -15,7 +15,7 @@ RUN cd scripts && \
 # -----------------------
 # OpenTelemetry Collector
 # -----------------------
-FROM otel/opentelemetry-collector-contrib:0.70.0 as otel
+FROM otel/opentelemetry-collector-contrib:0.74.0 as otel
 ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 
 # ---


### PR DESCRIPTION
## QA-142

Bump `opentelemetry-collecter-contrib` version from `v0.70.0` to `v0.74.0`