### PR TITLE
DCMAW-6497: Reduce peak load duration for frontend E2E test

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -49,7 +49,7 @@ const profiles: ProfileList = {
       stages: [
         { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
         // { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
-        { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests on the ECS Scaling Policy
+        { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
       ],
       exec: 'mamIphonePassport'
     }


### PR DESCRIPTION
## DCMAW-6497 <!--Jira Ticket Number-->

### What?
Reduce load test sustain time to 5 minutes. 

#### Changes:
- add a temporary, reduced sustain stage of 5 minutes

---

### Why?
This is so we can run some shorter iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
