### PR TITLE
PLAT-1505 Fixed to always run perf test in VPC

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -11,8 +11,7 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
-  CreateVPCConfigurationForTestContainer:
-    !Equals [!Ref RunTestContainerInVPC, "True"]
+
 
 Parameters:
   Environment:
@@ -200,16 +199,14 @@ Resources:
         Image: "CONTAINER-IMAGE-PLACEHOLDER" # Replace this with the ECR repo for this SAM container pipeline.
         ImagePullCredentialsType: "SERVICE_ROLE"
         Type: "LINUX_CONTAINER"
-      VpcConfig: !If
-        - CreateVPCConfigurationForTestContainer
-        - SecurityGroupIds:
-            - !GetAtt TestContainerSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
-            - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
-          VpcId:
-            Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
-        - !Ref AWS::NoValue
+      VpcConfig:
+        SecurityGroupIds:
+          - !GetAtt TestContainerSecurityGroup.GroupId
+        Subnets:
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
+        VpcId:
+          Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
       TimeoutInMinutes: 480
       Source:
         Type: "NO_SOURCE"
@@ -281,7 +278,6 @@ Resources:
 
   TestContainerSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
-    Condition: CreateVPCConfigurationForTestContainer
     Properties:
       GroupDescription: >-
         Permits unrestricted outbound on 443 to allow the testcontainer to access VPC endpoints and outbound over SSL.


### PR DESCRIPTION
Updates the perf test to always run in the VPC, as will be always needed for new central platform.