### PR TITLE
Add new load profile for the mobile tests

### DIFF
--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -45,11 +45,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
-      preAllocatedVUs: 40,
-      maxVUs: 300,
+      preAllocatedVUs: 60,
+      maxVUs: 450,
       stages: [
-        { target: 4, duration: '15m' },
-        { target: 4, duration: '30m' }
+        { target: 6, duration: '15m' },
+        { target: 6, duration: '30m' }
       ],
       exec: 'backendJourney'
     }

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -40,6 +40,20 @@ const profiles: ProfileList = {
       exec: 'backendJourney'
     }
   },
+  loadSelfAssessment: {
+    backendJourney: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 40, 
+      maxVUs: 300,
+      stages: [
+        { target: 4, duration: '15m' },
+        { target: 4, duration: '30m' }
+      ],
+      exec: 'backendJourney'
+    }
+  },
   deploy: {
     backendJourney: {
       executor: 'constant-arrival-rate',

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -45,7 +45,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
-      preAllocatedVUs: 40, 
+      preAllocatedVUs: 40,
       maxVUs: 300,
       stages: [
         { target: 4, duration: '15m' },

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -61,7 +61,7 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 68,
-      maxVUs: 300, 
+      maxVUs: 300,
       stages: [
         { target: 4, duration: '15m' },
         { target: 4, duration: '30m' }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -55,6 +55,20 @@ const profiles: ProfileList = {
       exec: 'mamIphonePassport'
     }
   },
+  loadSelfAssessment: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 68,
+      maxVUs: 300, 
+      stages: [
+        { target: 4, duration: '15m' },
+        { target: 4, duration: '30m' }
+      ],
+      exec: 'mamIphonePassport'
+    }
+  },
   deploy: {
     mamIphonePassport: {
       executor: 'constant-arrival-rate',

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -60,11 +60,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
-      preAllocatedVUs: 68,
-      maxVUs: 300,
+      preAllocatedVUs: 100,
+      maxVUs: 450,
       stages: [
-        { target: 4, duration: '15m' },
-        { target: 4, duration: '30m' }
+        { target: 6, duration: '15m' },
+        { target: 6, duration: '30m' }
       ],
       exec: 'mamIphonePassport'
     }


### PR DESCRIPTION
## QA-XXX <!--Jira Ticket Number-->

### What?
Addition of a load profile

#### Changes:
- Targets 6TPS at sustained load after a ramp up period

---

### Why?
- To support a new performance test using new forecasted volumes

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
