### PR TITLE
[QA-448] AIS - Add name tags to metrics

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -157,8 +157,10 @@ export function retrieveIV (): void {
   iterationsStarted.add(1)
 
   group('B02_RetrieveIV_01_GetInterventionData GET', () =>
-    timeRequest(() => http.get(env.aisEnvURL + `/v1/ais/${retrieveData.userID}?history=true`),
-      { isStatusCode200, ...pageContentCheck('Perf Testing') }))
+    timeRequest(() => http.get(env.aisEnvURL + `/v1/ais/${retrieveData.userID}?history=true`, {
+      tags: { name: 'B02_RetrieveIV_01_GetInterventionData' }
+    }),
+    { isStatusCode200, ...pageContentCheck('Perf Testing') }))
   iterationsCompleted.add(1)
 }
 


### PR DESCRIPTION
## QA-448 <!--Jira Ticket Number-->

### What?
Added tag to step in AIS test to reduce logging

#### Changes:
- Added tag to step in AIS Retrieve Intervention script

---

### Why?
The results.gz file from the last stress test was too large to open so we could not get the summary metrics. Adding the tag will hopefully decrease the size of the logs.