### PR TITLE
[QA-358] Update `devplatform-upload` action location

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy SAM app to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.2
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.4
         with:
           artifact-bucket-name: ${{ secrets.PERF_ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.PERF_CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy SAM app to ECR
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.2
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.2
         with:
           artifact-bucket-name: ${{ secrets.PERF_ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.PERF_CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
## QA-358

### What?
Switch over github action to new organisation repo

#### Changes:
- `.github/workflows/publish.yaml`:
  - Updated action from [`alphagov/di-devplatform-upload-action-ecr`](https://github.com/alphagov/di-devplatform-upload-action-ecr) to [`govuk-one-login/devplatform-upload-action-ecr`](https://github.com/govuk-one-login/devplatform-upload-action-ecr)
  - Bump action version from `v1.0.2` to `v1.0.4`

---

### Why?
Action repository has migrated organisations

---

### Related:
- #358 
