### PR TITLE
[QA-352] Update CODEOWNERS teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
 # Global owners
-* @alphagov/di-dev-platform @govuk-one-login/performance-testers
+* @govuk-one-login/dev-platform @govuk-one-login/performance-testers
 
 # Test Scripts
 /deploy/scripts @govuk-one-login/performance-testers
 
 # Team Specific Test Script Directories
-/deploy/scripts/src/accounts @govuk-one-login/performance-testers @alphagov/gov-uk-accounts
+/deploy/scripts/src/accounts @govuk-one-login/performance-testers @govuk-one-login/bravo-team
 /deploy/scripts/src/authentication @govuk-one-login/performance-testers
-/deploy/scripts/src/btm @govuk-one-login/performance-testers @alphagov/di-billing-and-transaction-monitoring
-/deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @alphagov/di-ipv-kiwi-devs
-/deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
-/deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @alphagov/di-ipv-orange-cri-maintainers
-/deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @alphagov/digital-identity-ipv
-/deploy/scripts/src/mobile @govuk-one-login/performance-testers @alphagov/di-doc-checking-narwhal-codeowners
-/deploy/scripts/src/spot @govuk-one-login/performance-testers @alphagov/di-ipv-spot-team
-/deploy/scripts/src/txma @govuk-one-login/performance-testers @alphagov/digital-identity-txma
+/deploy/scripts/src/btm @govuk-one-login/performance-testers @govuk-one-login/btm
+/deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @govuk-one-login/kiwi-devs
+/deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @govuk-one-login/cri-lime-team
+/deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @govuk-one-login/cri-orange-team
+/deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @govuk-one-login/core-team
+/deploy/scripts/src/mobile @govuk-one-login/performance-testers @govuk-one-login/mobile-narwhal-team
+/deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/spot-team
+/deploy/scripts/src/txma @govuk-one-login/performance-testers @govuk-one-login/txma-team


### PR DESCRIPTION
## QA-352

### What?
Updating teams CODEOWNERS file

#### Changes:
- `.github/CODEOWNERS`: Updated team names

---

### Why?
After the migration from the `alphagov` organisations, there is a different set of teams

---

### Related:
- #358 
- #353 
