### PR TITLE
DCMAW-7817: Added deploy scenario for mobile FE tests

### DIFF
--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -39,19 +39,6 @@ const profiles: ProfileList = {
       ],
       exec: 'backendJourney'
     }
-  },
-  deploy: {
-    backendJourney: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1, // start with one iteration
-      timeUnit: '1s',
-      preAllocatedVUs: 10, // Calculation: 1 journeys / second * 10 seconds average journey time
-      maxVUs: 65, // Calculation: 1 journeys / second * 14 seconds maximum journey time + 50 buffer
-      stages: [
-        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 min
-      ],
-      exec: 'backendJourney'
-    }
   }
 }
 

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -39,6 +39,19 @@ const profiles: ProfileList = {
       ],
       exec: 'backendJourney'
     }
+  },
+  deploy: {
+    backendJourney: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1, // start with one iteration
+      timeUnit: '1s',
+      preAllocatedVUs: 10, // Calculation: 1 journeys / second * 10 seconds average journey time
+      maxVUs: 65, // Calculation: 1 journeys / second * 14 seconds maximum journey time + 50 buffer
+      stages: [
+        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 min
+      ],
+      exec: 'backendJourney'
+    }
   }
 }
 

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -31,11 +31,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1, // start with one iteration
       timeUnit: '1s',
-      preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
+      preAllocatedVUs: 75, // Calculation: 5 journeys / second * 15 seconds average journey time
       maxVUs: 120, // Calculation: 5 journeys / second * 24 seconds maximum journey time
       stages: [
-        { target: 1, duration: '30s' }, // linear increase from 1 iteration per second to 1 iterations per second for 30 seconds
-        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 seconds
+        { target: 5, duration: '30s' }, // linear increase from 1 iteration per second to 5 iterations per second for 30 seconds
+        { target: 5, duration: '30s' } // maintain 5 iterations per second for 30 seconds
       ],
       exec: 'mamIphonePassport'
     }
@@ -51,6 +51,19 @@ const profiles: ProfileList = {
         { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
         // { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
         { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
+      ],
+      exec: 'mamIphonePassport'
+    }
+  },
+  deploy: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1, // start with one iteration
+      timeUnit: '1s',
+      preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
+      maxVUs: 75, // Calculation: 1 journeys / second * 24 seconds maximum journey time + 50 buffer
+      stages: [
+        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 min
       ],
       exec: 'mamIphonePassport'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -34,8 +34,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
       maxVUs: 120, // Calculation: 5 journeys / second * 24 seconds maximum journey time
       stages: [
-        { target: 1, duration: '30s' }, // linear increase from 1 iteration per second to 5 iterations per second for 30 seconds
-        { target: 1, duration: '25m' } // maintain 5 iterations per second for 30 seconds
+        { target: 1, duration: '30s' }, // linear increase from 1 iteration per second to 1 iterations per second for 30 seconds
+        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 seconds
       ],
       exec: 'mamIphonePassport'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -31,11 +31,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1, // start with one iteration
       timeUnit: '1s',
-      preAllocatedVUs: 75, // Calculation: 5 journeys / second * 15 seconds average journey time
+      preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
       maxVUs: 120, // Calculation: 5 journeys / second * 24 seconds maximum journey time
       stages: [
-        { target: 5, duration: '30s' }, // linear increase from 1 iteration per second to 5 iterations per second for 30 seconds
-        { target: 5, duration: '30s' } // maintain 5 iterations per second for 30 seconds
+        { target: 1, duration: '30s' }, // linear increase from 1 iteration per second to 5 iterations per second for 30 seconds
+        { target: 1, duration: '25m' } // maintain 5 iterations per second for 30 seconds
       ],
       exec: 'mamIphonePassport'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -57,14 +57,12 @@ const profiles: ProfileList = {
   },
   deploy: {
     mamIphonePassport: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1, // start with one iteration
+      executor: 'constant-arrival-rate',
+      rate: 1,
       timeUnit: '1s',
+      duration: '25m',
       preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
       maxVUs: 75, // Calculation: 1 journeys / second * 24 seconds maximum journey time + 50 buffer
-      stages: [
-        { target: 1, duration: '25m' } // maintain 1 iterations per second for 25 min
-      ],
       exec: 'mamIphonePassport'
     }
   }


### PR DESCRIPTION
## DCMAW-781 <!--Jira Ticket Number-->

### What?
The smoke scenario details for the FE E2E mobile scripts. 

#### Changes:
- target of 1 request per second 
- 25m sustained volumes at 1 requests per seconds
- preAllocated VUs decreased to 15 
---

### Why?
Migrate a Frontend stack in the Dev account from the DCMAW to Dev Platform VPC whilst a performance test is running. It is suggested that this performance test runs at low volumes, aiming at 1TPS per journey

---

### Related:
- [DCMAW-7817](https://govukverify.atlassian.net/browse/DCMAW-7817) 

EVIDENCE:
<img width="1035" alt="Screenshot 2024-01-11 at 17 19 00" src="https://github.com/govuk-one-login/performance-testing/assets/122101235/0e783338-efaf-4a19-9109-54f82d756c69">


[DCMAW-7817]: https://govukverify.atlassian.net/browse/DCMAW-7817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ