### PR TITLE
[QA-424]: Split OIDC and Auth calls in Auth scenarios

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -368,8 +368,8 @@ export function signIn (): void {
         }),
         { isStatusCode302 })
 
-        rpStubCheck = (res.headers.Location).includes('auth-stub')
-        acceptNewTerms = (res.headers.Location).includes('signin')
+        rpStubCheck = res.headers.Location.includes('auth-stub')
+        acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
 
         if (rpStubCheck) {
           res = timeRequest(() => http.get(res.headers.Location, {
@@ -410,8 +410,8 @@ export function signIn (): void {
         }),
         { isStatusCode302 })
 
-        rpStubCheck = (res.headers.Location).includes('auth-stub')
-        acceptNewTerms = (res.headers.Location).includes('signin')
+        rpStubCheck = res.headers.Location.includes('auth-stub')
+        acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
 
         if (rpStubCheck) {
           res = timeRequest(() => http.get(res.headers.Location, {

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -376,9 +376,7 @@ export function signIn (): void {
             tags: { name: 'B02_SignIn_05_AuthMFA_EnterTOTP_03_RPStub' }
           }),
           { isStatusCode200, ...pageContentCheck('User information') })
-        }
-
-        if (acceptNewTerms) {
+        } else if (acceptNewTerms) {
           res = timeRequest(() => http.get(res.headers.Location, {
             tags: { name: 'B02_SignIn_05_AuthMFA_EnterTOTP_04_AuthAcceptTerms' }
           }),
@@ -420,9 +418,7 @@ export function signIn (): void {
             tags: { name: 'B02_SignIn_07_SMSMFA_EnterOTP_03_RPStub' }
           }),
           { isStatusCode200, ...pageContentCheck('User information') })
-        }
-
-        if (acceptNewTerms) {
+        } else if (acceptNewTerms) {
           res = timeRequest(() => http.get(res.headers.Location, {
             tags: { name: 'B02_SignIn_07_SMSMFA_EnterOTP_03_AuthAcceptTerms' } // pragma: allowlist secret
           }),

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -290,17 +290,33 @@ export function signUp (): void {
       tags: { name: 'B01_SignUp_11_ContinueAccountCreated_03_RPStub' }
     }),
     { isStatusCode200, ...pageContentCheck('User information') })
-    iterationsCompleted.add(1)
   })
 
   // 25% of users logout
   if (Math.random() <= 0.25) {
     sleep(1)
-    res = group('B01_SignUp_12_Logout', () =>
-      timeRequest(() => res.submitForm({
-        params: { tags: { name: 'B01_SignUp_12_Logout' } }
-      }), { isStatusCode200, ...pageContentCheck('Successfully signed out') }))
+
+    group('B01_SignUp_12_Logout POST', () => {
+      res = timeRequest(() => res.submitForm({
+        params: {
+          redirects: 0,
+          tags: { name: 'B01_SignUp_12_Logout_01_RPStub' }
+        }
+      }),
+      { isStatusCode302 })
+      res = timeRequest(() => http.get(res.headers.Location, {
+        redirects: 0,
+        tags: { name: 'B01_SignUp_12_Logout_02_OIDCCall' }
+      }),
+      { isStatusCode302 })
+      res = timeRequest(() => http.get(res.headers.Location, {
+        tags: { name: 'B01_SignUp_12_Logout_03_RPStub' }
+      }),
+      { isStatusCode200, ...pageContentCheck('Successfully signed out') })
+    })
   }
+
+  iterationsCompleted.add(1)
 }
 
 export function signIn (): void {
@@ -438,15 +454,29 @@ export function signIn (): void {
         }), { isStatusCode200, ...pageContentCheck('User information') }))
   }
 
-  iterationsCompleted.add(1)
-
   // 25% of users logout
   if (Math.random() <= 0.25) {
     sleep(1)
 
-    res = group('B02_SignIn_09_Logout POST', () =>
-      timeRequest(() => res.submitForm({
-        params: { tags: { name: 'B02_SignIn_09_Logout' } }
-      }), { isStatusCode200, ...pageContentCheck('Successfully signed out') }))
+    group('B02_SignIn_09_Logout POST', () => {
+      res = timeRequest(() => res.submitForm({
+        params: {
+          redirects: 0,
+          tags: { name: 'B02_SignIn_09_Logout_01_RPStub' }
+        }
+      }),
+      { isStatusCode302 })
+      res = timeRequest(() => http.get(res.headers.Location, {
+        redirects: 0,
+        tags: { name: 'B02_SignIn_09_Logout_02_OIDCCall' }
+      }),
+      { isStatusCode302 })
+      res = timeRequest(() => http.get(res.headers.Location, {
+        tags: { name: 'B02_SignIn_09_Logout_03_RPStub' }
+      }),
+      { isStatusCode200, ...pageContentCheck('Successfully signed out') })
+    })
   }
+
+  iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-424 <!--Jira Ticket Number-->

### What?
Split OIDC and Auth calls in `sign-up` and `sign-in` scenarios

#### Changes:
- Split OIDC and Auth calls in `sign-up` and `sign-in` scenarios.
- Modified tag names.
- Corrected the position of the `iterationCompleted` metric 

---

### Why?
To evaluate the performance metrics of both Orchestration and Authentication calls separately.