### PR TITLE
[QA-409] Updating the load profile for putContraIndicators scenario in CIMIT

### DIFF
--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -94,10 +94,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 500,
+      maxVUs: 1200,
       stages: [
-        { target: 100, duration: '15m' }, // Ramp up to 100 iterations per second in 15 minutes
-        { target: 100, duration: '30m' }, // Maintain steady state at 100 iterations per second for 30 minutes
+        { target: 400, duration: '15m' }, // Ramp up to 400 iterations per second in 15 minutes
+        { target: 400, duration: '30m' }, // Maintain steady state at 400 iterations per second for 30 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'putContraIndicators'


### PR DESCRIPTION
## QA-409 <!--Jira Ticket Number-->

### What?
Updated the load profile for `putContraIndicators` scenario in the CIMIT script

#### Changes:
- updated the load profile of `putContraIndicators` scenario in `src/cimit/test.ts` to have maxVUs of 1200 and target load of 400 iterations per second.
---

### Why?
to perform a load test for CIMIT with volumes according to the NFRs.

---
