### PR TITLE
DCMAW-7858: Changed the load profile from 100 to 40 TPS and raised load window

### DIFF
--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -31,11 +31,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
-      preAllocatedVUs: 1000, // Calculation: 100 journeys / second * 10 seconds average journey time
-      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
+      preAllocatedVUs: 400, // Calculation: 40 journeys / second * 10 seconds average journey time
+      maxVUs: 1500, // Calculation: 40 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
       stages: [
-        { target: 100, duration: '15m' }, // linear increase from 1 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
-        { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
+        { target: 40, duration: '15m' }, // linear increase from 1 iteration per second to 40 iterations per second for 15 min -> 0.044 t/s/s
+        { target: 40, duration: '30m' } // maintain 40 iterations per second for 30 min
       ],
       exec: 'backendJourney'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -50,7 +50,6 @@ const profiles: ProfileList = {
       stages: [
         { target: 40, duration: '15m' }, // linear increase from 0 iteration per second to 40 iterations per second for 15 min -> 0.044 t/s/s
         { target: 40, duration: '30m' } // maintain 40 iterations per second for 30 min
-        // { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
       ],
       exec: 'mamIphonePassport'
     }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -45,12 +45,12 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '1s',
-      preAllocatedVUs: 1700, // Calculation: 100 journeys / second * 17 seconds average journey time
-      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
+      preAllocatedVUs: 700, // Calculation: 40 journeys / second * 17 seconds average journey time
+      maxVUs: 1500, // Calculation: 40 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
       stages: [
-        { target: 100, duration: '15m' }, // linear increase from 0 iteration per second to 100 iterations per second for 15 min -> 0.11 t/s/s
-        // { target: 100, duration: '30m' } // maintain 100 iterations per second for 30 min
-        { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
+        { target: 40, duration: '15m' }, // linear increase from 0 iteration per second to 40 iterations per second for 15 min -> 0.044 t/s/s
+        { target: 40, duration: '30m' } // maintain 40 iterations per second for 30 min
+        // { target: 100, duration: '5m' } // Temporary reduction for running iterative load tests for https://govukverify.atlassian.net/browse/DCMAW-6497
       ],
       exec: 'mamIphonePassport'
     }


### PR DESCRIPTION
## DCMAW-7858 <!--Jira Ticket Number-->

### What?
Changed load profile from 100 to 40 TPS and raised the load window to full 30m

#### Changes:
- changed BE and FE load profile TPS to 40
- changed BE and FE load profile maxVUs and preallocatedVUs
- raised BE and fe load profile window to full 30 m

---

### Why?
Target a lower NFR, given this will give us short-term benefits we can deliver sooner into Production.

---

### Related:
- [DCMAW-7858](https://govukverify.atlassian.net/browse/DCMAW-7858) to any relevant documentation or relevant pull requests



[DCMAW-7858]: https://govukverify.atlassian.net/browse/DCMAW-7858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ