### PR TITLE
[QA-446] Adding load profile of 200r/s to Auth sign-in

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -64,6 +64,21 @@ const profiles: ProfileList = {
       exec: 'signIn'
     }
   },
+  load: {
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 900,
+      stages: [
+        { target: 200, duration: '15m' }, // Ramps up to 200 iterations per second in 15 minutes
+        { target: 200, duration: '30m' }, // Maintain steady state at 200 iterations per second for 30 minutes
+        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
+      ],
+      exec: 'signIn'
+    }
+  },
   stress: {
     signUp: {
       executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-446 <!--Jira Ticket Number-->

### What?
Created an addition load profile for Auth sign-in with a target volume of 200 iterations per second. 

#### Changes:
added the following to `deploy/scripts/src/authentication/test.ts`
```
load: {
    signIn: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '1s',
      preAllocatedVUs: 1,
      maxVUs: 900,
      stages: [
        { target: 200, duration: '15m' }, // Ramps up to 200 iterations per second in 15 minutes
        { target: 200, duration: '30m' }, // Maintain steady state at 200 iterations per second for 30 minutes
        { target: 0, duration: '5m' } // Total ramp down in 5 minutes
      ],
      exec: 'signIn'
    }
  }
```

---

### Why?
to run a load test for Auth sign-in at 200 iterations per second

