### PR TITLE
[QA-366]: BTM - Removed Iteration Started and Completed counts from event type

### DIFF
--- a/deploy/scripts/src/btm/test.ts
+++ b/deploy/scripts/src/btm/test.ts
@@ -221,51 +221,37 @@ const payloadTimestampMax: number = Number(payloadTimestampArray[1])
 
 export function sendEventType1 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[0]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType2 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[1]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType3 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[2]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType4 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[3]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType5 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[4]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType6 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[5]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendEventType7 (): void {
   const messageBody: Record<string, unknown> = payloadEventsArray[6]
-  iterationsStarted.add(1)
   sendSQSMessage(messageBody)
-  iterationsCompleted.add(1)
 }
 
 export function sendSQSMessage (messageBody: Record<string, unknown>): void {


### PR DESCRIPTION
…functions

## QA-366 <!--Jira Ticket Number-->

### What?
Removed iteration counter for individual events in BTM script

#### Changes:
- (btm/test.js) Removed iterationsStarted.add(1) and iterationsCompleted.add(1) for sendEvent functions

---

### Why?
Iterations Started and Iterations Completed metrics were being counted twice due to them being counted in both the sendEvent functions and the sendSQSMessage function, so one of these needed to be removed

---
