### PR TITLE
[QA-415] Update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.5.0
     hooks:
       - id: detect-private-key
       - id: detect-aws-credentials
@@ -11,7 +11,7 @@ repos:
       - id: trailing-whitespace
       - id: check-merge-conflict
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.2.0
+    rev: v1.4.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
@@ -22,7 +22,7 @@ repos:
                      ^pyproject.toml
               )
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.5.4
     hooks:
       - id: remove-tabs
       - id: remove-crlf
@@ -32,19 +32,19 @@ repos:
       - id: search-and-replace
         stages: [commit-msg, commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v8.0.0
+    rev: v9.11.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         args: ['--verbose']
         verbose: true
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.65.1
+    rev: v0.85.0
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '2.2.130'
+    rev: '3.2.3'
     hooks:
       - id: checkov
         args: ['--framework', 'cloudformation', '--quiet']


### PR DESCRIPTION
## QA-415

### What?
Bump pre-commit hook versions: `pre-commit autoupdate`

#### Changes:
- [`pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks): from `v4.2.0` to `v4.5.0`. [Release notes](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.5.0)
- [`Yelp/detect-secrets`](https://github.com/Yelp/detect-secrets): from `v1.2.0` to `v1.4.0`. [Release notes](https://github.com/Yelp/detect-secrets/releases/tag/v1.4.0)
- [`Lucas-C/pre-commit-hooks`](https://github.com/Lucas-C/pre-commit-hooks): from `v1.1.13` to `v1.5.4`. [Release notes](https://github.com/Lucas-C/pre-commit-hooks/releases/tag/v1.5.4)
- [`alessandrojcm/commitlint-pre-commit-hook`](https://github.com/alessandrojcm/commitlint-pre-commit-hook): from `v8.0.0` to `v9.11.0`. [Release notes](https://github.com/alessandrojcm/commitlint-pre-commit-hook/releases/tag/v9.11.0)
- [`aws-cloudformation/cfn-python-lint`](https://github.com/aws-cloudformation/cfn-python-lint): from `v0.65.1` to `v0.85.0`. [Release notes](https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.85.0)
- [`bridgecrewio/checkov`](https://github.com/bridgecrewio/checkov): from `2.2.130` to `3.2.3`. [Release notes](https://github.com/bridgecrewio/checkov/releases/tag/3.2.3)

---

### Why?
Ever-greening dependencies

---

### Related:
- #13 
- #91
