### PR TITLE
[QA-425] Pin GHAs to specific SHAs

### DIFF
--- a/.github/workflows/feature-branch-publish.yaml
+++ b/.github/workflows/feature-branch-publish.yaml
@@ -33,22 +33,22 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.8"
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v4.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.PERF_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Upload Fargates to S3
         env:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: '0'
 
@@ -32,12 +32,12 @@ jobs:
         run: npm start
 
       - name: Run local k6 unit test script
-        uses: grafana/k6-action@v0.3.1
+        uses: grafana/k6-action@e4714b734f2b0afaabeb7b4a69142745548ab9ec # v0.3.1
         with:
           filename: ./deploy/scripts/dist/common/unit-tests.js
 
       - run: git fetch origin main
       - name:  Run pre-commit action
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
         with:
           extra_args: --from-ref FETCH_HEAD --to-ref HEAD

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy SAM app to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@b09ef1e0fd113edd21c1081672b95f46688292d5 # 1.2.0
         with:
           artifact-bucket-name: ${{ secrets.PERF_ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.PERF_CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
## QA-425

### What?
Pin GitHub Actions to specific SHAs

#### Changes:
- Changed all GitHub Action versions using to semver to pin to specific SHAs instead with the semver tag as a comment

---

### Why?
Improve security of GitHub Actions and prevent malicious code from executing by changing the tag to a different commit. Align to the GDS way.

---

### Related:
- [GDS Way documentation](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/use-github.html#using-github-actions-and-workflows)
- [GitHub documentation](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions)
