### PR TITLE
[QA-418] Revert s3 Bucket ACL settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$
+        args: ['--ignore-checks', 'W3045']
   - repo: https://github.com/bridgecrewio/checkov.git
     rev: '3.2.3'
     hooks:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -324,6 +324,7 @@ Resources:
   ResultsBucket:
     Type: AWS::S3::Bucket
     Properties:
+      AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
## QA-418

### What?
Reverting the Access Control changes made to the s3 results bucket to prevent deployment failures

#### Changes:
- Revert s3 bucket `AccessControl` setting 
- Added ignore warning `W3045` to cfn-lint pre-commit hook

---

### Why?
Updates to the cfn-lint hook have added a warning for an access control setting which has been moved to legacy. The s3 bucket we have was created with these legacy settings, so this cannot be removed from the IaC and updated in place without a deployment error. Ignoring the warning and reverting the access control setting to it's legacy configuration fixes this deployment issue.

---

### Related:
- #480
- [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html#cfn-s3-bucket-accesscontrol)
