### PR TITLE
DCMAW-7830: Added deploy scenario for mobile BE tests 

### DIFF
--- a/deploy/scripts/src/mobile/README.md
+++ b/deploy/scripts/src/mobile/README.md
@@ -31,8 +31,9 @@ Test Scripts are located in the `/mobile` folder with naming convention `*.test.
 # Generating dist files
 npm start
 ```
+Replace `your_environment` variable with `DEV` or `BUILD` value. Replace the url variables with the corresponding one for the selected environment.
 
 ```bash
 # Run k6 test. Replace with actual values
-k6 run ./dist/mobile/<your_test_file>.test.js -e PROFILE=<your_profile_name> -e SCENARIO=<your_scenario_name> -e MOBILE_TEST_CLIENT_EXECUTE_URL=<your_test_client_execute_url> -e MOBILE_BACK_END_URL=<your_backend_url> -e MOBILE_FRONT_END_URL=<your_frontend_url>
+k6 run ./dist/mobile/<your_test_file>.test.js -e PROFILE=<your_profile_name> -e SCENARIO=<your_scenario_name> -e MOBILE_<your_environment>_TEST_CLIENT_URL=<your_test_client_execute_url> -e MOBILE_<your_environment>_BACKEND_URL=<your_backend_url> -e MOBILE_<your_environment>_FRONTEND_URL=<your_frontend_url> -e ENVIRONMENT=<your_environment>
 ```

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -39,6 +39,17 @@ const profiles: ProfileList = {
       ],
       exec: 'backendJourney'
     }
+  },
+  deploy: {
+    backendJourney: {
+      executor: 'constant-arrival-rate',
+      rate: 1,
+      timeUnit: '1s',
+      duration: '25m',
+      preAllocatedVUs: 10, // Calculation: 1 journeys / second * 10 seconds average journey time
+      maxVUs: 65, // Calculation: 1 journeys / second * 14 seconds maximum journey time + 50 buffer
+      exec: 'backendJourney'
+    }
   }
 }
 


### PR DESCRIPTION
## DCMAW-7830 <!--Jira Ticket Number-->

### What?
Added the `deploy` profile to the BE journey mobile scripts. 

#### Changes:
- added `deploy` profile to the `backend-e2e.test.ts` file. This profile is a `constant-arrival-rate` with 1 rate per second and a total duration of 25 minutes.
- readme file with the latest names of the environment variables.

### Why?
Understand if our BE Lambda’s work with the Dev platform VPC, without making changes to our egress implementation.


### Related:
- [DCMAW-7830](https://govukverify.atlassian.net/browse/DCMAW-7830) 

EVIDENCE:

<img width="975" alt="Screenshot 2024-01-12 at 10 36 05" src="https://github.com/govuk-one-login/performance-testing/assets/122101235/6117e8dc-c1d4-4bfa-9c4c-35caa1c20dbf">



[DCMAW-7830]: https://govukverify.atlassian.net/browse/DCMAW-7830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ