### PR TITLE
[QA-387]: Correct target volume for KBV script

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -46,7 +46,7 @@ const profiles: ProfileList = {
       maxVUs: 408,
       stages: [
         { target: 14, duration: '15m' }, // Ramp up to 14 iterations per second in 15 minutes
-        { target: 15, duration: '30m' }, // Maintain steady state at 14 iterations per second for 30 minutes
+        { target: 14, duration: '30m' }, // Maintain steady state at 14 iterations per second for 30 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'kbvScenario1'


### PR DESCRIPTION
## QA-387 <!--Jira Ticket Number-->

### What?
Correct target volume of the stress test load profile in KBV script.

#### Changes:
- Steady state target volume of KBV stress test profile was incorrectly set to 15 (instead of 14). This has been corrected now.

---

### Why?
To correct the target volume in KBV and conduct stress test.