### PR TITLE
[QA-459] Reduce memory usage

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -82,7 +82,8 @@ const groupMap = {
 
 export const options: Options = {
   scenarios: loadProfile.scenarios,
-  thresholds: getThresholds(groupMap)
+  thresholds: getThresholds(groupMap),
+  tags: { name: '' }
 }
 
 export function setup (): void {

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -483,7 +483,7 @@ Resources:
             build:
               commands:
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS --system-tags=proto,subproto,status,method,group,check,error,error_code,tls_version,scenario,service,expected_response
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS --system-tags=status,method,group,check,error,scenario
             post_build:
               commands:
                 - echo "Uploading test results to s3"


### PR DESCRIPTION
## QA-459

### What?
Two changes which may address memory usage

#### Changes:
- `deploy/scripts/src/authentication/test.ts`: Added the `options.tags.name` to be a blank string
- `deploy/template.yaml`: Removed unused system tags in the k6 command

---

### Why?
After a recent test run which ended with k6 out-of-memory killed, I suspect that a recent change has introduced a memory leak into the injector. After some local smoke testing it seems that when the `options.tags.name` flag is not set then the memory usage of the application increases over time, even though the system tags flag should ensure that `name` is not being used, and when is it set to a blank string the memory usage appears constant.

This needs some more testing and investigation but making these changes to see if it makes a material difference at higher volumes.

---

### Related:
- #528
