### PR TITLE
[QA-391]: Update Max VUs for Summarise VC stress profile

### DIFF
--- a/deploy/scripts/src/accounts/id-reuse.ts
+++ b/deploy/scripts/src/accounts/id-reuse.ts
@@ -87,7 +87,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 20000,
+      maxVUs: 5000,
       stages: [
         { target: 1900, duration: '15m' }, // Ramps up to target load
         { target: 1900, duration: '30m' }, // Steady State of 15 minutes at the ramp up load i.e. 1900 iterations/second


### PR DESCRIPTION
## QA-391 <!--Jira Ticket Number-->

### What?
Update Max VUs for Summarise VC stress profile

#### Changes:
- Reduced Max VUs for Summarise VC stress profile from 20000 to 5000.

---

### Why?
20000 VUs on a single load generator was causing resource contention on the load generator. Additionally, as per NFR calculations, the max VUs for this scenario should be 5000.