### PR TITLE
[QA-440]: Remove Retrieve VC step from Persist scenario

### DIFF
--- a/deploy/scripts/src/accounts/vc-storage.ts
+++ b/deploy/scripts/src/accounts/vc-storage.ts
@@ -175,13 +175,6 @@ export function persistVC (): void {
         isStatusCode202: (r) => r.status === 202,
         ...pageContentCheck('messageId')
       }))
-
-  sleepBetween(2, 4) // Random sleep between 2-4 seconds
-
-  options.tags.name = 'R01_PersistVC_03_RetrieveVC'
-  res = group('R01_PersistVC_03_Retrieve GET', () =>
-    timeRequest(() => http.get(env.envURL + `/vcs/${subjectID}`, options),
-      { isStatusCode200, ...pageContentCheck('vcs') }))
   iterationsCompleted.add(1)
 }
 


### PR DESCRIPTION
## QA-440 <!--Jira Ticket Number-->

### What?
Remove Retrieve VC step from Persist scenario

#### Changes:
- Remove Retrieve VC step from Persist scenario

---

### Why?
Retrieving a VC immediately after creating it is not a real world behaviour and is leading to HTTP-404 errors in high volume tests. 