### PR TITLE
QA-483 Increase reserved concurrency for mock to cope with 4x traffic load than seen in perf test

### DIFF
--- a/koa-stub/template.yaml
+++ b/koa-stub/template.yaml
@@ -76,7 +76,7 @@ Resources:
       Handler: serverless.handler
       Runtime: nodejs20.x
       MemorySize: 512
-      ReservedConcurrentExecutions: 200
+      ReservedConcurrentExecutions: 800
       Environment:
         Variables:
           CLIENT_ID: "{{resolve:ssm:StubClientId}}"


### PR DESCRIPTION

## QA-483

### What?
Increase max concurrency on mock lambda.

https://govukverify.atlassian.net/wiki/spaces/DID/pages/4113694905/24-04-12+Authentication+SignIn+Load+Test 