### PR TITLE
AIS - Increased stress test target to new NFR

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -83,10 +83,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 11400,
+      maxVUs: 17100,
       stages: [
-        { target: 3800, duration: '15m' }, // Ramp up to 3800 iterations per second in 15 minutes
-        { target: 3800, duration: '30m' }, // Maintain a steady state of 3800 iterations per second for 30 minutes
+        { target: 5700, duration: '15m' }, // Ramp up to 5700 iterations per second in 15 minutes
+        { target: 5700, duration: '30m' }, // Maintain a steady state of 5700 iterations per second for 30 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'retrieveIV'


### PR DESCRIPTION
## QA-444 <!--Jira Ticket Number-->

### What?
Increased stress test target to new NFR value for AIS

#### Changes:
- Increased stress test target volume from 3,800 to 5,700 in AIS script
---

### Why?
To carry out a stress test at the new NFR value target load
---