### PR TITLE
[QA-390] Load profile for canary testing

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -49,6 +49,47 @@ const profiles: ProfileList = {
       exec: 'idReuse'
     }
   },
+  deployment: {
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 60,
+      stages: [
+        { target: 2, duration: '5m' }, // Ramp up to 2 iterations per second over 5 minutes
+        { target: 2, duration: '20m' }, // Steady State of 20 minutes at the ramp up load i.e. 2 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes
+      ],
+      exec: 'passport'
+    },
+    drivingLicence: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 60,
+      stages: [
+        { target: 2, duration: '5m' }, // Ramp up to 2 iterations per second over 5 minutes
+        { target: 2, duration: '20m' }, // Steady State of 20 minutes at the ramp up load i.e. 2 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes
+      ],
+      exec: 'drivingLicence'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 30,
+      stages: [
+        { target: 10, duration: '5m' }, // Ramp up to 10 iterations per second over 5 minutes
+        { target: 10, duration: '20m' }, // Steady State of 20 minutes at the ramp up load i.e. 10 iterations/second
+        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes
+      ],
+      exec: 'idReuse'
+    }
+  },
   lowVolumeTest: {
     passport: {
       executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-390

### What?
Add a load profile to the IPV Core script for canary deployments and deployment testing

#### Changes:
- `deploy/scripts/ipv-core/test.ts`: Added a `deployment` load profile, with targets for `passport`, `drivingLicence` and `idReuse` of `2`, `2` and `20` per second respectively over `30` mins (including `5` minutes ramp-up and ramp-down each)

---

### Why?
To facilitate testing of canary deployments, we need to send volumes of traffic to the development environment using the IPV Core script for ~30 mins at a time

---

### Related:
- #425 
