### PR TITLE
Mobile: increase load profile TPS

### DIFF
--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -48,8 +48,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 60,
       maxVUs: 450,
       stages: [
-        { target: 6, duration: '15m' },
-        { target: 6, duration: '30m' }
+        { target: 10, duration: '15m' },
+        { target: 10, duration: '10m' }
       ],
       exec: 'backendJourney'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -63,8 +63,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 450,
       stages: [
-        { target: 6, duration: '15m' },
-        { target: 6, duration: '30m' }
+        { target: 10, duration: '15m' },
+        { target: 10, duration: '10m' }
       ],
       exec: 'mamIphonePassport'
     }


### PR DESCRIPTION
## QA-XXX <!--Jira Ticket Number-->

### What?
A change to the volumetrics in the load profile

#### Changes:
- Change from 6 to 10 TPS for the selfAsessement load profile
- Reduction of peak load from 30 mins to 10 mins for earlier feedback

---

### Why?
Why are these changes being made?

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
