### PR TITLE
[QA-412] Add BAU load profiles for Passport CRI

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -46,7 +46,39 @@ const profiles: ProfileList = {
       exec: 'passport'
     }
   },
-  lowVolumeTest: {
+  bau1x: {
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1m',
+      preAllocatedVUs: 1,
+      maxVUs: 8,
+      stages: [
+        { target: 5, duration: '5m' }, // Ramp up to 5 iterations per minute in 5 minutes
+        { target: 5, duration: '10m' }, // Maintain steady state at 5 iterations per minute for 10 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
+      ],
+      exec: 'passport'
+    }
+  },
+  bau5x: {
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1m',
+      preAllocatedVUs: 1,
+      maxVUs: 40,
+      stages: [
+        { target: 5, duration: '5m' }, // Ramp up to 5 iterations per minute in 5 minutes
+        { target: 5, duration: '5m' }, // Maintain steady state at 5 iterations per minute for 5 minutes
+        { target: 25, duration: '15m' }, // Ramp up to 25 iterations per minute in 25 minutes
+        { target: 25, duration: '5m' }, // Maintain steady state at 25 iterations per minute for 5 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
+      ],
+      exec: 'passport'
+    }
+  },
+  lowVolume: {
     fraud: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
@@ -127,7 +159,6 @@ const profiles: ProfileList = {
       ],
       exec: 'passport'
     }
-
   }
 }
 

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -71,7 +71,7 @@ const profiles: ProfileList = {
       stages: [
         { target: 5, duration: '5m' }, // Ramp up to 5 iterations per minute in 5 minutes
         { target: 5, duration: '5m' }, // Maintain steady state at 5 iterations per minute for 5 minutes
-        { target: 25, duration: '15m' }, // Ramp up to 25 iterations per minute in 25 minutes
+        { target: 25, duration: '10m' }, // Ramp up to 25 iterations per minute in 10 minutes
         { target: 25, duration: '5m' }, // Maintain steady state at 25 iterations per minute for 5 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],


### PR DESCRIPTION
## QA-412

### What?
Add two load profiles for the Passport CRI script 

#### Changes:
- Added `bau1x` load profile
   - 5 min ramp ⤴ 1x prod vol
   - 10 min steady @ 1x prod vol
   - 5 min ramp ⤵ 0

![image](https://github.com/govuk-one-login/performance-testing/assets/110121463/f5f406a0-e508-4eac-8372-25629bf15041)

- Added `bau5x` load profile
   - 5 min ramp ⤴ 1x prod vol
   - 5 min steady @ 1x prod vol
   - 10 min ramp ⤴ 5x prod vol
   - 5 min steady @ 5x prod vol
   - 5 min ramp ⤵ 0

![image](https://github.com/govuk-one-login/performance-testing/assets/110121463/e7471fac-1b9e-41b0-ab89-12c233225dcf)

- Changed `lowVolumeTest` load profile name to `lowVolume`

---

### Why?
Testing BAU load for observability monitoring.

---

### Related
- [Confluence Approach Documentation](https://govukverify.atlassian.net/l/cp/pM0ABy0o)
