### PR TITLE
[QA-482] Address SonarCloud code smells

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,21 +1,19 @@
 # -----------------------
 # Typescript > Javascript
 # -----------------------
-FROM node:20-alpine3.18 as node-build
+FROM node:20-alpine3.18 AS node-build
 
 ENV WORKDIR=/home/node
 
 ADD scripts ${WORKDIR}/scripts
 
-WORKDIR ${WORKDIR}
-RUN cd scripts && \
-    npm install && \
-    npm start
+WORKDIR ${WORKDIR}/scripts
+RUN npm install && npm start
 
 # -------------------------------
 # Build k6 binary with extensions
 # -------------------------------
-FROM golang:1.22-alpine as k6-build
+FROM golang:1.22-alpine AS k6-build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@v0.10.0
@@ -24,7 +22,7 @@ RUN xk6 build v0.49.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --out
 # -----------------------
 # OpenTelemetry Collector
 # -----------------------
-FROM otel/opentelemetry-collector-contrib:0.98.0 as otel
+FROM otel/opentelemetry-collector-contrib:0.98.0 AS otel
 ADD otel-config-template.yaml /etc/otelcol/config-template.yaml
 
 # ---

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -8,7 +8,8 @@ ENV WORKDIR=/home/node
 ADD scripts ${WORKDIR}/scripts
 
 WORKDIR ${WORKDIR}/scripts
-RUN npm install && npm start
+RUN npm install --ignore-scripts
+RUN npm start
 
 # -------------------------------
 # Build k6 binary with extensions

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -1,5 +1,5 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { sleep, group } from 'k6'
+import { sleep } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import TOTP from '../common/utils/authentication/totp'
@@ -12,7 +12,7 @@ import {
   LoadProfile
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getEnv } from '../common/utils/config/environment-variables'
@@ -150,107 +150,95 @@ export function changeEmail(): void {
   iterationsStarted.add(1)
 
   // B01_ChangeEmail_01_LaunchAccountsHome
-  res = group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL), {
-      isStatusCode200,
-      ...pageContentCheck('Services you can use with GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[0], () => http.get(env.envURL), {
+    isStatusCode200,
+    ...pageContentCheck('Services you can use with GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_02_ClickSecurityTab
-  res = group(groups[1], () =>
-    timeRequest(() => http.get(env.envURL + '/security'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[1], () => http.get(env.envURL + '/security'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_03_ClickChangeEmailLink
-  res = group(groups[2], () =>
-    timeRequest(() => http.get(env.envURL + '/enter-password?type=changeEmail'), {
-      isStatusCode200,
-      ...pageContentCheck('Enter your password')
-    })
-  )
+  res = timeGroup(groups[2], () => http.get(env.envURL + '/enter-password?type=changeEmail'), {
+    isStatusCode200,
+    ...pageContentCheck('Enter your password')
+  })
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_04_EnterCurrentPassword
-  res = group(groups[3], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/enter-password']",
-          fields: {
-            requestType: 'changeEmail',
-            password: credentials.currPassword
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter your new email address') }
-    )
+  res = timeGroup(
+    groups[3],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/enter-password']",
+        fields: {
+          requestType: 'changeEmail',
+          password: credentials.currPassword
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter your new email address') }
   )
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_05_EnterNewEmailID
-  res = group(groups[4], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/change-email']",
-          fields: {
-            email: newEmail
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('Check your email') }
-    )
+  res = timeGroup(
+    groups[4],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/change-email']",
+        fields: {
+          email: newEmail
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('Check your email') }
   )
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_06_EnterEmailOTP
-  res = group(groups[5], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/check-your-email']",
-          fields: {
-            email: newEmail,
-            code: credentials.fixedEmailOTP
-          }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('You’ve changed your email address')
-      }
-    )
+  res = timeGroup(
+    groups[5],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/check-your-email']",
+        fields: {
+          email: newEmail,
+          code: credentials.fixedEmailOTP
+        }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('You’ve changed your email address')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_07_ClickBackToSecurity
-  res = group(groups[6], () =>
-    timeRequest(() => http.get(env.envURL + '/manage-your-account'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[6], () => http.get(env.envURL + '/manage-your-account'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_08_SignOut
-  res = group(groups[7], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/sign-out']"
-        }),
-      { isStatusCode200, ...pageContentCheck('You have signed out') }
-    )
+  res = timeGroup(
+    groups[7],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/sign-out']"
+      }),
+    { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
 
   iterationsCompleted.add(1)
@@ -262,88 +250,77 @@ export function changePassword(): void {
   iterationsStarted.add(1)
 
   // B02_ChangePassword_01_LaunchAccountsHome
-  res = group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL), {
-      isStatusCode200,
-      ...pageContentCheck('Services you can use with GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[0], () => http.get(env.envURL), {
+    isStatusCode200,
+    ...pageContentCheck('Services you can use with GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_02_ClickSecurityTab
-  res = group(groups[1], () =>
-    timeRequest(() => http.get(env.envURL + '/security'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[1], () => http.get(env.envURL + '/security'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_03_ClickChangePasswordLink
-  res = group(groups[2], () =>
-    timeRequest(() => http.get(env.envURL + '/enter-password?type=changePassword'), {
-      isStatusCode200,
-      ...pageContentCheck('Enter your current password')
-    })
-  )
+  res = timeGroup(groups[2], () => http.get(env.envURL + '/enter-password?type=changePassword'), {
+    isStatusCode200,
+    ...pageContentCheck('Enter your current password')
+  })
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_04_EnterCurrentPassword
-  res = group(groups[3], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/enter-password']",
-          fields: {
-            requestType: 'changePassword',
-            password: credentials.currPassword
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter your new password') }
-    )
+  res = timeGroup(
+    groups[3],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/enter-password']",
+        fields: {
+          requestType: 'changePassword',
+          password: credentials.currPassword
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter your new password') }
   )
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_05_EnterNewPassword
-  res = group(groups[4], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/change-password']",
-          fields: {
-            password: credentials.newPassword,
-            'confirm-password': credentials.newPassword
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('You’ve changed your password') }
-    )
+  res = timeGroup(
+    groups[4],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/change-password']",
+        fields: {
+          password: credentials.newPassword,
+          'confirm-password': credentials.newPassword
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('You’ve changed your password') }
   )
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_06_ClickBackToSecurity
-  res = group(groups[5], () =>
-    timeRequest(() => http.get(env.envURL + '/manage-your-account'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[5], () => http.get(env.envURL + '/manage-your-account'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B02_ChangePassword_07_SignOut
-  res = group(groups[6], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/sign-out']"
-        }),
-      { isStatusCode200, ...pageContentCheck('You have signed out') }
-    )
+  res = timeGroup(
+    groups[6],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/sign-out']"
+      }),
+    { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
   iterationsCompleted.add(1)
 }
@@ -354,113 +331,101 @@ export function changePhone(): void {
   iterationsStarted.add(1)
 
   // B03_ChangePhone_01_LaunchAccountsHome
-  res = group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL), {
-      isStatusCode200,
-      ...pageContentCheck('Services you can use with GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[0], () => http.get(env.envURL), {
+    isStatusCode200,
+    ...pageContentCheck('Services you can use with GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_02_ClickSecurityTab
-  res = group(groups[1], () =>
-    timeRequest(() => http.get(env.envURL + '/security'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[1], () => http.get(env.envURL + '/security'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_03_ClickChangePhoneNumberLink
-  res = group(groups[2], () =>
-    timeRequest(() => http.get(env.envURL + '/enter-password?type=changePhoneNumber'), {
-      isStatusCode200,
-      ...pageContentCheck('Enter your password')
-    })
-  )
+  res = timeGroup(groups[2], () => http.get(env.envURL + '/enter-password?type=changePhoneNumber'), {
+    isStatusCode200,
+    ...pageContentCheck('Enter your password')
+  })
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_04_EnterCurrentPassword
-  res = group(groups[3], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/enter-password']",
-          fields: {
-            requestType: 'changePhoneNumber',
-            password: credentials.currPassword
-          }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Enter your new mobile phone number')
-      }
-    )
+  res = timeGroup(
+    groups[3],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/enter-password']",
+        fields: {
+          requestType: 'changePhoneNumber',
+          password: credentials.currPassword
+        }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your new mobile phone number')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_05_EnterNewPhoneID
-  res = group(groups[4], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/change-phone-number']",
-          fields: {
-            phoneNumber: phoneData.newPhone,
-            internationalPhoneNumber: ''
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('Check your phone') }
-    )
+  res = timeGroup(
+    groups[4],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/change-phone-number']",
+        fields: {
+          phoneNumber: phoneData.newPhone,
+          internationalPhoneNumber: ''
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('Check your phone') }
   )
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_06_EnterSMSOTP
-  res = group(groups[5], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/check-your-phone']",
-          fields: {
-            phoneNumber: phoneData.newPhone,
-            resendCodeLink: '/resend-phone-code',
-            changePhoneNumberLink: '/change-phone-number',
-            code: credentials.fixedPhoneOTP
-          }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('You’ve changed your phone number')
-      }
-    )
+  res = timeGroup(
+    groups[5],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/check-your-phone']",
+        fields: {
+          phoneNumber: phoneData.newPhone,
+          resendCodeLink: '/resend-phone-code',
+          changePhoneNumberLink: '/change-phone-number',
+          code: credentials.fixedPhoneOTP
+        }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('You’ve changed your phone number')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_07_ClickBackToSecurity
-  res = group(groups[6], () =>
-    timeRequest(() => http.get(env.envURL + '/manage-your-account'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[6], () => http.get(env.envURL + '/manage-your-account'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B03_ChangePhone_08_SignOut
-  res = group(groups[7], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/sign-out']"
-        }),
-      { isStatusCode200, ...pageContentCheck('You have signed out') }
-    )
+  res = timeGroup(
+    groups[7],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/sign-out']"
+      }),
+    { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
   iterationsCompleted.add(1)
 }
@@ -471,64 +436,56 @@ export function deleteAccount(): void {
   iterationsStarted.add(1)
 
   // B04_DeleteAccount_01_LaunchAccountsHome
-  res = group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL), {
-      isStatusCode200,
-      ...pageContentCheck('Services you can use with GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[0], () => http.get(env.envURL), {
+    isStatusCode200,
+    ...pageContentCheck('Services you can use with GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B04_DeleteAccount_02_ClickSecurityTab
-  res = group(groups[1], () =>
-    timeRequest(() => http.get(env.envURL + '/security'), {
-      isStatusCode200,
-      ...pageContentCheck('Delete your GOV.UK One Login')
-    })
-  )
+  res = timeGroup(groups[1], () => http.get(env.envURL + '/security'), {
+    isStatusCode200,
+    ...pageContentCheck('Delete your GOV.UK One Login')
+  })
 
   sleepBetween(1, 3)
 
   // B04_DeleteAccount_03_ClickDeleteAccountLink
-  res = group(groups[2], () =>
-    timeRequest(() => http.get(env.envURL + '/enter-password?type=deleteAccount'), {
-      isStatusCode200,
-      ...pageContentCheck('Enter your password')
-    })
-  )
+  res = timeGroup(groups[2], () => http.get(env.envURL + '/enter-password?type=deleteAccount'), {
+    isStatusCode200,
+    ...pageContentCheck('Enter your password')
+  })
 
   sleepBetween(1, 3)
 
   // B04_DeleteAccount_04_EnterCurrentPassword
-  res = group(groups[3], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/enter-password']",
-          fields: {
-            requestType: 'deleteAccount',
-            password: credentials.currPassword
-          }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Are you sure you want to delete your GOV.UK One Login')
-      }
-    )
+  res = timeGroup(
+    groups[3],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/enter-password']",
+        fields: {
+          requestType: 'deleteAccount',
+          password: credentials.currPassword
+        }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Are you sure you want to delete your GOV.UK One Login')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B04_DeleteAccount_05_DeleteAccountConfirm
-  res = group(groups[4], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/delete-account']"
-        }),
-      { isStatusCode200, ...pageContentCheck('You have signed out') }
-    )
+  res = timeGroup(
+    groups[4],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/delete-account']"
+      }),
+    { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
   iterationsCompleted.add(1)
 }
@@ -540,42 +497,38 @@ export function validateUser(): void {
   iterationsStarted.add(1)
 
   // B05_ValidateUser_01_LaunchAccountsHome
-  res = group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL), {
-      isStatusCode200,
-      ...pageContentCheck('Create a GOV.UK One Login or sign in')
-    })
-  )
+  res = timeGroup(groups[0], () => http.get(env.envURL), {
+    isStatusCode200,
+    ...pageContentCheck('Create a GOV.UK One Login or sign in')
+  })
 
   sleepBetween(1, 3)
 
   // B05_ValidateUser_02_ClickSignIn
-  res = group(groups[1], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: {
-            supportInternationalNumbers: 'true'
-          }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Enter your email address to sign in to your GOV.UK One Login')
-      }
-    )
+  res = timeGroup(
+    groups[1],
+    () =>
+      res.submitForm({
+        fields: {
+          supportInternationalNumbers: 'true'
+        }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your email address to sign in to your GOV.UK One Login')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B05_ValidateUser_03_EnterEmailAddress
-  res = group(groups[2], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: { email: userData.email }
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter your password') }
-    )
+  res = timeGroup(
+    groups[2],
+    () =>
+      res.submitForm({
+        fields: { email: userData.email }
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter your password') }
   )
 
   sleepBetween(1, 3)
@@ -584,71 +537,67 @@ export function validateUser(): void {
   switch (userData.mfaOption) {
     case 'AUTH_APP': {
       // B05_ValidateUser_04_AuthMFA_EnterPassword
-      res = group(groups[3], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { password: credentials.currPassword }
-            }),
-          {
-            isStatusCode200,
-            ...pageContentCheck('Enter the 6 digit security code shown in your authenticator app')
-          }
-        )
+      res = timeGroup(
+        groups[3],
+        () =>
+          res.submitForm({
+            fields: { password: credentials.currPassword }
+          }),
+        {
+          isStatusCode200,
+          ...pageContentCheck('Enter the 6 digit security code shown in your authenticator app')
+        }
       )
 
       sleepBetween(1, 3)
 
       const totp = new TOTP(credentials.authAppKey)
       // B05_ValidateUser_05_AuthMFA_EnterTOTP
-      res = group(groups[4], () =>
-        timeRequest(
-          () => {
-            const response = res.submitForm({
-              fields: { code: totp.generateTOTP() }
-            })
-            acceptNewTerms = (response.body as string).includes('terms of use update')
-            return response
-          },
-          {
-            isStatusCode200,
-            'verify page content': r =>
-              acceptNewTerms || (r.body as string).includes('Services you can use with GOV.UK One Login')
-          }
-        )
+      res = timeGroup(
+        groups[4],
+        () => {
+          const response = res.submitForm({
+            fields: { code: totp.generateTOTP() }
+          })
+          acceptNewTerms = (response.body as string).includes('terms of use update')
+          return response
+        },
+        {
+          isStatusCode200,
+          'verify page content': r =>
+            acceptNewTerms || (r.body as string).includes('Services you can use with GOV.UK One Login')
+        }
       )
       break
     }
     case 'SMS': {
       // B05_ValidateUser_06_SMSMFA_EnterPassword
-      res = group(groups[5], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { password: credentials.currPassword }
-            }),
-          { isStatusCode200, ...pageContentCheck('Check your phone') }
-        )
+      res = timeGroup(
+        groups[5],
+        () =>
+          res.submitForm({
+            fields: { password: credentials.currPassword }
+          }),
+        { isStatusCode200, ...pageContentCheck('Check your phone') }
       )
 
       sleep(1)
 
       // B05_ValidateUser_07_SMSMFA_EnterOTP
-      res = group(groups[6], () =>
-        timeRequest(
-          () => {
-            const response = res.submitForm({
-              fields: { code: credentials.fixedPhoneOTP }
-            })
-            acceptNewTerms = (response.body as string).includes('terms of use update')
-            return response
-          },
-          {
-            isStatusCode200,
-            'verify page content': r =>
-              acceptNewTerms || (r.body as string).includes('Services you can use with GOV.UK One Login')
-          }
-        )
+      res = timeGroup(
+        groups[6],
+        () => {
+          const response = res.submitForm({
+            fields: { code: credentials.fixedPhoneOTP }
+          })
+          acceptNewTerms = (response.body as string).includes('terms of use update')
+          return response
+        },
+        {
+          isStatusCode200,
+          'verify page content': r =>
+            acceptNewTerms || (r.body as string).includes('Services you can use with GOV.UK One Login')
+        }
       )
       break
     }
@@ -656,17 +605,16 @@ export function validateUser(): void {
 
   if (acceptNewTerms) {
     // B05_ValidateUser_08_AcceptTermsConditions
-    res = group(groups[7], () =>
-      timeRequest(
-        () =>
-          res.submitForm({
-            fields: { termsAndConditionsResult: 'accept' }
-          }),
-        {
-          isStatusCode200,
-          ...pageContentCheck('Services you can use with GOV.UK One Login')
-        }
-      )
+    res = timeGroup(
+      groups[7],
+      () =>
+        res.submitForm({
+          fields: { termsAndConditionsResult: 'accept' }
+        }),
+      {
+        isStatusCode200,
+        ...pageContentCheck('Services you can use with GOV.UK One Login')
+      }
     )
   }
 
@@ -675,25 +623,22 @@ export function validateUser(): void {
 
   for (let i = 0; i < 5; i++) {
     // B05_ValidateUser_09_ClickSecurityTab
-    res = group(groups[8], () =>
-      timeRequest(() => http.get(env.envURL + '/security'), {
-        isStatusCode200,
-        ...pageContentCheck(`${userData.email}`)
-      })
-    )
+    res = timeGroup(groups[8], () => http.get(env.envURL + '/security'), {
+      isStatusCode200,
+      ...pageContentCheck(`${userData.email}`)
+    })
   }
 
   sleepBetween(1, 3)
 
   // B05_ValidateUser_10_Logout
-  res = group(groups[9], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          formSelector: "form[action='/sign-out']"
-        }),
-      { isStatusCode200, ...pageContentCheck('You have signed out') }
-    )
+  res = timeGroup(
+    groups[9],
+    () =>
+      res.submitForm({
+        formSelector: "form[action='/sign-out']"
+      }),
+    { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
   iterationsCompleted.add(1)
 }
@@ -703,11 +648,9 @@ export function contactsPage(): void {
   iterationsStarted.add(1)
 
   // B06_01_ContactsPage
-  group(groups[0], () =>
-    timeRequest(() => http.get(env.envURL + '/contact-gov-uk-one-login'), {
-      isStatusCode200,
-      ...pageContentCheck('Contact GOV.UK One Login')
-    })
-  )
+  timeGroup(groups[0], () => http.get(env.envURL + '/contact-gov-uk-one-login'), {
+    isStatusCode200,
+    ...pageContentCheck('Contact GOV.UK One Login')
+  })
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -101,11 +101,11 @@ export function setup(): void {
 }
 
 type mfaType = 'SMS' | 'AUTH_APP'
-interface validateUserData {
+interface ValidateUserData {
   email: string
   mfaOption: mfaType
 }
-const validateData: validateUserData[] = new SharedArray('data', () =>
+const validateData: ValidateUserData[] = new SharedArray('data', () =>
   Array.from({ length: 10000 }, (_, i) => {
     const id: string = Math.floor(i / 2 + 1)
       .toString()

--- a/deploy/scripts/src/accounts/vc-storage.ts
+++ b/deploy/scripts/src/accounts/vc-storage.ts
@@ -80,12 +80,11 @@ const env = {
 }
 export function persistVC(): void {
   const groups = groupMap.persistVC
-  let res: Response
   const userID = uuidv4()
   const subjectID = `urn:fdc:gov.uk:2022:${userID}`
   iterationsStarted.add(1)
   // R01_PersistVC_01_GenerateToken
-  res = group(groups[0], () =>
+  const res: Response = group(groups[0], () =>
     timeRequest(
       () =>
         http.post(
@@ -113,7 +112,7 @@ export function persistVC(): void {
     'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOlBWUUk3Z0VmR1o2a080X0Z4eDZjaHF0SGNobzVzcjgtazA0MUdxci1YbzQiLCJuYmYiOjE2NTIwMjAxNTMsImlzcyI6Imh0dHBzOi8va2J2LWNyaS5hY2NvdW50Lmdvdi51ayIsInZvdCI6IlAyIiwiZXhwIjoxNjgzNjI4MTUzLCJpYXQiOjE2NTIwOTIxNTMsInZjIjp7ImV2aWRlbmNlIjpbeyJhY3Rpdml0eUhpc3RvcnlTY29yZSI6MCwidmFsaWRpdHlTY29yZSI6MCwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjAsInR4biI6InR4biIsImlkZW50aXR5RnJhdWRTY29yZSI6MCwidHlwZSI6IklkZW50aXR5Q2hlY2sifV0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiSmFuZSJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IldyaWdodCJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsidmFsaWRVbnRpbCI6IjIwMjktMDQtMDEiLCJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IkphbmUifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJXcmlnaHQifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbC9jb250ZXh0cy9pZGVudGl0eS12MS5qc29ubGQiXX0sInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.MEUCIQC8U5VKnsYhlt35vMCaaBLws_3WqfDHMnCnRJIdJ7v_zQIgMdsi_B2UEsD7P_QwLsG7owv4eI_AV5oTpjtmZCeKhs8' // pragma: allowlist secret
   ])
   // R01_PersistVC_02_CreateVC
-  res = group(groups[1], () =>
+  group(groups[1], () =>
     timeRequest(() => http.post(env.envURL + `/vcs/${subjectID}`, body, options), {
       isStatusCode202: r => r.status === 202,
       ...pageContentCheck('messageId')
@@ -124,12 +123,11 @@ export function persistVC(): void {
 
 export function summariseVC(): void {
   const groups = groupMap.summariseVC
-  let res: Response
   const summariseData = csvData[Math.floor(Math.random() * csvData.length)]
   iterationsStarted.add(1)
 
   // R02_SummariseVC_01_GenerateTokenSummary
-  res = group(groups[0], () =>
+  const res: Response = group(groups[0], () =>
     timeRequest(
       () =>
         http.post(
@@ -152,7 +150,7 @@ export function summariseVC(): void {
     }
   }
   // R02_SummariseVC_02_Summarise
-  res = group(groups[1], () =>
+  group(groups[1], () =>
     timeRequest(() => http.get(env.envURL + `/summarise-vcs/${summariseData.subID}`, options), {
       isStatusCode200,
       ...pageContentCheck('vcs')

--- a/deploy/scripts/src/accounts/vc-storage.ts
+++ b/deploy/scripts/src/accounts/vc-storage.ts
@@ -1,5 +1,5 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { group, fail } from 'k6'
+import { fail } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import {
@@ -11,7 +11,7 @@ import {
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import { uuidv4 } from '../common/utils/jslib'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { getEnv } from '../common/utils/config/environment-variables'
@@ -84,17 +84,16 @@ export function persistVC(): void {
   const subjectID = `urn:fdc:gov.uk:2022:${userID}`
   iterationsStarted.add(1)
   // R01_PersistVC_01_GenerateToken
-  const res: Response = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.post(
-          env.envMock + '/generate',
-          JSON.stringify({
-            sub: subjectID
-          })
-        ),
-      { isStatusCode200, ...pageContentCheck('token') }
-    )
+  const res: Response = timeGroup(
+    groups[0],
+    () =>
+      http.post(
+        env.envMock + '/generate',
+        JSON.stringify({
+          sub: subjectID
+        })
+      ),
+    { isStatusCode200, ...pageContentCheck('token') }
   )
   const token = getToken(res)
 
@@ -112,12 +111,10 @@ export function persistVC(): void {
     'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOlBWUUk3Z0VmR1o2a080X0Z4eDZjaHF0SGNobzVzcjgtazA0MUdxci1YbzQiLCJuYmYiOjE2NTIwMjAxNTMsImlzcyI6Imh0dHBzOi8va2J2LWNyaS5hY2NvdW50Lmdvdi51ayIsInZvdCI6IlAyIiwiZXhwIjoxNjgzNjI4MTUzLCJpYXQiOjE2NTIwOTIxNTMsInZjIjp7ImV2aWRlbmNlIjpbeyJhY3Rpdml0eUhpc3RvcnlTY29yZSI6MCwidmFsaWRpdHlTY29yZSI6MCwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjAsInR4biI6InR4biIsImlkZW50aXR5RnJhdWRTY29yZSI6MCwidHlwZSI6IklkZW50aXR5Q2hlY2sifV0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiSmFuZSJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IldyaWdodCJ9XSwidmFsaWRGcm9tIjoiMjAxOS0wNC0wMSJ9LHsidmFsaWRVbnRpbCI6IjIwMjktMDQtMDEiLCJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IkphbmUifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJXcmlnaHQifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODktMDctMDYifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbC9jb250ZXh0cy9pZGVudGl0eS12MS5qc29ubGQiXX0sInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.MEUCIQC8U5VKnsYhlt35vMCaaBLws_3WqfDHMnCnRJIdJ7v_zQIgMdsi_B2UEsD7P_QwLsG7owv4eI_AV5oTpjtmZCeKhs8' // pragma: allowlist secret
   ])
   // R01_PersistVC_02_CreateVC
-  group(groups[1], () =>
-    timeRequest(() => http.post(env.envURL + `/vcs/${subjectID}`, body, options), {
-      isStatusCode202: r => r.status === 202,
-      ...pageContentCheck('messageId')
-    })
-  )
+  timeGroup(groups[1], () => http.post(env.envURL + `/vcs/${subjectID}`, body, options), {
+    isStatusCode202: r => r.status === 202,
+    ...pageContentCheck('messageId')
+  })
   iterationsCompleted.add(1)
 }
 
@@ -127,19 +124,18 @@ export function summariseVC(): void {
   iterationsStarted.add(1)
 
   // R02_SummariseVC_01_GenerateTokenSummary
-  const res: Response = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.post(
-          env.envMock + '/generate',
-          JSON.stringify({
-            sub: summariseData.subID,
-            aud: 'accountManagementAudience',
-            ttl: 120
-          })
-        ),
-      { isStatusCode200, ...pageContentCheck('token') }
-    )
+  const res: Response = timeGroup(
+    groups[0],
+    () =>
+      http.post(
+        env.envMock + '/generate',
+        JSON.stringify({
+          sub: summariseData.subID,
+          aud: 'accountManagementAudience',
+          ttl: 120
+        })
+      ),
+    { isStatusCode200, ...pageContentCheck('token') }
   )
   const token = getToken(res)
 
@@ -150,12 +146,10 @@ export function summariseVC(): void {
     }
   }
   // R02_SummariseVC_02_Summarise
-  group(groups[1], () =>
-    timeRequest(() => http.get(env.envURL + `/summarise-vcs/${summariseData.subID}`, options), {
-      isStatusCode200,
-      ...pageContentCheck('vcs')
-    })
-  )
+  timeGroup(groups[1], () => http.get(env.envURL + `/summarise-vcs/${summariseData.subID}`, options), {
+    isStatusCode200,
+    ...pageContentCheck('vcs')
+  })
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -11,8 +11,7 @@ import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { generatePersistIVRequest, interventionCodes } from './requestGenerator/aisReqGen'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
 import { uuidv4 } from '../common/utils/jslib/index'
-import { group } from 'k6'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { SharedArray } from 'k6/data'
 import http from 'k6/http'
@@ -102,12 +101,10 @@ export function retrieveIV(): void {
   iterationsStarted.add(1)
 
   // B02_RetrieveIV_01_GetInterventionData
-  group(groups[0], () =>
-    timeRequest(() => http.get(env.aisEnvURL + `/v1/ais/${retrieveData.userID}?history=true`), {
-      isStatusCode200,
-      ...pageContentCheck('Perf Testing')
-    })
-  )
+  timeGroup(groups[0], () => http.get(env.aisEnvURL + `/v1/ais/${retrieveData.userID}?history=true`), {
+    isStatusCode200,
+    ...pageContentCheck('Perf Testing')
+  })
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -97,11 +97,11 @@ export function setup(): void {
 }
 
 type mfaType = 'SMS' | 'AUTH_APP'
-interface signInData {
+interface SignInData {
   email: string
   mfaOption: mfaType
 }
-const dataSignIn: signInData[] = new SharedArray('data', () =>
+const dataSignIn: SignInData[] = new SharedArray('data', () =>
   Array.from({ length: 10000 }, (_, i) => {
     const id: string = Math.floor(i / 2 + 1)
       .toString()

--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -9,10 +9,9 @@ import { type AssumeRoleOutput } from '../common/utils/aws/types'
 import { AWSConfig } from '../common/utils/jslib/aws-sqs'
 import { SignatureV4 } from '../common/utils/jslib/aws-signature'
 import { generatePutCI, generateGetCIC, generatePostMitigations } from './requestGenerator/cimitReqGen'
-import { group } from 'k6'
 import http from 'k6/http'
 import { type Options } from 'k6/options'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200 } from '../common/utils/checks/assertions'
 import { SharedArray } from 'k6/data'
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
@@ -101,14 +100,13 @@ export function putContraIndicators(): void {
   const signedRequest = signer.sign(request)
   iterationsStarted.add(1)
   // B01_CIMIT_01_PutContraIndicator
-  group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.post(signedRequest.url, putContraIndicatorPayload, {
-          headers: signedRequest.headers
-        }),
-      { isStatusCode200 }
-    )
+  timeGroup(
+    groups[0],
+    () =>
+      http.post(signedRequest.url, putContraIndicatorPayload, {
+        headers: signedRequest.headers
+      }),
+    { isStatusCode200 }
   )
   iterationsCompleted.add(1)
 }
@@ -128,14 +126,13 @@ export function getContraIndicatorCredentials(): void {
   const signedRequest = signer.sign(request)
   iterationsStarted.add(1)
   // B02_CIMIT_01_GetContraIndicatorCredentials
-  group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.post(signedRequest.url, getCICPayload, {
-          headers: signedRequest.headers
-        }),
-      { isStatusCode200 }
-    )
+  timeGroup(
+    groups[0],
+    () =>
+      http.post(signedRequest.url, getCICPayload, {
+        headers: signedRequest.headers
+      }),
+    { isStatusCode200 }
   )
   iterationsCompleted.add(1)
 }
@@ -154,14 +151,13 @@ export function postMitigations(): void {
   const signedRequest = signer.sign(request)
   iterationsStarted.add(1)
   // B03_CIMIT_01_PostMitigations
-  group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.post(signedRequest.url, postMitigationsPayload, {
-          headers: signedRequest.headers
-        }),
-      { isStatusCode200 }
-    )
+  timeGroup(
+    groups[0],
+    () =>
+      http.post(signedRequest.url, postMitigationsPayload, {
+        headers: signedRequest.headers
+      }),
+    { isStatusCode200 }
   )
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/common/unit-tests.ts
+++ b/deploy/scripts/src/common/unit-tests.ts
@@ -18,7 +18,7 @@ import {
   uuidv4
 } from './utils/jslib'
 import { URL, URLSearchParams } from './utils/jslib/url'
-import { timeFunction, timeRequest } from './utils/request/timing'
+import { timeFunction, timeGroup, timeRequest } from './utils/request/timing'
 import { sleepBetween } from './utils/sleep/sleepBetween'
 import { isStatusCode200, isStatusCode201, isStatusCode302, pageContentCheck } from './utils/checks/assertions'
 import { type RefinedResponse, type ResponseType, type Response } from 'k6/http'
@@ -373,6 +373,17 @@ export default (): void => {
         }
       )
     })
+
+    timeGroup(
+      'timeGroup()',
+      () => {
+        const string = 'OK'
+        return 'A' + string
+      },
+      {
+        'check result': s => s === 'AOK'
+      }
+    )
   })
 
   group('sleep/sleepBetween', () => {

--- a/deploy/scripts/src/common/utils/authentication/totp.ts
+++ b/deploy/scripts/src/common/utils/authentication/totp.ts
@@ -86,7 +86,7 @@ function base32ToBytes(base32: string): ArrayBuffer {
   const bytes: number[] = []
 
   // Removes padding chars, if any
-  base32 = base32.replace(/=+$/, '')
+  base32 = base32.replace(/={1,7}$/, '')
 
   // Converts base32 string to bits
   for (let i = 0; i < base32.length; i++) {

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -39,11 +39,14 @@ export function getProfile(profiles: ProfileList, profileName: string): Profile 
  */
 export function getScenarios(scenarios: ScenarioList, selections: string | undefined): ScenarioList {
   let enabled: ScenarioList = {}
-  selections == null || selections === '' || selections.toLowerCase() === 'all' // Enable all scenarios is selection string is null, empty or set to 'all'
-    ? (enabled = scenarios)
-    : selections.split(',').forEach(scenario => {
-        enabled[scenario] = scenarios[scenario]
-      })
+  // Enable all scenarios is selection string is null, empty or set to 'all'
+  if (selections == null || selections === '' || selections.toLowerCase() === 'all') {
+    enabled = scenarios
+  } else {
+    selections.split(',').forEach(scenario => {
+      enabled[scenario] = scenarios[scenario]
+    })
+  }
   return enabled
 }
 

--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -1,5 +1,4 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { group } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import {
@@ -10,7 +9,7 @@ import {
   LoadProfile
 } from '../common/utils/config/load-profiles'
 import { b64encode } from 'k6/encoding'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { bankingPayload } from './data/BAVdata'
@@ -65,83 +64,75 @@ export function BAV(): void {
   iterationsStarted.add(1)
 
   // B01_BAV_01_IPVStubCall
-  res = group(groups[0], () =>
-    timeRequest(() => http.post(env.BAV.ipvStub + '/start', JSON.stringify({ bankingPayload })), {
-      'is status 201': r => r.status === 201,
-      ...pageContentCheck(b64encode('{"alg":"RSA', 'rawstd'))
-    })
-  )
+  res = timeGroup(groups[0], () => http.post(env.BAV.ipvStub + '/start', JSON.stringify({ bankingPayload })), {
+    'is status 201': r => r.status === 201,
+    ...pageContentCheck(b64encode('{"alg":"RSA', 'rawstd'))
+  })
   const authorizeLocation = getAuthorizeauthorizeLocation(res)
   const clientId = getClientID(res)
 
   // B01_BAV_02_Authorize
-  res = group(groups[1], () =>
-    timeRequest(() => http.get(authorizeLocation), {
-      isStatusCode200,
-      ...pageContentCheck('Continue to your bank or building society account details')
-    })
-  )
+  res = timeGroup(groups[1], () => http.get(authorizeLocation), {
+    isStatusCode200,
+    ...pageContentCheck('Continue to your bank or building society account details')
+  })
 
   // B01_BAV_03_Continue
-  res = group(groups[2], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          submitSelector: '#landingPageContinue'
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter your account details') }
-    )
+  res = timeGroup(
+    groups[2],
+    () =>
+      res.submitForm({
+        submitSelector: '#landingPageContinue'
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter your account details') }
   )
 
   sleepBetween(1, 3)
 
   // B01_BAV_04_BankDetails
-  res = group(groups[3], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: {
-            sortCode: testSortCode,
-            accountNumber: testAccountNumber
-          },
-          submitSelector: '#continue'
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Check your details match with your bank or building society account')
-      }
-    )
+  res = timeGroup(
+    groups[3],
+    () =>
+      res.submitForm({
+        fields: {
+          sortCode: testSortCode,
+          accountNumber: testAccountNumber
+        },
+        submitSelector: '#continue'
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Check your details match with your bank or building society account')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B01_BAV_05_CheckDetails
-  res = group(groups[4], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          submitSelector: '#submitDetails'
-        }),
-      {
-        'verify url body': r => r.url.includes(clientId)
-      }
-    )
+  res = timeGroup(
+    groups[4],
+    () =>
+      res.submitForm({
+        submitSelector: '#submitDetails'
+      }),
+    {
+      'verify url body': r => r.url.includes(clientId)
+    }
   )
   const codeUrl = getCodeFromUrl(res.url)
 
   sleepBetween(1, 3)
 
   // B01_BAV_06_SendAuthorizationCode
-  res = group(groups[5], () =>
-    timeRequest(
-      () =>
-        http.post(env.BAV.target + '/token', {
-          grant_type: 'authorization_code',
-          code: codeUrl,
-          redirect_uri: env.BAV.ipvStub + '/redirect?id=bav'
-        }),
-      { isStatusCode200, ...pageContentCheck('access_token') }
-    )
+  res = timeGroup(
+    groups[5],
+    () =>
+      http.post(env.BAV.target + '/token', {
+        grant_type: 'authorization_code',
+        code: codeUrl,
+        redirect_uri: env.BAV.ipvStub + '/redirect?id=bav'
+      }),
+    { isStatusCode200, ...pageContentCheck('access_token') }
   )
 
   const accessToken = getAccessToken(res)
@@ -153,11 +144,9 @@ export function BAV(): void {
     headers: { Authorization: authHeader }
   }
   // B01_BAV_07_SendBearerToken
-  res = group(groups[6], () =>
-    timeRequest(() => http.post(env.BAV.target + '/userinfo', {}, options), {
-      isStatusCode200,
-      ...pageContentCheck('credentialJWT')
-    })
-  )
+  res = timeGroup(groups[6], () => http.post(env.BAV.target + '/userinfo', {}, options), {
+    isStatusCode200,
+    ...pageContentCheck('credentialJWT')
+  })
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqFormat.ts
+++ b/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqFormat.ts
@@ -1,4 +1,4 @@
-export interface AUTH_IPV_AUTHORISATION_REQUESTED {
+export interface AuthIpvAuthorisationRequested {
   event_id: string
   client_id: string
   clientLandingPageUrl: string
@@ -13,7 +13,7 @@ export interface AUTH_IPV_AUTHORISATION_REQUESTED {
   }
 }
 
-export interface F2F_YOTI_START {
+export interface F2fYotiStart {
   event_id: string
   client_id: string
   clientLandingPageUrl: string
@@ -49,7 +49,7 @@ export interface F2F_YOTI_START {
   }
 }
 
-export interface F2F_DOCUMENT_UPLOADED {
+export interface F2fDocumentUploaded {
   event_name: string
   event_id: string
   user: {
@@ -66,7 +66,7 @@ export interface F2F_DOCUMENT_UPLOADED {
   timestamp: number
 }
 
-export interface IPV_F2F_CRI_VC_CONSUMED {
+export interface IpvF2fVcConsumed {
   event_id: string
   client_id: string
   clientLandingPageUrl: string

--- a/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqGen.ts
+++ b/deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqGen.ts
@@ -1,12 +1,12 @@
 import {
-  type AUTH_IPV_AUTHORISATION_REQUESTED,
-  type F2F_YOTI_START,
-  type IPV_F2F_CRI_VC_CONSUMED,
-  type F2F_DOCUMENT_UPLOADED
+  type AuthIpvAuthorisationRequested,
+  type F2fYotiStart,
+  type IpvF2fVcConsumed,
+  type F2fDocumentUploaded
 } from '../requestGenerator/ipvrReqFormat'
 import { uuidv4, randomString, randomIntBetween } from '../../common/utils/jslib/index'
 
-export function generateAuthRequest(userID: string, signinJourneyID: string): AUTH_IPV_AUTHORISATION_REQUESTED {
+export function generateAuthRequest(userID: string, signinJourneyID: string): AuthIpvAuthorisationRequested {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),
@@ -24,7 +24,7 @@ export function generateAuthRequest(userID: string, signinJourneyID: string): AU
   }
 }
 
-export function generateF2FRequest(userID: string, signinJourneyID: string): F2F_YOTI_START {
+export function generateF2FRequest(userID: string, signinJourneyID: string): F2fYotiStart {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),
@@ -63,7 +63,7 @@ export function generateF2FRequest(userID: string, signinJourneyID: string): F2F
   }
 }
 
-export function generateDocumentUploadedRequest(userID: string): F2F_DOCUMENT_UPLOADED {
+export function generateDocumentUploadedRequest(userID: string): F2fDocumentUploaded {
   return {
     event_name: 'F2F_DOCUMENT_UPLOADED',
     event_id: uuidv4(),
@@ -82,7 +82,7 @@ export function generateDocumentUploadedRequest(userID: string): F2F_DOCUMENT_UP
   }
 }
 
-export function generateIPVRequest(userID: string, signinJourneyID: string): IPV_F2F_CRI_VC_CONSUMED {
+export function generateIPVRequest(userID: string, signinJourneyID: string): IpvF2fVcConsumed {
   const timestamp = new Date().toISOString()
   return {
     event_id: uuidv4(),

--- a/deploy/scripts/src/cri-kiwi/utils/authorization.ts
+++ b/deploy/scripts/src/cri-kiwi/utils/authorization.ts
@@ -8,7 +8,7 @@ export function getClientID(r: Response): string {
 }
 
 export function getCodeFromUrl(url: string): string {
-  const code = url.match(/code=([^&]*)/)
+  const code = /code=([^&]*)/.exec(url)
   if (code?.[1] != null) return code[1]
   fail('Code not found')
 }

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -1,5 +1,4 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { group } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import encoding from 'k6/encoding'
@@ -12,7 +11,7 @@ import {
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getEnv } from '../common/utils/config/environment-variables'
@@ -237,91 +236,90 @@ export function fraud(): void {
   iterationsStarted.add(1)
 
   // B01_Fraud_01_CoreStubEditUserContinue
-  group(groups[0], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[0],
+    () => {
       // 01_CoreStubCall
-      res = group(groups[1].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.post(
-              env.ipvCoreStub + '/edit-user',
-              {
-                cri: `fraud-cri-${env.envName}`,
-                rowNumber: '197',
-                firstName: userDetails.firstName,
-                surname: userDetails.lastName,
-                'dateOfBirth-day': `${userDetails.day}`,
-                'dateOfBirth-month': `${userDetails.month}`,
-                'dateOfBirth-year': `${userDetails.year}`,
-                buildingNumber: `${userDetails.buildNum}`,
-                buildingName: userDetails.buildName,
-                street: userDetails.street,
-                townCity: userDetails.city,
-                postCode: userDetails.postCode,
-                validFromDay: '26',
-                validFromMonth: '02',
-                validFromYear: '2021',
-                validUntilDay: '',
-                validUntilMonth: '',
-                validUntilYear: '',
-                'SecondaryUKAddress.buildingNumber': '',
-                'SecondaryUKAddress.buildingName': '',
-                'SecondaryUKAddress.street': '',
-                'SecondaryUKAddress.townCity': '',
-                'SecondaryUKAddress.postCode': '',
-                'SecondaryUKAddress.validFromDay': '',
-                'SecondaryUKAddress.validFromMonth': '',
-                'SecondaryUKAddress.validFromYear': '',
-                'SecondaryUKAddress.validUntilDay': '',
-                'SecondaryUKAddress.validUntilMonth': '',
-                'SecondaryUKAddress.validUntilYear': ''
-              },
-              {
-                headers: { Authorization: `Basic ${encodedCredentials}` },
-                redirects: 0
-              }
-            ),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[1].split('::')[1],
+        () =>
+          http.post(
+            env.ipvCoreStub + '/edit-user',
+            {
+              cri: `fraud-cri-${env.envName}`,
+              rowNumber: '197',
+              firstName: userDetails.firstName,
+              surname: userDetails.lastName,
+              'dateOfBirth-day': `${userDetails.day}`,
+              'dateOfBirth-month': `${userDetails.month}`,
+              'dateOfBirth-year': `${userDetails.year}`,
+              buildingNumber: `${userDetails.buildNum}`,
+              buildingName: userDetails.buildName,
+              street: userDetails.street,
+              townCity: userDetails.city,
+              postCode: userDetails.postCode,
+              validFromDay: '26',
+              validFromMonth: '02',
+              validFromYear: '2021',
+              validUntilDay: '',
+              validUntilMonth: '',
+              validUntilYear: '',
+              'SecondaryUKAddress.buildingNumber': '',
+              'SecondaryUKAddress.buildingName': '',
+              'SecondaryUKAddress.street': '',
+              'SecondaryUKAddress.townCity': '',
+              'SecondaryUKAddress.postCode': '',
+              'SecondaryUKAddress.validFromDay': '',
+              'SecondaryUKAddress.validFromMonth': '',
+              'SecondaryUKAddress.validFromYear': '',
+              'SecondaryUKAddress.validUntilDay': '',
+              'SecondaryUKAddress.validUntilMonth': '',
+              'SecondaryUKAddress.validUntilYear': ''
+            },
+            {
+              headers: { Authorization: `Basic ${encodedCredentials}` },
+              redirects: 0
+            }
+          ),
+        { isStatusCode302 }
       )
       // 01_CRICall
-      res = group(groups[2].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('We need to check your details')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('We need to check your details')
+      })
+    },
+    {}
+  )
 
   sleepBetween(1, 3)
 
   // B01_Fraud_02_ContinueToCheckFraudDetails
-  group(groups[3], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[3],
+    () => {
       // 01_CRICall
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              params: { redirects: 1 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[4].split('::')[1],
+        () =>
+          res.submitForm({
+            params: { redirects: 1 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreStubCall
-      res = group(groups[5].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-        )
+      res = timeGroup(
+        groups[5].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 
@@ -338,17 +336,16 @@ export function drivingLicence(): void {
   iterationsStarted.add(1)
 
   // B02_Driving_01_DLEntryFromCoreStub_${licenceIssuer}
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(`${env.ipvCoreStub}/authorize?cri=driving-licence-cri-${env.envName}&rowNumber=197`, {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Who was your UK driving licence issued by?')
-      }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(`${env.ipvCoreStub}/authorize?cri=driving-licence-cri-${env.envName}&rowNumber=197`, {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Who was your UK driving licence issued by?')
+    }
   )
 
   sleepBetween(1, 3)
@@ -394,49 +391,48 @@ export function drivingLicence(): void {
         }
 
   // B02_Driving_02_Select_${licenceIssuer}
-  res = group(groups[1], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: { licenceIssuer },
-          submitSelector: '#submitButton'
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Enter your details exactly as they appear on your UK driving licence')
-      }
-    )
+  res = timeGroup(
+    groups[1],
+    () =>
+      res.submitForm({
+        fields: { licenceIssuer },
+        submitSelector: '#submitButton'
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your details exactly as they appear on your UK driving licence')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B02_Driving_03_${licenceIssuer}_EnterDetailsConfirm
-  group(groups[2], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[2],
+    () => {
       // 01_CRICall
-      res = group(groups[3].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields,
-              params: { redirects: 2 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[3].split('::')[1],
+        () =>
+          res.submitForm({
+            fields,
+            params: { redirects: 2 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreStubCall
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-        )
+      res = timeGroup(
+        groups[4].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 
@@ -449,59 +445,58 @@ export function passport(): void {
   iterationsStarted.add(1)
 
   // B03_Passport_01_PassportCRIEntryFromStub
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(env.ipvCoreStub + '/authorize?cri=passport-v1-cri-' + env.envName + '&rowNumber=197', {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Enter your details exactly as they appear on your UK passport')
-      }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(env.ipvCoreStub + '/authorize?cri=passport-v1-cri-' + env.envName + '&rowNumber=197', {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your details exactly as they appear on your UK passport')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B03_Passport_02_EnterPassportDetailsAndContinue
-  group(groups[1], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[1],
+    () => {
       // 01_CRICall
-      res = group(groups[2].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                passportNumber: userPassport.passportNumber,
-                surname: userPassport.surname,
-                firstName: userPassport.firstName,
-                middleNames: userPassport.middleName,
-                'dateOfBirth-day': userPassport.birthday,
-                'dateOfBirth-month': userPassport.birthmonth,
-                'dateOfBirth-year': userPassport.birthyear,
-                'expiryDate-day': userPassport.expiryDay,
-                'expiryDate-month': userPassport.expiryMonth,
-                'expiryDate-year': userPassport.expiryYear
-              },
-              params: { redirects: 2 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[2].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              passportNumber: userPassport.passportNumber,
+              surname: userPassport.surname,
+              firstName: userPassport.firstName,
+              middleNames: userPassport.middleName,
+              'dateOfBirth-day': userPassport.birthday,
+              'dateOfBirth-month': userPassport.birthmonth,
+              'dateOfBirth-year': userPassport.birthyear,
+              'expiryDate-day': userPassport.expiryDay,
+              'expiryDate-month': userPassport.expiryMonth,
+              'expiryDate-year': userPassport.expiryYear
+            },
+            params: { redirects: 2 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreStubCall
-      res = group(groups[3].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-        )
+      res = timeGroup(
+        groups[3].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -1,5 +1,4 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { group } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import {
@@ -10,7 +9,7 @@ import {
   LoadProfile
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getEnv } from '../common/utils/config/environment-variables'
@@ -66,81 +65,78 @@ export function kbv(): void {
   iterationsStarted.add(1)
 
   // B01_KBV_01_CoreStubEditUserContinue
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(env.ipvCoreStub + '/authorize?cri=kbv-cri-' + env.envName + '&rowNumber=197', {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('You can find this amount on your loan agreement')
-      }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(env.ipvCoreStub + '/authorize?cri=kbv-cri-' + env.envName + '&rowNumber=197', {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('You can find this amount on your loan agreement')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B01_KBV_02_KBVQuestion1
-  res = group(groups[1], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: { Q00042: kbvAnsJSON.kbvAns1 },
-          submitSelector: '#continue'
-        }),
-      { isStatusCode200, ...pageContentCheck('This includes any interest') }
-    )
+  res = timeGroup(
+    groups[1],
+    () =>
+      res.submitForm({
+        fields: { Q00042: kbvAnsJSON.kbvAns1 },
+        submitSelector: '#continue'
+      }),
+    { isStatusCode200, ...pageContentCheck('This includes any interest') }
   )
 
   sleepBetween(1, 3)
 
   // B01_KBV_03_KBVQuestion2
-  res = group(groups[2], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: { Q00015: kbvAnsJSON.kbvAns2 },
-          submitSelector: '#continue'
-        }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('Think about the amount you agreed to pay back every month')
-      }
-    )
+  res = timeGroup(
+    groups[2],
+    () =>
+      res.submitForm({
+        fields: { Q00015: kbvAnsJSON.kbvAns2 },
+        submitSelector: '#continue'
+      }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('Think about the amount you agreed to pay back every month')
+    }
   )
 
   sleepBetween(1, 3)
 
   // B01_KBV_04_KBVQuestion3
-  group(groups[3], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[3],
+    () => {
       // 01_KBVCRICall
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { Q00018: kbvAnsJSON.kbvAns3 },
-              params: { redirects: 2 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[4].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { Q00018: kbvAnsJSON.kbvAns3 },
+            params: { redirects: 2 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreStubCall
-      res = group(groups[5].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          {
-            isStatusCode200,
-            ...pageContentCheck('verificationScore&quot;: 2')
-          }
-        )
+      res = timeGroup(
+        groups[5].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        {
+          isStatusCode200,
+          ...pageContentCheck('verificationScore&quot;: 2')
+        }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -57,12 +57,12 @@ const kbvAnswersOBJ = {
 export function kbv(): void {
   const groups = groupMap.kbvScenario1
   let res: Response
-  interface kbvAnswers {
+  interface KbvAnswers {
     kbvAns1: string
     kbvAns2: string
     kbvAns3: string
   }
-  const kbvAnsJSON: kbvAnswers = JSON.parse(kbvAnswersOBJ.kbvAnswers)
+  const kbvAnsJSON: KbvAnswers = JSON.parse(kbvAnswersOBJ.kbvAnswers)
   iterationsStarted.add(1)
 
   // B01_KBV_01_CoreStubEditUserContinue

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -54,7 +54,7 @@ const stubCreds = {
   password: getEnv('IDENTITY_CORE_STUB_PASSWORD')
 }
 
-interface nino {
+interface Nino {
   firstName: string
   lastName: string
   birthDay: string
@@ -63,7 +63,7 @@ interface nino {
   niNumber: string
 }
 
-const csvData1: nino[] = new SharedArray('csvDataNino', () => {
+const csvData1: Nino[] = new SharedArray('csvDataNino', () => {
   return open('./data/ninoCRIData.csv')
     .split('\n')
     .slice(1)

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -1,5 +1,4 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { group } from 'k6'
 import { SharedArray } from 'k6/data'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
@@ -11,7 +10,7 @@ import {
   createScenario,
   LoadProfile
 } from '../common/utils/config/load-profiles'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getEnv } from '../common/utils/config/environment-variables'
@@ -89,67 +88,65 @@ export function ninoCheck(): void {
   iterationsStarted.add(1)
 
   // B02_Nino_01_EntryFromStub
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(env.ipvCoreStub + '/edit-user?cri=check-hmrc-build', {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      { isStatusCode200, ...pageContentCheck('Edit User') }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(env.ipvCoreStub + '/edit-user?cri=check-hmrc-build', {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    { isStatusCode200, ...pageContentCheck('Edit User') }
   )
 
   sleepBetween(1, 3)
 
   // B02_Nino_02_AddUser
-  res = group(groups[1], () =>
-    timeRequest(
-      () =>
-        res.submitForm({
-          fields: {
-            firstName: userNino.firstName,
-            surname: userNino.lastName,
-            'dateOfBirth-day': userNino.birthDay,
-            'dateOfBirth-month': userNino.birthMonth,
-            'dateOfBirth-year': userNino.birthYear
-          },
-          submitSelector: '#govuk-button button',
-          params: {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }
-        }),
-      { isStatusCode200, ...pageContentCheck('national insurance number') }
-    )
+  res = timeGroup(
+    groups[1],
+    () =>
+      res.submitForm({
+        fields: {
+          firstName: userNino.firstName,
+          surname: userNino.lastName,
+          'dateOfBirth-day': userNino.birthDay,
+          'dateOfBirth-month': userNino.birthMonth,
+          'dateOfBirth-year': userNino.birthYear
+        },
+        submitSelector: '#govuk-button button',
+        params: {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }
+      }),
+    { isStatusCode200, ...pageContentCheck('national insurance number') }
   )
 
   sleepBetween(1, 3)
 
   // B02_Nino_03_SearchNiNo
-  group(groups[2], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[2],
+    () => {
       // 01_NiNOCRICall
-      res = group(groups[3].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { nationalInsuranceNumber: userNino.niNumber },
-              params: { redirects: 1 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[3].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { nationalInsuranceNumber: userNino.niNumber },
+            params: { redirects: 1 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreStubCall
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('Verifiable') }
-        )
+      res = timeGroup(
+        groups[4].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('Verifiable') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/examples/dev-platform.ts
+++ b/deploy/scripts/src/examples/dev-platform.ts
@@ -1,6 +1,6 @@
 import http from 'k6/http'
 import { type Options } from 'k6/options'
-import { group, sleep } from 'k6'
+import { sleep } from 'k6'
 import {
   selectProfile,
   type ProfileList,
@@ -9,7 +9,7 @@ import {
   LoadProfile
 } from '../common/utils/config/load-profiles'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { getEnv } from '../common/utils/config/environment-variables'
 
 const profiles: ProfileList = {
@@ -78,22 +78,18 @@ const env = {
 }
 
 export function demoSamApp(): void {
-  group('GET - {demoSamApp} /test', () =>
-    timeRequest(() => http.get(env.BE_URL + '/test'), {
-      isStatusCode200,
-      'verify page content': r => JSON.parse(r.body as string).code === 'success'
-    })
-  )
+  timeGroup('GET - {demoSamApp} /test', () => http.get(env.BE_URL + '/test'), {
+    isStatusCode200,
+    'verify page content': r => JSON.parse(r.body as string).code === 'success'
+  })
 
   sleep(1)
 }
 
 export function demoNodeApp(): void {
-  group('GET - {demoNodeApp} /toy', () =>
-    timeRequest(() => http.get(env.FE_URL + '/toy'), {
-      isStatusCode200,
-      ...pageContentCheck('We need to ask you about your favourite toy')
-    })
-  )
+  timeGroup('GET - {demoNodeApp} /toy', () => http.get(env.FE_URL + '/toy'), {
+    isStatusCode200,
+    ...pageContentCheck('We need to ask you about your favourite toy')
+  })
   sleep(1)
 }

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -1,6 +1,5 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
 import encoding from 'k6/encoding'
-import { group } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import {
@@ -10,7 +9,7 @@ import {
   createScenario,
   LoadProfile
 } from '../common/utils/config/load-profiles'
-import { timeRequest } from '../common/utils/request/timing'
+import { timeGroup } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
 import { addressPayloadDL, kbvPayloaDL, fraudPayloadDL, drivingLicencePayload } from './data/drivingLicenceData'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
@@ -182,14 +181,13 @@ export function passport(): void {
   const testEmail = `perftest${timestamp}${iteration}@digital.cabinet-office.gov.uk`
   iterationsStarted.add(1)
   // B01_Passport_01_LaunchOrchestratorStub
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(env.orchStubEndPoint, {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter userId manually') }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(env.orchStubEndPoint, {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter userId manually') }
   )
 
   const userId = getUserId(res)
@@ -198,284 +196,271 @@ export function passport(): void {
   sleepBetween(0.5, 1)
 
   // B01_Passport_02_GoToFullJourneyRoute
-  res = group(groups[1], () =>
-    timeRequest(
-      () => {
-        const response = http.get(
-          env.orchStubEndPoint +
-            `/authorize?journeyType=full&userIdText=${userId}&signInJourneyIdText=${signInJourneyId}&vtrText=Cl.Cm.P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${testEmail}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
-          {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }
-        )
-        return response
-      },
-      {
-        isStatusCode200,
-        ...pageContentCheck('Tell us if you have one of the following types of photo ID')
-      }
-    )
+  res = timeGroup(
+    groups[1],
+    () => {
+      const response = http.get(
+        env.orchStubEndPoint +
+          `/authorize?journeyType=full&userIdText=${userId}&signInJourneyIdText=${signInJourneyId}&vtrText=Cl.Cm.P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${testEmail}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
+        {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }
+      )
+      return response
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Tell us if you have one of the following types of photo ID')
+    }
   )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_03_ClickContinueStartPage
-  group(groups[2], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[2],
+    () => {
       // 01_CoreCall
-      res = group(groups[3].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { journey: 'next' },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[3].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { journey: 'next' },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_DCMAWStub
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('DOC Checking App (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('DOC Checking App (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_04_DCMAWContinue
-  group(groups[5], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[5],
+    () => {
       // 01_DCMAWStub
-      res = group(groups[6].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                requested_oauth_error_endpoint: 'auth',
-                requested_oauth_error: 'access_denied'
-              },
-              params: { redirects: 1 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[6].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              requested_oauth_error_endpoint: 'auth',
+              requested_oauth_error: 'access_denied'
+            },
+            params: { redirects: 1 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[7].split('::')[1], () =>
-        timeRequest(() => http.get(env.ipvCoreURL + res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Enter your UK passport details and answer security questions online')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Enter your UK passport details and answer security questions online')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_05_ContinueOnPYIStartPage
-  group(groups[8], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[8],
+    () => {
       // 01_CoreCall
-      res = group(groups[9].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { journey: 'next/passport' },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[9].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { journey: 'next/passport' },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_PassStub
-      res = group(groups[10].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('UK Passport (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('UK Passport (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_06_PassportDataContinue
-  group(groups[11], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[11],
+    () => {
       // 01_PassStub
-      res = group(groups[12].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: passportPayload,
-                strengthScore: '4',
-                validityScore: '2'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[12].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: passportPayload,
+              strengthScore: '4',
+              validityScore: '2'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[13].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-      )
+      res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
       // 03_AddStub
-      res = group(groups[14].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Address (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Address (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_07_AddrDataContinue
-  group(groups[15], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[15],
+    () => {
       // 01_AddStub
-      res = group(groups[16].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { jsonPayload: addressPayloadP },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[16].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { jsonPayload: addressPayloadP },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[17].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-      )
+      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
       // 03_FraudStub
-      res = group(groups[18].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Fraud Check (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Fraud Check (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_08_FraudDataContinue
-  group(groups[19], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[19],
+    () => {
       // 01_FraudStub
-      res = group(groups[20].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: fraudPayloadP,
-                identityFraudScore: '2'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[20].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: fraudPayloadP,
+              identityFraudScore: '2'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[21].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Answer security questions')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Answer security questions')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_09_PreKBVTransition
-  group(groups[22], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[22],
+    () => {
       // 01_CoreCall
-      res = group(groups[23].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[23].split('::')[1],
+        () =>
+          res.submitForm({
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_KBVStub
-      res = group(groups[24].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Knowledge Based Verification (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Knowledge Based Verification (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_10_KBVDataContinue
-  group(groups[25], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[25],
+    () => {
       // 01_KBVStub
-      res = group(groups[26].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: kbvPayloadP,
-                verificationScore: '2'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[26].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: kbvPayloadP,
+              verificationScore: '2'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[27].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('You’ve successfully proved your identity')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('You’ve successfully proved your identity')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_11_ContinuePYISuccessPage
-  group(groups[28], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[28],
+    () => {
       // 01_CoreCall
-      res = group(groups[29].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[29].split('::')[1],
+        () =>
+          res.submitForm({
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_OrchStub
-      res = group(groups[30].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('User information') }
-        )
+      res = timeGroup(
+        groups[30].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('User information') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 
@@ -490,14 +475,13 @@ export function drivingLicence(): void {
   iterationsStarted.add(1)
 
   // B02_DrivingLicence_01_LaunchOrchestratorStub
-  res = group(groups[0], () =>
-    timeRequest(
-      () =>
-        http.get(env.orchStubEndPoint, {
-          headers: { Authorization: `Basic ${encodedCredentials}` }
-        }),
-      { isStatusCode200, ...pageContentCheck('Enter userId manually') }
-    )
+  res = timeGroup(
+    groups[0],
+    () =>
+      http.get(env.orchStubEndPoint, {
+        headers: { Authorization: `Basic ${encodedCredentials}` }
+      }),
+    { isStatusCode200, ...pageContentCheck('Enter userId manually') }
   )
   const userId = getUserId(res)
   const signInJourneyId = getSignInJourneyId(res)
@@ -505,286 +489,273 @@ export function drivingLicence(): void {
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_02_SelectUserIDContinue
-  res = group(groups[1], () =>
-    timeRequest(
-      () => {
-        const response = http.get(
-          env.orchStubEndPoint +
-            `/authorize?journeyType=full&userIdText=${userId}&signInJourneyIdText=${signInJourneyId}&vtrText=Cl.Cm.P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${testEmail}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
-          {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }
-        )
-        return response
-      },
-      {
-        isStatusCode200,
-        ...pageContentCheck('Tell us if you have one of the following types of photo ID')
-      }
-    )
+  res = timeGroup(
+    groups[1],
+    () => {
+      const response = http.get(
+        env.orchStubEndPoint +
+          `/authorize?journeyType=full&userIdText=${userId}&signInJourneyIdText=${signInJourneyId}&vtrText=Cl.Cm.P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${testEmail}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
+        {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }
+      )
+      return response
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Tell us if you have one of the following types of photo ID')
+    }
   )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_03_ContinueStartPage
-  group(groups[2], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[2],
+    () => {
       // 01_CoreCall
-      res = group(groups[3].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { journey: 'next' },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[3].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { journey: 'next' },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_DCMAWStub
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('DOC Checking App (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('DOC Checking App (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_04_DCMAWContinue
-  group(groups[5], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[5],
+    () => {
       // 01_DCMAWStub
-      res = group(groups[6].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                requested_oauth_error_endpoint: 'auth',
-                requested_oauth_error: 'access_denied'
-              },
-              params: { redirects: 1 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[6].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              requested_oauth_error_endpoint: 'auth',
+              requested_oauth_error: 'access_denied'
+            },
+            params: { redirects: 1 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[7].split('::')[1], () =>
-        timeRequest(() => http.get(env.ipvCoreURL + res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Enter your UK photocard driving licence details and answer security questions online')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Enter your UK photocard driving licence details and answer security questions online')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_05_ContinueOnPYIStartPage
-  group(groups[8], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[8],
+    () => {
       // 01_CoreCall
-      res = group(groups[9].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { journey: 'next/driving-licence' },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[9].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { journey: 'next/driving-licence' },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_DLStub
-      res = group(groups[10].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Driving Licence (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Driving Licence (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_06_DrivingLicenceDataContinue
-  group(groups[11], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[11],
+    () => {
       // 01_DLStub
-      res = group(groups[12].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: drivingLicencePayload,
-                strengthScore: '3',
-                validityScore: '2',
-                activityHistoryScore: '1'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[12].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: drivingLicencePayload,
+              strengthScore: '3',
+              validityScore: '2',
+              activityHistoryScore: '1'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[13].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-      )
+      res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
       // 03_AddStub
-      res = group(groups[14].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Address (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Address (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_07_AddrDataContinue
-  group(groups[15], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[15],
+    () => {
       // 01_AddStub
-      res = group(groups[16].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { jsonPayload: addressPayloadDL },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[16].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { jsonPayload: addressPayloadDL },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[17].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-      )
+      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
       // 03_FraudStub
-      res = group(groups[18].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Fraud Check (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Fraud Check (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_08_FraudDataContinue
-  group(groups[19], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[19],
+    () => {
       // 01_FraudStub
-      res = group(groups[20].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: fraudPayloadDL,
-                identityFraudScore: '2',
-                activityHistoryScore: '2'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[20].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: fraudPayloadDL,
+              identityFraudScore: '2',
+              activityHistoryScore: '2'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[21].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Answer security questions')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Answer security questions')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_09_PreKBVTransition
-  group(groups[22], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[22],
+    () => {
       // 01_CoreCall
-      res = group(groups[23].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[23].split('::')[1],
+        () =>
+          res.submitForm({
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_KBVStub
-      res = group(groups[24].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Knowledge Based Verification (Stub)')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Knowledge Based Verification (Stub)')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_10_KBVDataContinue
-  group(groups[25], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[25],
+    () => {
       // 01_KBVStub
-      res = group(groups[26].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: {
-                jsonPayload: kbvPayloaDL,
-                verificationScore: '2'
-              },
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[26].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: {
+              jsonPayload: kbvPayloaDL,
+              verificationScore: '2'
+            },
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[27].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Continue to the service you want to use')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Continue to the service you want to use')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_11_ContinueDrivingLicenceSuccessPage
-  group(groups[28], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[28],
+    () => {
       // 01_CoreCall
-      res = group(groups[29].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              params: { redirects: 0 }
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[29].split('::')[1],
+        () =>
+          res.submitForm({
+            params: { redirects: 0 }
+          }),
+        { isStatusCode302 }
       )
       // 02_OrchStub
-      res = group(groups[30].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('User information') }
-        )
+      res = timeGroup(
+        groups[30].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('User information') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 
@@ -798,62 +769,61 @@ export function idReuse(): void {
   const signInJourneyId = uuidv4()
 
   // B03_IDReuse_01_LoginToCore
-  group(groups[0], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[0],
+    () => {
       // 01_OrchStub
-      res = group(groups[1].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(
-              env.orchStubEndPoint +
-                `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${idReuseUserID.emailID}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
-              {
-                headers: { Authorization: `Basic ${encodedCredentials}` },
-                redirects: 0
-              }
-            ),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[1].split('::')[1],
+        () =>
+          http.get(
+            env.orchStubEndPoint +
+              `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${idReuseUserID.emailID}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
+            {
+              headers: { Authorization: `Basic ${encodedCredentials}` },
+              redirects: 0
+            }
+          ),
+        { isStatusCode302 }
       )
       // 02_CoreCall
-      res = group(groups[2].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('You have already proved your identity')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('You have already proved your identity')
+      })
+    },
+    {}
+  )
 
   sleepBetween(0.5, 1)
 
   // B03_IDReuse_02_ClickContinue
-  group(groups[3], () => {
-    timeRequest(() => {
+  timeGroup(
+    groups[3],
+    () => {
       // 01_CoreCall
-      res = group(groups[4].split('::')[1], () =>
-        timeRequest(
-          () =>
-            res.submitForm({
-              fields: { submitButton: '' },
-              params: { redirects: 0 },
-              submitSelector: '#continue'
-            }),
-          { isStatusCode302 }
-        )
+      res = timeGroup(
+        groups[4].split('::')[1],
+        () =>
+          res.submitForm({
+            fields: { submitButton: '' },
+            params: { redirects: 0 },
+            submitSelector: '#continue'
+          }),
+        { isStatusCode302 }
       )
       // 02_OrchStub
-      res = group(groups[5].split('::')[1], () =>
-        timeRequest(
-          () =>
-            http.get(res.headers.Location, {
-              headers: { Authorization: `Basic ${encodedCredentials}` }
-            }),
-          { isStatusCode200, ...pageContentCheck('User information') }
-        )
+      res = timeGroup(
+        groups[5].split('::')[1],
+        () =>
+          http.get(res.headers.Location, {
+            headers: { Authorization: `Basic ${encodedCredentials}` }
+          }),
+        { isStatusCode200, ...pageContentCheck('User information') }
       )
-    }, {})
-  })
+    },
+    {}
+  )
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -10,7 +10,6 @@ import {
   createScenario,
   LoadProfile
 } from '../common/utils/config/load-profiles'
-// import { getStaticResources } from '../common/utils/request/static'
 import { timeRequest } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
 import { addressPayloadDL, kbvPayloaDL, fraudPayloadDL, drivingLicencePayload } from './data/drivingLicenceData'
@@ -209,7 +208,6 @@ export function passport(): void {
             headers: { Authorization: `Basic ${encodedCredentials}` }
           }
         )
-        // if (env.staticResources) getStaticResources(response)
         return response
       },
       {
@@ -517,7 +515,6 @@ export function drivingLicence(): void {
             headers: { Authorization: `Basic ${encodedCredentials}` }
           }
         )
-        // if (env.staticResources) getStaticResources(response)
         return response
       },
       {


### PR DESCRIPTION
## QA-482

### What?
Addresses code smells from SonarCloud.

#### Changes:
- `deploy/Dockerfile`:
  - Replaced `RUN cd` command with `WORKDIR`
  - Added `--ignore-scripts` to `npm install` command
  - Capitalised `AS` commands
- `deploy/scripts/src/common/utils/request/timing.ts`:
  - Added new `timeGroup` function which replaces the previous pattern of `group(name, () => timeRequest(function, checks)` with `timeGroup(name, function, checks)`. Simplifying code and addressing code smells of nested functions being too deep
- `deploy/scripts/src/**/*.ts`:
  - Used new `timeGroup()` function
- `deploy/scripts/src/common/utils/config/load-profiles.ts`:
  - Replaced ternary with if/else statement
-  `deploy/scripts/src/cri-kiwi/requestGenerator/ipvrReqFormat.ts`:
   -  Changed interface names to PascalCase
- `deploy/scripts/src/cri-kiwi/utils/authorization.ts`:
  - Replaced `sting.match(regex)` with `regex.exec(string)` 

---

### Why?
Improve code quality and reduce noise from future SonarCloud scans.
