### PR TITLE
[QA-453] Increasing target volume of Auth sign-in load test to 500r/s

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -70,10 +70,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '1s',
       preAllocatedVUs: 1,
-      maxVUs: 6000,
+      maxVUs: 15000,
       stages: [
-        { target: 200, duration: '15m' }, // Ramps up to 200 iterations per second in 15 minutes
-        { target: 200, duration: '30m' }, // Maintain steady state at 200 iterations per second for 30 minutes
+        { target: 500, duration: '15m' }, // Ramps up to 500 iterations per second in 15 minutes
+        { target: 500, duration: '30m' }, // Maintain steady state at 500 iterations per second for 30 minutes
         { target: 0, duration: '5m' } // Total ramp down in 5 minutes
       ],
       exec: 'signIn'


### PR DESCRIPTION
## QA-453 <!--Jira Ticket Number-->

### What?
increase the target volume from 200r/s to 500r/s in the load profile for Auth signIn. 

#### Changes:
- increase the target volume in the Auth signIn load profile to 500r/s
- increase the maxVUs to 15,000

---

### Why?
to run a performance test of Auth signIn at 500r/s. 

---
