### PR TITLE
[QA-418] Output k6 web dashboard

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,8 +18,8 @@ RUN cd scripts && \
 FROM golang:1.21-alpine as k6-build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
-RUN go install go.k6.io/xk6/cmd/xk6@v0.9.2
-RUN xk6 build v0.47.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --output /k6
+RUN go install go.k6.io/xk6/cmd/xk6@v0.10.0
+RUN xk6 build v0.49.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --output /k6
 
 # -----------------------
 # OpenTelemetry Collector
@@ -37,6 +37,8 @@ ENV K6_STATSD_ENABLE_TAGS=true
 ENV K6_STATSD_BUFFER_SIZE=100
 ENV K6_STATSD_PUSH_INTERVAL=100ms
 ENV K6_SUMMARY_TREND_STATS=avg,min,med,p(95),p(99),max
+ENV K6_WEB_DASHBOARD=true
+ENV K6_WEB_DASHBOARD_EXPORT=report.html
 ENV OTEL_METRIC_EXPORT_INTERVAL=100
 ENV OTEL_TEMPLATE=/otel/etc/otelcol/config-template.yaml
 ENV OTEL_CONFIG=/home/k6/config.yaml

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -324,7 +324,6 @@ Resources:
   ResultsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -482,7 +481,8 @@ Resources:
               commands:
                 - echo "Uploading test results to s3"
                 - S3_LOCATION=s3://${S3_BUCKET}/${TEST_SCRIPT%.*}/$(date +%F/%T)
-                - aws s3 cp $JSON_RESULTS ${S3_LOCATION}/$JSON_RESULTS
+                - aws s3 cp $K6_WEB_DASHBOARD_EXPORT $S3_LOCATION/$K6_WEB_DASHBOARD_EXPORT
+                - aws s3 cp $JSON_RESULTS $S3_LOCATION/$JSON_RESULTS
                 - echo "Shutting down OpenTelemetry collector"
                 - sleep 120
                 - OTEL_PID=$(pgrep /otel/otelcol-contrib)


### PR DESCRIPTION
## QA-418

### What?
Produce the newly introduced [k6 web dashboard](https://grafana.com/docs/k6/latest/results-output/web-dashboard/) and upload to S3.

Example of what the report looks like:
<img width="818" alt="image" src="https://github.com/govuk-one-login/performance-testing/assets/110121463/f41fb90a-3ddf-4522-8947-df24a91629e0">

#### Changes:
- Bump k6 version from `v0.47.0` to `v0.49.0`
- Added environment variables to produce the k6 web dashboard
- Add command to upload the web dashboard to S3

---

### Why?
To add additional options for quick reporting/insight into performance tests

---

### Related:
- [k6 web dashboard documentation](https://grafana.com/docs/k6/latest/results-output/web-dashboard/)
- [k6 v0.49.0 Release notes](https://github.com/grafana/k6/releases/tag/v0.49.0)
- #481 
