### PR TITLE
[QA-459] Filter out unused metrics in OpenTelemetry Collector

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -10,6 +10,17 @@ receivers:
       network:
 
 processors:
+  filter:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'name == "k6.http_req_blocked"'
+        - 'name == "k6.http_req_connecting"'
+        - 'name == "k6.http_req_tls_handshaking"'
+        - 'name == "k6.http_req_sending"'
+        - 'name == "k6.http_req_waiting"'
+        - 'name == "k6.http_req_receiving"'
+
   batch:
     send_batch_size: 1000
     send_batch_max_size: 1000
@@ -43,5 +54,5 @@ service:
   pipelines:
     metrics:
       receivers: [statsd, hostmetrics]
-      processors: [batch, metricstransform]
+      processors: [filter, batch, metricstransform]
       exporters: [otlphttp]


### PR DESCRIPTION
## QA-459

### What?
This change filters out some k6 metrics in the OpenTelemetry processing.
Specifically these metrics:
- `k6.http_req_blocked`
- `k6.http_req_connecting`
- `k6.http_req_tls_handshaking`
- `k6.http_req_sending`
- `k6.http_req_waiting`
- `k6.http_req_receiving`

#### Changes:
- `deploy/otel-config-template.yaml`: Added a filter processor to drop the above metrics
---

### Why?
To reduce the memory usage of the OpenTelemetry collector to stop it crashing. These metrics were not currently being used in monitoring/graphing and can alternatively be found in the HTML report uploaded to s3.

Smoke tests of the authentication script showed the following analysis

|Dimension|Count without filter|Count with filter|
|--|--|--|
|`resource metrics`|3|2|
|`metrics`|2083|851|
|`data points`|2083|851|

This was tested using only the statsd reciever, and averaged over three smoke tests each. These results show a 60% reduction in statsd metrics being exported

---

### Related:
- #550 
- [`filterprocessor` documenation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
