### PR TITLE
[QA-351] Update references from `alphagov/di-devplatform-performance` to `govuk-one-login/performance-testing`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
 # Global owners
-* @alphagov/di-dev-platform @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers
+* @alphagov/di-dev-platform @govuk-one-login/performance-testers
 
 # Test Scripts
-/deploy/scripts @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers
+/deploy/scripts @govuk-one-login/performance-testers
 
 # Team Specific Test Script Directories
-/deploy/scripts/src/accounts @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/gov-uk-accounts
-/deploy/scripts/src/authentication @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers
-/deploy/scripts/src/btm @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/di-billing-and-transaction-monitoring
-/deploy/scripts/src/cri-kiwi @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/di-ipv-kiwi-devs
-/deploy/scripts/src/cri-lime @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
-/deploy/scripts/src/cri-orange @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/di-ipv-orange-cri-maintainers
-/deploy/scripts/src/ipv-core @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
-/deploy/scripts/src/mobile @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/di-doc-checking-narwhal-codeowners
-/deploy/scripts/src/spot @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/di-ipv-spot-team
-/deploy/scripts/src/txma @alphagov/digital-identity-performance-test @govuk-one-login/performance-testers @alphagov/digital-identity-txma
+/deploy/scripts/src/accounts @govuk-one-login/performance-testers @alphagov/gov-uk-accounts
+/deploy/scripts/src/authentication @govuk-one-login/performance-testers
+/deploy/scripts/src/btm @govuk-one-login/performance-testers @alphagov/di-billing-and-transaction-monitoring
+/deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @alphagov/di-ipv-kiwi-devs
+/deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
+/deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @alphagov/di-ipv-orange-cri-maintainers
+/deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
+/deploy/scripts/src/mobile @govuk-one-login/performance-testers @alphagov/di-doc-checking-narwhal-codeowners
+/deploy/scripts/src/spot @govuk-one-login/performance-testers @alphagov/di-ipv-spot-team
+/deploy/scripts/src/txma @govuk-one-login/performance-testers @alphagov/digital-identity-txma

--- a/.github/workflows/feature-branch-publish.yaml
+++ b/.github/workflows/feature-branch-publish.yaml
@@ -9,11 +9,11 @@ name: Feature Branch Publish
 #          -H "Accept: application/vnd.github+json" \
 #          -H "Authorization: Bearer <YOUR-TOKEN>"\
 #          -H "X-GitHub-Api-Version: 2022-11-28" \
-#          https://api.github.com/repos/alphagov/di-devplatform-performance/actions/oidc/customization/sub \
+#          https://api.github.com/repos/govuk-one-login/performance-testing/actions/oidc/customization/sub \
 #          -d '{"use_default":false,"include_claim_keys":["repo","context","ref"]}'
 #
 # With the above setup, example sub from AssumeRoleWithWebIdentity as seen in Cloudtrail in build account
-#        "subjectFromWebIdentityToken": "repo:alphagov/di-devplatform-performance:environment:build:ref:refs/heads/main",
+#        "subjectFromWebIdentityToken": "repo:govuk-one-login/performance-testing:environment:build:ref:refs/heads/main",
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Publish](https://github.com/alphagov/di-devplatform-performance/actions/workflows/publish.yaml/badge.svg?branch=main)](https://github.com/alphagov/di-devplatform-performance/actions/workflows/publish.yaml)
+[![Publish](https://github.com/govuk-one-login/performance-testing/actions/workflows/publish.yaml/badge.svg?branch=main)](https://github.com/govuk-one-login/performance-testing/actions/workflows/publish.yaml)
 
 ---
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,9 +5,9 @@ Changes to the CloudFormation Infrastructure-as-Code [`template.yaml`](template.
 
 To deploy a feature branch to the Development environment:
 
-1. Go to the '[Feature Branch Publish](https://github.com/alphagov/di-devplatform-performance/actions/workflows/feature-branch-publish.yaml)' GitHub action
+1. Go to the '[Feature Branch Publish](https://github.com/govuk-one-login/performance-testing/actions/workflows/feature-branch-publish.yaml)' GitHub action
 
-    [![Feature Branch Publish](https://github.com/alphagov/di-devplatform-performance/actions/workflows/feature-branch-publish.yaml/badge.svg?event=workflow_dispatch)](https://github.com/alphagov/di-devplatform-performance/actions/workflows/feature-branch-publish.yaml)
+    [![Feature Branch Publish](https://github.com/govuk-one-login/performance-testing/actions/workflows/feature-branch-publish.yaml/badge.svg?event=workflow_dispatch)](https://github.com/govuk-one-login/performance-testing/actions/workflows/feature-branch-publish.yaml)
 
 2. Click the 'Run Workflow' dropdown
 

--- a/deploy/scripts/package.json
+++ b/deploy/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scripts",
   "version": "1.0.0",
-  "repository": "git@github.com:alphagov/di-devplatform-performance.git",
+  "repository": "git@github.com:govuk-one-login/performance-testing.git",
   "description": "Performance Testing for Digital Identity",
   "main": "index.js",
   "devDependencies": {

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -472,7 +472,7 @@ Resources:
         - Key: "Service"
           Value: "ci/cd"
         - Key: "Source"
-          Value: "alphagov/di-devplatform-performance"
+          Value: "govuk-one-login/performance-testing"
 
   TestContainerSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"


### PR DESCRIPTION
## QA-351

### What?
Update all references from `alphagov/di-devplatform-performance` to `govuk-one-login/performance-testing`

#### Changes:
- `.github/CODEOWNERS`: Removed old `@alphagov/digital-identity-performance-test` team
- `.github/workflows/feature-branch-publish.yaml`: Updated references in comments
- `README.md` & `deploy/README.md`: Updated references in hrefs
- `deploy/scripts/package.json`: Updated repo name
- `deploy/template.yaml`: Updated repo name used in value

---

### Why?
Repository was migrated between GitHub organisations and renamed

---

### Related:
- #353 
