### PR TITLE
[QA-393] Updating MaxVUs for CRI-Lime drivingLicence stress test

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -106,7 +106,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 411,
+      maxVUs: 1500,
       stages: [
         { target: 55, duration: '15m' }, // Ramp up to 55 iterations per second in 15 minutes
         { target: 55, duration: '30m' }, // Maintain steady state at 55 iterations per second for 30 minutes


### PR DESCRIPTION
## QA-393 <!--Jira Ticket Number-->

### What?
Updated the MaxVUs for the drivingLicence scenario of the stress test for CRI-Lime.

#### Changes:

[deploy/scripts/src/cri-lime/test.ts]

- changed the MaxVUs for drivingLicence stress test from 411 to 1500.

---

### Why?
To support the increase in target iterations from 14 to 55 to perform a performance stress test. 

---
