### PR TITLE
[QA-434] Update low volume AIS retrieveIV scenario target volume to 1000r/s

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -55,10 +55,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 150,
+      maxVUs: 3000,
       stages: [
-        { target: 100, duration: '15m' }, // Ramp up to 100 iterations per second in 15 minutes
-        { target: 100, duration: '30m' }, // Maintain a steady state of 100 iterations per second for 30 minutes
+        { target: 1000, duration: '15m' }, // Ramp up to 1000 iterations per second in 15 minutes
+        { target: 1000, duration: '30m' }, // Maintain a steady state of 1000 iterations per second for 30 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'retrieveIV'


### PR DESCRIPTION
## QA-434 <!--Jira Ticket Number-->

### What?
changes the AIS retrieveIV scenario, lowVolumeTest target volume from 100 iterations per second to 1000 iterations per second; and increase the maxVUs to 3000. 

#### Changes:
- change the target volume for lowVolume test to 1000 iterations per second for AIS retrieveIV scenario.
- change the maxVUs to 3000.

---

### Why?
To conduct a low volume test for AIS retrieveIV scenario at 1000r/s. 

---
