### PR TITLE
[QA-377] Minify test scripts

### DIFF
--- a/deploy/scripts/.eslintrc.json
+++ b/deploy/scripts/.eslintrc.json
@@ -10,7 +10,7 @@
         "sourceType": "module",
         "project": "**/tsconfig.json"
     },
-    "ignorePatterns": ["src/common/utils/jslib/*.js", "dist/**", "build.js"],
+    "ignorePatterns": ["src/common/utils/jslib/*.js", "dist/**"],
     "rules": {
     }
 }

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -33,7 +33,7 @@ Further, you can add the `--fix` flag to fix any auto-fixable problems in your T
 
 ## Local Testing
 
-Test scripts are contained in the `src` folder, with a folder for each product team. Test script files must match the path ( `src/<team_name>/*.ts`) specified in the [build.js](build.js#L8) file. Static data files are kept in `src/<team_name>/data` folders, they are copied to `dist/<team_name>/data` by esbuild as defined [here](build.js#L17-L24).
+Test scripts are contained in the `src` folder, with a folder for each product team. Test script files must match the path ( `src/<team_name>/*.ts`) specified in the [build.mjs](build.mjs#L8) file. Static data files are kept in `src/<team_name>/data` folders, they are copied to `dist/<team_name>/data` by esbuild as defined [here](build.mjs#L17-L24).
 
 To run a TypeScript test locally, navigate to the `deploy/scripts` folder and run the following
 

--- a/deploy/scripts/build.js
+++ b/deploy/scripts/build.js
@@ -11,8 +11,8 @@ build({
   target: 'es6',
   format: 'esm',
   bundle: true,
-  sourcemap: true,
-  minify: false,
+  sourcemap: false,
+  minify: true,
   external: ['k6*', 'https://*'],
   plugins: [
     copy({

--- a/deploy/scripts/build.mjs
+++ b/deploy/scripts/build.mjs
@@ -1,11 +1,11 @@
-const { build } = require('esbuild')
-const { copy } = require('esbuild-plugin-copy')
-const glob = require('glob')
+import { build } from 'esbuild'
+import { copy } from 'esbuild-plugin-copy'
+import { sync } from 'glob'
 const outbase = './src'
 const outdir = './dist'
 
 build({
-  entryPoints: glob.sync('src/*/*.ts'),
+  entryPoints: sync('src/*/*.ts'),
   outbase,
   outdir,
   target: 'es6',
@@ -25,7 +25,7 @@ build({
 })
   .then(() => {
     console.log('Test scripts transpiled:')
-    glob.sync(outdir + '/*/*.js').sort().forEach(file => {
+    sync(outdir + '/*/*.js').sort().forEach(file => {
       console.log(`+ \x1b[32m${file}\x1b[0m`)
     })
   })

--- a/deploy/scripts/package.json
+++ b/deploy/scripts/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "lint": "npx eslint 'src/**/*.ts'",
-    "pretest": "node build.js",
-    "start": "node build.js",
+    "pretest": "node build.mjs",
+    "start": "node build.mjs",
     "test": "k6 run dist/common/unit-tests.js",
     "tsc": "tsc"
   },


### PR DESCRIPTION
## QA-377

### What?
Enabling minification and removing source maps of transpiled test scripts. Also updated `build.js` to an `*.mjs` file

#### Changes:
- Enabled esbuild `minify`
- Disabled esbuild `sourcemap`
- Converted `build.js` to `build.mjs`

---

### Why?
These changes reduce the size of the output test script files, these files are copied into memory for every virtual user so it is important that these are as small as possible to reduce the memory usage on the load injector. The previous total `dist` output was about `~4.8MB` and now this has been reduced to `~2.7MB` with these changes.

---

### Related:
- [esbuild minify](https://esbuild.github.io/api/#minify)
- [esbuild sourcemap](https://esbuild.github.io/api/#sourcemap)
