### PR TITLE
DCMAW-7858: Added incremental small volumes scenario

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -99,6 +99,26 @@ const profiles: ProfileList = {
       ],
       exec: 'mamIphonePassport'
     }
+  },
+  incrementalSmallVolumes: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 700, // Calculation: 40 journeys / second * 17 seconds average journey time
+      maxVUs: 1500, // Calculation: 40 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
+      stages: [
+        { target: 5, duration: '4m' }, // linear increase from 0 iteration per second to 5 iterations per second for 4 mins
+        { target: 5, duration: '10m' }, // maintain 5 iterations per second for 10 min
+        { target: 15, duration: '4m' }, // linear increase from 15 iteration per second to 50 iterations per second for 4 mins
+        { target: 15, duration: '10m' }, // maintain 15 iterations per second for 10 min
+        { target: 30, duration: '4m' }, // linear increase from 15 iteration per second to 30 iterations per second for 4 mins
+        { target: 30, duration: '10m' }, // maintain 30 iterations per second for 10 min
+        { target: 40, duration: '4m' }, // linear increase from 30 iteration per second to 40 iterations per second for 4 mins
+        { target: 40, duration: '10m' } // maintain 40 iterations per second for 10 min
+      ],
+      exec: 'mamIphonePassport'
+    }
   }
 }
 


### PR DESCRIPTION
## DCMAW-7858 <!--Jira Ticket Number-->

### What?
Added the `incrementalSmallVolumes` profile to the FE journey mobile scripts. 

#### Changes:
- added `incrementalSmallVolumes` profile to the `frontend-e2e.test.ts` file. This profile reflects the incremental ramp-up from the below picture:
<img width="662" alt="Screenshot 2024-01-30 at 15 01 16" src="https://github.com/govuk-one-login/performance-testing/assets/122101235/cdbfc471-3f68-4e53-81c6-0b6401d681a1">


### Why?
Understand how our system is performing on different normal loads.


### Related:
- [DCMAW-7830](https://govukverify.atlassian.net/browse/DCMAW-7830) 

EVIDENCE:
![Screenshot 2024-01-30 at 14 51 49](https://github.com/govuk-one-login/performance-testing/assets/122101235/c1b17c3f-e143-4ff8-ae13-e3bcf7dc9699)



[DCMAW-7858]: https://govukverify.atlassian.net/browse/DCMAW-7858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCMAW-7830]: https://govukverify.atlassian.net/browse/DCMAW-7830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ