### PR TITLE
[QA-396]: Updated load profile of Contacts Page scenario in OLH

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -152,8 +152,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 1,
       maxVUs: 300,
       stages: [
-        { target: 10, duration: '3m' }, // Ramp up to 10 iterations per second in 3 minutes
-        { target: 10, duration: '6m' }, // Steady State of 6 minutes at the ramp up load i.e. 10 iterations/second
+        { target: 10, duration: '5m' }, // Ramp up to 10 iterations per second in 5 minutes
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '1m' } // Ramp down duration of 1 minute.
       ],
       exec: 'contactsPage'


### PR DESCRIPTION
## QA-396 <!--Jira Ticket Number-->

### What?
Updated load profile of OLH Contacts Page scenario.

#### Changes:
- Ramp up duration increased to 5 minutes.
- Steady state increased to 30 minutes.

---

### Why?
To validate the fix provided for live incident through an extended duration volume test.