### PR TITLE
BAV CRI - Increase ramp up time

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -24,7 +24,7 @@ const profiles: ProfileList = {
       exec: 'BAV'
     }
   },
-  lowVolume: {
+  load: {
     BAV: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
@@ -32,23 +32,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 1,
       maxVUs: 300,
       stages: [
-        { target: 10, duration: '5m' }, // Ramps up to target load
-        { target: 10, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 10 iterations/second
-        { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
-      ],
-      exec: 'BAV'
-    }
-  },
-  stress: {
-    BAV: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 1,
-      maxVUs: 900,
-      stages: [
-        { target: 30, duration: '5m' }, // Ramps up to target load
-        { target: 30, duration: '15m' }, // Steady State of 15 minutes at the ramp up load i.e. 30 iterations/second
+        { target: 10, duration: '15m' }, // Ramps up to target load
+        { target: 10, duration: '30m' }, // Steady State of 30 minutes at the ramp up load i.e. 10 iterations/second
         { target: 0, duration: '5m' } // Ramp down duration of 5 minutes.
       ],
       exec: 'BAV'


### PR DESCRIPTION
## QA-442 <!--Jira Ticket Number-->

### What?
Change workload of BAV CRI load test for next test run

#### Changes:
- Increased ramp up to 15m and steady state time to 30m for test target 10 (new NFR)
- Removed load profile of test target 30 (old NFR)

---

### Why?
The next test run should have an increased ramp up time as 10j/s is the NFR (based on the expected volume of 6.2% of new identity attempts using BAV CRI)
