### PR TITLE
KBV - Changed stress test load profile to use full

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -17,7 +17,7 @@ const profiles: ProfileList = {
     ...createScenario('kbv', LoadProfile.short, 5)
   },
   stress: {
-    ...createScenario('kbv', LoadProfile.short, 14)
+    ...createScenario('kbv', LoadProfile.full, 14)
   }
 }
 


### PR DESCRIPTION
## QA-464 <!--Jira Ticket Number-->

### What?
Changed KBV stress test profile to use full load profile

#### Changes:
- Changed KBV stress test load profile type to full
---

### Why?
The KBV stress test should be run with a 15,30,5 load profile
---
