### PR TITLE
[QA-450] Handle environment variables with a utility function

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -9,6 +9,7 @@ import { SharedArray } from 'k6/data'
 import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -198,20 +199,20 @@ const validateData: validateUserData[] = new SharedArray('data', () => Array.fro
 ))
 
 const env = {
-  envURL: __ENV.ACCOUNT_HOME_URL,
-  signinURL: __ENV.ACCOUNT_SIGNIN_URL
+  envURL: getEnv('ACCOUNT_HOME_URL'),
+  signinURL: getEnv('ACCOUNT_SIGNIN_URL')
 }
 
 const credentials = {
-  authAppKey: __ENV.ACCOUNT_APP_KEY,
-  currPassword: __ENV.ACCOUNT_APP_PASSWORD,
-  newPassword: __ENV.ACCOUNT_APP_PASSWORD_NEW,
-  fixedPhoneOTP: __ENV.ACCOUNT_PHONE_OTP,
-  fixedEmailOTP: __ENV.ACCOUNT_EMAIL_OTP
+  authAppKey: getEnv('ACCOUNT_APP_KEY'),
+  currPassword: getEnv('ACCOUNT_APP_PASSWORD'),
+  newPassword: getEnv('ACCOUNT_APP_PASSWORD_NEW'),
+  fixedPhoneOTP: getEnv('ACCOUNT_PHONE_OTP'),
+  fixedEmailOTP: getEnv('ACCOUNT_EMAIL_OTP')
 }
 
 const phoneData = {
-  newPhone: __ENV.ACCOUNT_NEW_PHONE
+  newPhone: getEnv('ACCOUNT_NEW_PHONE')
 }
 
 export function changeEmail (): void {

--- a/deploy/scripts/src/accounts/vc-storage.ts
+++ b/deploy/scripts/src/accounts/vc-storage.ts
@@ -8,6 +8,7 @@ import { uuidv4 } from '../common/utils/jslib'
 import { timeRequest } from '../common/utils/request/timing'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -134,10 +135,10 @@ const csvData: SummariseSubjectID[] = new SharedArray('Summarise Subject ID', fu
 })
 
 const env = {
-  envURL: __ENV.ACCOUNT_BRAVO_ID_REUSE_URL,
-  envMock: __ENV.ACCOUNT_BRAVO_ID_REUSE_MOCK,
-  envApiKey: __ENV.ACCOUNT_BRAVO_ID_REUSE_API_KEY,
-  envApiKeySummarise: __ENV.ACCOUNT_BRAVO_ID_REUSE_API_KEY_SUMMARISE
+  envURL: getEnv('ACCOUNT_BRAVO_ID_REUSE_URL'),
+  envMock: getEnv('ACCOUNT_BRAVO_ID_REUSE_MOCK'),
+  envApiKey: getEnv('ACCOUNT_BRAVO_ID_REUSE_API_KEY'),
+  envApiKeySummarise: getEnv('ACCOUNT_BRAVO_ID_REUSE_API_KEY_SUMMARISE')
 }
 export function persistVC (): void {
   let res: Response

--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -10,6 +10,7 @@ import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { SharedArray } from 'k6/data'
 import http from 'k6/http'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -118,8 +119,8 @@ export function setup (): void {
 }
 
 const env = {
-  sqs_queue: __ENV.ACCOUNT_BRAVO_AIS_TxMASQS,
-  aisEnvURL: __ENV.ACCOUNT_BRAVO_AIS_URL
+  sqs_queue: getEnv('ACCOUNT_BRAVO_AIS_TxMASQS'),
+  aisEnvURL: getEnv('ACCOUNT_BRAVO_AIS_URL')
 }
 
 interface RetrieveUserID {
@@ -134,9 +135,9 @@ const csvData: RetrieveUserID[] = new SharedArray('Retrieve Intervention User ID
   })
 })
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -10,6 +10,7 @@ import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { randomString } from '../common/utils/jslib'
 import { URL } from '../common/utils/jslib/url'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -145,21 +146,21 @@ const dataSignIn: signInData[] = new SharedArray('data', () => Array.from({ leng
 ))
 
 const credentials = {
-  authAppKey: __ENV.ACCOUNT_APP_KEY,
-  password: __ENV.ACCOUNT_APP_PASSWORD,
-  emailOTP: __ENV.ACCOUNT_EMAIL_OTP,
-  phoneOTP: __ENV.ACCOUNT_PHONE_OTP
+  authAppKey: getEnv('ACCOUNT_APP_KEY'),
+  password: getEnv('ACCOUNT_APP_PASSWORD'),
+  emailOTP: getEnv('ACCOUNT_EMAIL_OTP'),
+  phoneOTP: getEnv('ACCOUNT_PHONE_OTP')
 }
 
 function startJourneyUrl (): string {
-  const url = new URL(__ENV.ACCOUNT_OP_URL)
-  url.searchParams.append('client_id', __ENV.ACCOUNT_RP_STUB_CLIENT_ID)
+  const url = new URL(getEnv('ACCOUNT_OP_URL'))
+  url.searchParams.append('client_id', getEnv('ACCOUNT_RP_STUB_CLIENT_ID'))
   url.searchParams.append('nonce', randomString(20))
   url.searchParams.append('state', randomString(20))
   url.searchParams.append('vtr', '["Cl.Cm"]')
   url.searchParams.append('scope', 'openid email phone')
   url.searchParams.append('response_type', 'code')
-  url.searchParams.append('redirect_uri', `${__ENV.ACCOUNT_RP_STUB}/oidc/authorization-code/callback`)
+  url.searchParams.append('redirect_uri', `${getEnv('ACCOUNT_RP_STUB')}/oidc/authorization-code/callback`)
   return url.toString()
 }
 

--- a/deploy/scripts/src/btm/test.ts
+++ b/deploy/scripts/src/btm/test.ts
@@ -4,6 +4,7 @@ import { selectProfile, type ProfileList, describeProfile } from '../common/util
 import { uuidv4, randomIntBetween } from '../common/utils/jslib/index'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -195,12 +196,12 @@ export function setup (): void {
 }
 
 const env = {
-  sqs_queue: __ENV.DATA_BTM_SQS
+  sqs_queue: getEnv('DATA_BTM_SQS')
 }
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken
@@ -208,8 +209,8 @@ const awsConfig = new AWSConfig({
 const sqs = new SQSClient(awsConfig)
 
 const eventData = {
-  payloadEventsString: __ENV.DATA_BTM_SQS_PAYLOAD_EVENTS,
-  payloadTimestamp: __ENV.DATA_BTM_SQS_PAYLOAD_TIMESTAMP
+  payloadEventsString: getEnv('DATA_BTM_SQS_PAYLOAD_EVENTS'),
+  payloadTimestamp: getEnv('DATA_BTM_SQS_PAYLOAD_TIMESTAMP')
 }
 
 const payloadEventsArray = JSON.parse(eventData.payloadEventsString)

--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -10,6 +10,7 @@ import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200 } from '../common/utils/checks/assertions'
 import { SharedArray } from 'k6/data'
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -151,14 +152,14 @@ export function setup (): void {
 }
 
 const env = {
-  putCIURL: __ENV.IDENTITY_CIMIT_PUTCI,
-  getCICURL: __ENV.IDENTITY_CIMIT_GETCIC,
-  postMitigationURL: __ENV.IDENTITY_CIMIT_POSTMITIGATION
+  putCIURL: getEnv('IDENTITY_CIMIT_PUTCI'),
+  getCICURL: getEnv('IDENTITY_CIMIT_GETCIC'),
+  postMitigationURL: getEnv('IDENTITY_CIMIT_POSTMITIGATION')
 }
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken

--- a/deploy/scripts/src/common/unit-tests.ts
+++ b/deploy/scripts/src/common/unit-tests.ts
@@ -10,7 +10,7 @@ import { isStatusCode200, isStatusCode201, isStatusCode302, pageContentCheck } f
 import { type RefinedParams, type RefinedResponse, type ResponseType, type Response } from 'k6/http'
 import { type Selection } from 'k6/html'
 import { iterationsCompleted, iterationsStarted } from './utils/custom_metric/counter'
-import { getEnv, getEnvVar } from './utils/config/environment-variables'
+import { getEnv } from './utils/config/environment-variables'
 
 export const options = {
   vus: 1,

--- a/deploy/scripts/src/common/unit-tests.ts
+++ b/deploy/scripts/src/common/unit-tests.ts
@@ -10,6 +10,7 @@ import { isStatusCode200, isStatusCode201, isStatusCode302, pageContentCheck } f
 import { type RefinedParams, type RefinedResponse, type ResponseType, type Response } from 'k6/http'
 import { type Selection } from 'k6/html'
 import { iterationsCompleted, iterationsStarted } from './utils/custom_metric/counter'
+import { getEnv, getEnvVar } from './utils/config/environment-variables'
 
 export const options = {
   vus: 1,
@@ -58,6 +59,27 @@ export default (): void => {
       const title = 'Page Title'
       response.body = `<html><body><h1>${title}</h1></body></html>`
       check(response, { ...pageContentCheck(title) })
+    })
+  })
+
+  group('config/env-vars', () => {
+    group('getEnv()', () => {
+      let errorFound = false
+      try {
+        getEnv('NON_EXISTENT')
+      } catch (error) {
+        errorFound = true
+      }
+
+      const name = 'EXISTING VARIABLE'
+      const value = 'sampleValue1'
+      __ENV[name] = value
+
+      check(null, {
+        'Error when not variable not found': () => errorFound,
+        'Undefined when not found and not required': () => getEnv('NON_EXISTENT', false) === undefined,
+        'Value retrieved correctly': () => getEnv(name) === value
+      })
     })
   })
 

--- a/deploy/scripts/src/common/utils/config/environment-variables.ts
+++ b/deploy/scripts/src/common/utils/config/environment-variables.ts
@@ -1,0 +1,19 @@
+/**
+ * Get environment variables. Given an environment variable name, will retrieve
+ * the value. If the variable does not exist and it is required for the test,
+ * this function will throw an Error
+ * @param {string} name - Name of the environment variable
+ * @param {bool} [required] - Optional boolean specifying if an error should be
+ * thrown if the variable is not found. Defaults to `true`.
+ * @returns {string} Value of the environment variable
+ * @example
+ * const password = getEnv('ACCOUNT_APP_PASSWORD')  // Required for test run
+ * const profile = getEnv('PROFILE', false) ?? 'smoke'  // Optional variable defaults to 'smoke' if variable does not exist
+ */
+export function getEnv (name: string, required: boolean = true): string {
+  const variable = __ENV[name]
+  if (required && variable === undefined) {
+    throw new Error(`Environment variable '${name}' does not exist.`)
+  }
+  return variable
+}

--- a/deploy/scripts/src/common/utils/jslib/aws-sqs.d.ts
+++ b/deploy/scripts/src/common/utils/jslib/aws-sqs.d.ts
@@ -13,9 +13,9 @@ export class AWSConfig {
    * @param {string} [sessionToken] The AWS secret access token to use for authentication
    * @example
    * const awsConfig = new AWSConfig({
-   *  region: __ENV.AWS_REGION,
-   *  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
-   *  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+   *  region: getEnv('AWS_REGION'),
+   *  accessKeyId: getEnv('AWS_ACCESS_KEY_ID'),
+   *  secretAccessKey: getEnv('AWS_SECRET_ACCESS_KEY'),
    * })
    * const sqs = new SQSClient(awsConfig)
    */

--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -57,8 +57,8 @@ export function setup (): void {
 
 const env = {
   BAV: {
-    ipvStub: __ENV.IDENTITY_KIWI_BAV_STUB_URL,
-    target: __ENV.IDENTITY_KIWI_BAV_TARGET
+    ipvStub: getEnv('IDENTITY_KIWI_BAV_STUB_URL'),
+    target: getEnv('IDENTITY_KIWI_BAV_TARGET')
   }
 }
 

--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -84,12 +84,12 @@ export function setup (): void {
 
 const env = {
   CIC: {
-    ipvStub: __ENV.IDENTITY_KIWI_CIC_STUB_URL,
-    target: __ENV.IDENTITY_KIWI_CIC_TARGET
+    ipvStub: getEnv('IDENTITY_KIWI_CIC_STUB_URL'),
+    target: getEnv('IDENTITY_KIWI_CIC_TARGET')
   },
   F2F: {
-    ipvStub: __ENV.IDENTITY_KIWI_F2F_STUB_URL,
-    target: __ENV.IDENTITY_KIWI_F2F_TARGET
+    ipvStub: getEnv('IDENTITY_KIWI_F2F_STUB_URL'),
+    target: getEnv('IDENTITY_KIWI_F2F_TARGET')
   }
 }
 

--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -5,6 +5,7 @@ import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { generateAuthRequest, generateF2FRequest, generateIPVRequest, generateDocumentUploadedRequest } from './requestGenerator/ipvrReqGen'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
 import { uuidv4 } from '../common/utils/jslib/index'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -104,12 +105,12 @@ export function setup (): void {
 }
 
 const env = {
-  sqs_queue: __ENV.IDENTITY_KIWI_STUB_SQS
+  sqs_queue: getEnv('IDENTITY_KIWI_STUB_SQS')
 }
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -177,16 +177,16 @@ export function setup (): void {
 }
 
 const env = {
-  ipvCoreStub: __ENV.IDENTITY_CORE_STUB_URL,
-  fraudUrl: __ENV.IDENTITY_FRAUD_URL,
-  drivingUrl: __ENV.IDENTITY_DRIVING_URL,
-  passportURL: __ENV.IDENTITY_PASSPORT_URL,
-  envName: __ENV.ENVIRONMENT
+  ipvCoreStub: getEnv('IDENTITY_CORE_STUB_URL'),
+  fraudUrl: getEnv('IDENTITY_FRAUD_URL'),
+  drivingUrl: getEnv('IDENTITY_DRIVING_URL'),
+  passportURL: getEnv('IDENTITY_PASSPORT_URL'),
+  envName: getEnv('ENVIRONMENT')
 }
 
 const stubCreds = {
-  userName: __ENV.IDENTITY_CORE_STUB_USERNAME,
-  password: __ENV.IDENTITY_CORE_STUB_PASSWORD
+  userName: getEnv('IDENTITY_CORE_STUB_USERNAME'),
+  password: getEnv('IDENTITY_CORE_STUB_PASSWORD')
 }
 
 interface DrivingLicenseUser {

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -7,6 +7,7 @@ import { env, encodedCredentials } from './utils/config'
 import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -69,7 +70,7 @@ export function setup (): void {
 }
 
 const kbvAnswersOBJ = {
-  kbvAnswers: __ENV.IDENTITY_KBV_ANSWERS
+  kbvAnswers: getEnv('IDENTITY_KBV_ANSWERS')
 }
 
 export function kbvScenario1 (): void {

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -8,6 +8,7 @@ import { selectProfile, type ProfileList, describeProfile } from '../common/util
 import { timeRequest } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -54,11 +55,11 @@ export function setup (): void {
   describeProfile(loadProfile)
 }
 
-const env = { ipvCoreStub: __ENV.IDENTITY_CORE_STUB_URL }
+const env = { ipvCoreStub: getEnv('IDENTITY_CORE_STUB_URL') }
 
 const stubCreds = {
-  userName: __ENV.IDENTITY_CORE_STUB_USERNAME,
-  password: __ENV.IDENTITY_CORE_STUB_PASSWORD
+  userName: getEnv('IDENTITY_CORE_STUB_USERNAME'),
+  password: getEnv('IDENTITY_CORE_STUB_PASSWORD')
 }
 
 interface nino {

--- a/deploy/scripts/src/cri-orange/utils/config.ts
+++ b/deploy/scripts/src/cri-orange/utils/config.ts
@@ -1,15 +1,16 @@
 import encoding from 'k6/encoding'
+import { getEnv } from '../../common/utils/config/environment-variables'
 
 export const env = {
-  ipvCoreStub: __ENV.IDENTITY_CORE_STUB_URL,
-  kbvEndPoint: __ENV.IDENTITY_KBV_URL,
-  addressEndPoint: __ENV.IDENTITY_ADDRESS_URL,
-  envName: __ENV.ENVIRONMENT
+  ipvCoreStub: getEnv('IDENTITY_CORE_STUB_URL'),
+  kbvEndPoint: getEnv('IDENTITY_KBV_URL'),
+  addressEndPoint: getEnv('IDENTITY_ADDRESS_URL'),
+  envName: getEnv('ENVIRONMENT')
 }
 
 export const stubCreds = {
-  userName: __ENV.IDENTITY_CORE_STUB_USERNAME,
-  password: __ENV.IDENTITY_CORE_STUB_PASSWORD
+  userName: getEnv('IDENTITY_CORE_STUB_USERNAME'),
+  password: getEnv('IDENTITY_CORE_STUB_PASSWORD')
 }
 
 const credentials = `${stubCreds.userName}:${stubCreds.password}`

--- a/deploy/scripts/src/examples/dev-platform.ts
+++ b/deploy/scripts/src/examples/dev-platform.ts
@@ -4,6 +4,7 @@ import { group, sleep } from 'k6'
 import { selectProfile, type ProfileList, describeProfile } from '../common/utils/config/load-profiles'
 import { isStatusCode200 } from '../common/utils/checks/assertions'
 import { timeRequest } from '../common/utils/request/timing'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -74,8 +75,8 @@ export function setup (): void {
 }
 
 const env = {
-  FE_URL: __ENV.CFN_HelloWorldApi.replace(/\/$/, ''), // Output from demoNodeApp
-  BE_URL: __ENV.CFN_ApiGatewayEndpoint.replace(/\/$/, '') // Output from demoNodeApp
+  FE_URL: getEnv('CFN_HelloWorldApi').replace(/\/$/, ''), // Output from demoNodeApp
+  BE_URL: getEnv('CFN_ApiGatewayEndpoint').replace(/\/$/, '') // Output from demoNodeApp
 }
 
 export function demoSamApp (): void {

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -13,6 +13,7 @@ import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { SharedArray } from 'k6/data'
 import { uuidv4 } from '../common/utils/jslib/index'
 import execution from 'k6/execution'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -210,19 +211,19 @@ const csvData: IDReuseUserID[] = new SharedArray('ID Reuse User ID', function ()
   })
 })
 
-const environment = __ENV.ENVIRONMENT.toLocaleUpperCase()
+const environment = getEnv('ENVIRONMENT').toLocaleUpperCase()
 const validEnvironments = ['BUILD', 'DEV']
 if (!validEnvironments.includes(environment)) throw new Error(`Environment '${environment}' not in [${validEnvironments.toString()}]`)
 
 const env = {
   orchStubEndPoint: __ENV[`IDENTITY_${environment}_ORCH_STUB_URL`],
   ipvCoreURL: __ENV[`IDENTITY_${environment}_CORE_URL`]
-  // staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true'
+  // staticResources: getEnv('K6_NO_STATIC_RESOURCES') !== 'true'
 }
 
 const stubCreds = {
-  userName: __ENV.IDENTITY_ORCH_STUB_USERNAME,
-  password: __ENV.IDENTITY_ORCH_STUB_PASSWORD
+  userName: getEnv('IDENTITY_ORCH_STUB_USERNAME'),
+  password: getEnv('IDENTITY_ORCH_STUB_PASSWORD')
 }
 
 export function passport (): void {

--- a/deploy/scripts/src/mobile/utils/config.ts
+++ b/deploy/scripts/src/mobile/utils/config.ts
@@ -1,5 +1,3 @@
-// __ENV is the syntax in k6 for accessing environment variables
-
 import { getEnv } from '../../common/utils/config/environment-variables'
 
 // Refer to deploy/scripts/README.md for guidance on how to set environment variables

--- a/deploy/scripts/src/mobile/utils/config.ts
+++ b/deploy/scripts/src/mobile/utils/config.ts
@@ -1,6 +1,9 @@
 // __ENV is the syntax in k6 for accessing environment variables
+
+import { getEnv } from '../../common/utils/config/environment-variables'
+
 // Refer to deploy/scripts/README.md for guidance on how to set environment variables
-export const environment = __ENV.ENVIRONMENT.toLocaleUpperCase()
+export const environment = getEnv('ENVIRONMENT').toLocaleUpperCase()
 const validEnvironments = ['BUILD', 'DEV']
 if (!validEnvironments.includes(environment)) throw new Error(`Environment '${environment}' not in [${validEnvironments.toString()}]`)
 

--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -4,6 +4,7 @@ import { selectProfile, type ProfileList, describeProfile } from '../common/util
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { generateRequest } from './requestGenerator/spotReqGen'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -81,12 +82,12 @@ export function setup (): void {
 }
 
 const env = {
-  sqs_queue: __ENV.IDENTITY_SPOT_SQS
+  sqs_queue: getEnv('IDENTITY_SPOT_SQS')
 }
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -4,6 +4,7 @@ import { selectProfile, type ProfileList, describeProfile } from '../common/util
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
+import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
   smoke: {
@@ -66,19 +67,19 @@ export function setup (): void {
 }
 
 const env = {
-  sqs_queue: __ENV.DATA_TXMA_SQS
+  sqs_queue: getEnv('DATA_TXMA_SQS')
 }
 
-const credentials = (JSON.parse(__ENV.EXECUTION_CREDENTIALS) as AssumeRoleOutput).Credentials
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 const awsConfig = new AWSConfig({
-  region: __ENV.AWS_REGION,
+  region: getEnv('AWS_REGION'),
   accessKeyId: credentials.AccessKeyId,
   secretAccessKey: credentials.SecretAccessKey,
   sessionToken: credentials.SessionToken
 })
 
 const eventData = {
-  payload: __ENV.DATA_TXMA_SQS_PAYLOAD
+  payload: getEnv('DATA_TXMA_SQS_PAYLOAD')
 }
 
 const sqs = new SQSClient(awsConfig)


### PR DESCRIPTION
## QA-450

### What?
Adds a utility function called `getEnv()` that is used to get environment variables.

#### Changes:
- `deploy/scripts/src/common/utils/config/environment-variables.ts`: Added the new `getEnv()` utility function
- `deploy/scripts/src/common/unit-tests.ts`: Added unit tests for the new function to verify it is working as intended and documented
- `deploy/scripts/src/**/*.ts`: Updated all test scripts which retrieved environment variables to use this function
---

### Why?
Environment variables were previously being accessed directly from the `__ENV` object. When the environment variable didn't exist in the context it was running, the variable would have an `undefined` value. This resulted in un-intuitive error messages later whenever this variable was used, or even fail a functional assertion as the system under test did not respond as expected. To prevent these scenarios happening again this utility function will error and abort the test if the correct environment variables are not present, with a useful error message indicating the root cause of the problem.

---

### Related:
- [k6 environment variable documentation](https://k6.io/docs/using-k6/environment-variables/)
