### PR TITLE
DCMAW-7858: Added incremental load scenario

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -76,11 +76,11 @@ const profiles: ProfileList = {
       stages: [
         { target: 25, duration: '4m' }, // linear increase from 0 iteration per second to 25 iterations per second for 4 mins -> 0.1 t/s/s
         { target: 25, duration: '10m' }, // maintain 25 iterations per second for 10 min
-        { target: 50, duration: '4m' }, // linear increase from 0 iteration per second to 50 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 50, duration: '4m' }, // linear increase from 25 iteration per second to 50 iterations per second for 4 mins -> 0.1 t/s/s
         { target: 50, duration: '10m' }, // maintain 50 iterations per second for 10 min
-        { target: 75, duration: '4m' }, // linear increase from 0 iteration per second to 75 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 75, duration: '4m' }, // linear increase from 50 iteration per second to 75 iterations per second for 4 mins -> 0.1 t/s/s
         { target: 75, duration: '10m' }, // maintain 75 iterations per second for 10 min
-        { target: 100, duration: '4m' }, // linear increase from 0 iteration per second to 100 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 100, duration: '4m' }, // linear increase from 75 iteration per second to 100 iterations per second for 4 mins -> 0.1 t/s/s
         { target: 100, duration: '10m' } // maintain 100 iterations per second for 10 min
       ],
       exec: 'mamIphonePassport'

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -65,6 +65,26 @@ const profiles: ProfileList = {
       maxVUs: 75, // Calculation: 1 journeys / second * 24 seconds maximum journey time + 50 buffer
       exec: 'mamIphonePassport'
     }
+  },
+  incrementalLoad: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1700, // Calculation: 100 journeys / second * 17 seconds average journey time
+      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
+      stages: [
+        { target: 25, duration: '4m' }, // linear increase from 0 iteration per second to 25 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 25, duration: '10m' }, // maintain 25 iterations per second for 10 min
+        { target: 50, duration: '4m' }, // linear increase from 0 iteration per second to 50 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 50, duration: '10m' }, // maintain 50 iterations per second for 10 min
+        { target: 75, duration: '4m' }, // linear increase from 0 iteration per second to 75 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 75, duration: '10m' }, // maintain 75 iterations per second for 10 min
+        { target: 100, duration: '4m' }, // linear increase from 0 iteration per second to 100 iterations per second for 4 mins -> 0.1 t/s/s
+        { target: 100, duration: '10m' } // maintain 100 iterations per second for 10 min
+      ],
+      exec: 'mamIphonePassport'
+    }
   }
 }
 


### PR DESCRIPTION
## DCMAW-7858 <!--Jira Ticket Number-->

### What?
Added the `incrementalLoad` profile to the FE journey mobile scripts. 

#### Changes:
- added `incrementalLoad` profile to the `frontend-e2e.test.ts` file. This profile reflects the incremental ramp-up from the below picture:

<img width="678" alt="Screenshot 2024-01-19 at 15 11 53" src="https://github.com/govuk-one-login/performance-testing/assets/122101235/5fad4c6d-4ef2-4f10-8665-52e853981ceb">


### Why?
Understand how our system is performing on different loads.


### Related:
- [DCMAW-7830](https://govukverify.atlassian.net/browse/DCMAW-7830) 

EVIDENCE:
<img width="1071" alt="Screenshot 2024-01-19 at 15 09 48" src="https://github.com/govuk-one-login/performance-testing/assets/122101235/182aa30d-0cd3-4cf2-9555-19e154706519">


[DCMAW-7858]: https://govukverify.atlassian.net/browse/DCMAW-7858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCMAW-7830]: https://govukverify.atlassian.net/browse/DCMAW-7830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ