### PR TITLE
[QA-474]: Update Kiwi scripts to use pageContentCheck utility

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -110,7 +110,7 @@ export function BAV (): void {
       code: codeUrl,
       redirect_uri: env.BAV.ipvStub + '/redirect?id=bav'
     }),
-  { isStatusCode200, 'verify response body': (r) => (r.body as string).includes('access_token') }))
+  { isStatusCode200, ...pageContentCheck('access_token') }))
 
   const accessToken = getAccessToken(res)
 
@@ -122,6 +122,6 @@ export function BAV (): void {
   }
   res = group(groups[6], () => timeRequest(() => // B01_BAV_07_SendBearerToken
     http.post(env.BAV.target + '/userinfo', {}, options),
-  { isStatusCode200, 'verify response body': (r) => (r.body as string).includes('credentialJWT') }))
+  { isStatusCode200, ...pageContentCheck('credentialJWT') }))
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -150,7 +150,7 @@ export function CIC (): void {
       code: codeUrl,
       redirect_uri: env.CIC.ipvStub + '/redirect'
     }),
-  { isStatusCode200, 'verify response body': (r) => (r.body as string).includes('access_token') }))
+  { isStatusCode200, ...pageContentCheck('access_token') }))
 
   const accessToken = getAccessToken(res)
 
@@ -162,7 +162,7 @@ export function CIC (): void {
   }
   res = group(groups[6], () => timeRequest(() => // B01_CIC_07_SendBearerToken
     http.post(env.CIC.target + '/userinfo', {}, options),
-  { isStatusCode200, 'verify response body': (r) => (r.body as string).includes('credentialJWT') }))
+  { isStatusCode200, ...pageContentCheck('credentialJWT') }))
   iterationsCompleted.add(1)
 }
 


### PR DESCRIPTION
## QA-474 <!--Jira Ticket Number-->

### What?
Update Kiwi scripts to use pageContectCheck utility.

#### Changes:
- Updated couple of instances in the BAV and F2F/CIC scripts to use the pageContectCheck utility.

---

### Why?
To ensure consistency across all the scripts.