### PR TITLE
[QA-364]: Update timestamp type in BTM script

### DIFF
--- a/deploy/scripts/src/btm/test.ts
+++ b/deploy/scripts/src/btm/test.ts
@@ -273,7 +273,7 @@ export function sendSQSMessage (messageBody: Record<string, unknown>): void {
   const timestampFormatted: string = new Date(randomTimestamp * 1000).toISOString()
   iterationsStarted.add(1)
   messageBody.event_id = uuidv4()
-  messageBody.timestamp = randomTimestamp.toString()
+  messageBody.timestamp = randomTimestamp
   messageBody.timestamp_formatted = timestampFormatted.replace('Z', '')
   sqs.sendMessage(env.sqs_queue, JSON.stringify(messageBody))
   iterationsCompleted.add(1)


### PR DESCRIPTION
## QA-364 <!--Jira Ticket Number-->

### What?
Updated Timestamp type in the BTM script payloads

#### Changes:
- Timestamp used in the BTM payload should be a number. In the current script, this is being sent as a string resulting in message failure in Lambda function processing.

---

### Why?
To fix the error in clean Lambda function.
