### PR TITLE
[QA-408]: Script updates for AIS smoke testing

### DIFF
--- a/deploy/scripts/src/ais/data/retrieveInterventionUser.csv
+++ b/deploy/scripts/src/ais/data/retrieveInterventionUser.csv
@@ -1,2 +1,6 @@
 userID
-TestDataToBeUpdated
+urn:fdc:gov.uk:2022:fca47c1e-cc44-4d19-b57b-4c9a021990fd
+urn:fdc:gov.uk:2022:03151a2e-ba11-4dd8-8f1f-2816cac4c7df
+urn:fdc:gov.uk:2022:12b66d75-8e0b-45c9-a7d0-ea0624b2dd8d
+urn:fdc:gov.uk:2022:6c2f4d8f-a91e-4d98-9062-100cbb37b942
+urn:fdc:gov.uk:2022:6288d4e4-573d-46a8-84bd-479ad2fb2d12

--- a/deploy/scripts/src/ais/requestGenerator/aisReqGen.ts
+++ b/deploy/scripts/src/ais/requestGenerator/aisReqGen.ts
@@ -25,7 +25,7 @@ export function generatePersistIVRequest (userID: string, interventionCode: stri
     timestamp: Math.floor(Date.now() / 1000),
     event_timestamp_ms: Date.now(),
     event_name: 'TICF_ACCOUNT_INTERVENTION',
-    event_id: 'AUTH_IPV_AUTHORISATION_REQUESTED',
+    event_id: uuidv4(),
     component_id: 'TICF_CRI',
     user: {
       user_id: userID


### PR DESCRIPTION
## QA-408 <!--Jira Ticket Number-->

### What?
Script updates for AIS smoke testing

#### Changes:
- Corrected the value for `event_id` field in the payload.
- Added 5 records for smoke testing of the `RetrieveIV` scenario in the pipeline

---

### Why?
To conduct smoke testing of both Persist and Retrieve IV scenarios.
