### PR TITLE
[QA-423] - Increasing SPOT stress test volume to 2000r/s

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -55,10 +55,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 5000,
+      maxVUs: 6000,
       stages: [
-        { target: 1200, duration: '15m' }, // Ramp up to 1,200 iterations per second in 15 minutes
-        { target: 1200, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 1,200 iterations/second
+        { target: 2000, duration: '15m' }, // Ramp up to 2,000 iterations per second in 15 minutes
+        { target: 2000, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 2,000 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'spotScenario'


### PR DESCRIPTION
## QA-423 <!--Jira Ticket Number-->

### What?
Increased the SPOT stress test to a target volume of 2000 iterations per second with MaxVUs to 6000.

#### Changes:
- changed target volume to 2000r/s in SPOT stress test
- changed MaxVUs to 6000 in SPOT stress test

---

### Why?
to conduct a stress test of SPOT at 2000r/s
