### PR TITLE
[QA-454] Fix TypeDoc documentation publishing

### DIFF
--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          path: ./docs
+          path: deploy/scripts/docs
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 defaults:
   run:

--- a/deploy/scripts/src/common/utils/README.md
+++ b/deploy/scripts/src/common/utils/README.md
@@ -12,4 +12,4 @@ To generate [TypeDoc](https://typedoc.org/) documentation for these files run th
 % open ./docs/index.html
 ```
 
-This documentation is also avaialble on the GitHub page site for the repository.
+This documentation is also avaialble on the [GitHub pages site](https://govuk-one-login.github.io/performance-testing/) for the repository.


### PR DESCRIPTION
## QA-454

### What?
Fix issue with TypeDoc documentation publishing.

#### Changes:
- `.github/workflows/typedoc-publish.yml`: Updated the `path` parameter to account for that it is run in the root, also removed unused workflow dispatch trigger.
- `deploy/scripts/src/common/utils/README.md`: Added URL of github pages site to the README

---

### Why?
The previous [workflow](https://github.com/govuk-one-login/performance-testing/actions/runs/8391858781) failed due to the `upload-pages-artifact` action `path` parameter using the root directory of the repository as the working directory 

---

### Related:
- #543 
