### PR TITLE
[QA-484] Adding static assets in a http.batch() request to the Address CRI script

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -1,7 +1,7 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
 import { fail } from 'k6'
 import { type Options } from 'k6/options'
-import http, { ObjectBatchRequest, type Response } from 'k6/http'
+import http, { type Response } from 'k6/http'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
 import {
@@ -90,7 +90,7 @@ export function address(): void {
         { isStatusCode302 }
       )
       // 02_AddCRICall
-if (env.staticResources) {
+      if (env.staticResources) {
         const paths = [
           '/public/stylesheets/application.css',
           '/public/javascripts/all.js',

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -90,16 +90,16 @@ export function address(): void {
         )
       )
       // 02_AddCRICall
-      if (env.staticResources) {
-        const requests = [
-          { url: 'https://review-a.build.account.gov.uk/public/stylesheets/application.css' },
-          { url: 'https://review-a.build.account.gov.uk/public/javascripts/all.js' },
-          { url: 'https://review-a.build.account.gov.uk/public/javascripts/analytics.js' },
-          { url: 'https://review-a.build.account.gov.uk/public/fonts/bold-b542beb274-v2.woff2' },
-          { url: 'https://review-a.build.account.gov.uk/public/fonts/light-94a07e06a1-v2.woff2' },
-          { url: 'https://review-a.build.account.gov.uk/public/images/govuk-crest-2x.png' }
+if (env.staticResources) {
+        const paths = [
+          '/public/stylesheets/application.css',
+          '/public/javascripts/all.js',
+          '/public/javascripts/analytics.js',
+          '/public/fonts/bold-b542beb274-v2.woff2',
+          '/public/fonts/light-94a07e06a1-v2.woff2',
+          '/public/images/govuk-crest-2x.png'
         ]
-        const batchRequests: ObjectBatchRequest[] = requests.map(request => ({ url: request.url, method: 'GET' }))
+        const batchRequests = paths.map(path => env.addressEndPoint + path)
         http.batch(batchRequests)
       }
       res = group(groups[2].split('::')[1], () =>

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -90,22 +90,28 @@ export function address(): void {
         { isStatusCode302 }
       )
       // 02_AddCRICall
-      if (env.staticResources) {
-        const paths = [
-          '/public/stylesheets/application.css',
-          '/public/javascripts/all.js',
-          '/public/javascripts/analytics.js',
-          '/public/fonts/bold-b542beb274-v2.woff2',
-          '/public/fonts/light-94a07e06a1-v2.woff2',
-          '/public/images/govuk-crest-2x.png'
-        ]
-        const batchRequests = paths.map(path => env.addressEndPoint + path)
-        http.batch(batchRequests)
-      }
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Find your address')
-      })
+      timeGroup(
+        groups[2].split('::')[1],
+        () => {
+          if (env.staticResources) {
+            const paths = [
+              '/public/stylesheets/application.css',
+              '/public/javascripts/all.js',
+              '/public/javascripts/analytics.js',
+              '/public/fonts/bold-b542beb274-v2.woff2',
+              '/public/fonts/light-94a07e06a1-v2.woff2',
+              '/public/images/govuk-crest-2x.png'
+            ]
+            const batchRequests = paths.map(path => env.addressEndPoint + path)
+            http.batch(batchRequests)
+          }
+          return http.get(res.headers.Location)
+        },
+        {
+          isStatusCode200,
+          ...pageContentCheck('Find your address')
+        }
+      )
     },
     {}
   )

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -102,14 +102,13 @@ export function address(): void {
         const batchRequests = paths.map(path => env.addressEndPoint + path)
         http.batch(batchRequests)
       }
-      res = group(groups[2].split('::')[1], () =>
-        timeRequest(() => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('Find your address')
-        })
-      )
-    }, {})
-  })
+      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('Find your address')
+      })
+    },
+    {}
+  )
 
   sleepBetween(1, 3)
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -1,7 +1,7 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
 import { group, fail } from 'k6'
 import { type Options } from 'k6/options'
-import http, { type Response } from 'k6/http'
+import http, { ObjectBatchRequest, type Response } from 'k6/http'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
 import {
@@ -90,6 +90,18 @@ export function address(): void {
         )
       )
       // 02_AddCRICall
+      if (env.staticResources) {
+        const requests = [
+          { url: 'https://review-a.build.account.gov.uk/public/stylesheets/application.css' },
+          { url: 'https://review-a.build.account.gov.uk/public/javascripts/all.js' },
+          { url: 'https://review-a.build.account.gov.uk/public/javascripts/analytics.js' },
+          { url: 'https://review-a.build.account.gov.uk/public/fonts/bold-b542beb274-v2.woff2' },
+          { url: 'https://review-a.build.account.gov.uk/public/fonts/light-94a07e06a1-v2.woff2' },
+          { url: 'https://review-a.build.account.gov.uk/public/images/govuk-crest-2x.png' }
+        ]
+        const batchRequests: ObjectBatchRequest[] = requests.map(request => ({ url: request.url, method: 'GET' }))
+        http.batch(batchRequests)
+      }
       res = group(groups[2].split('::')[1], () =>
         timeRequest(() => http.get(res.headers.Location), {
           isStatusCode200,

--- a/deploy/scripts/src/cri-orange/utils/config.ts
+++ b/deploy/scripts/src/cri-orange/utils/config.ts
@@ -5,7 +5,8 @@ export const env = {
   ipvCoreStub: getEnv('IDENTITY_CORE_STUB_URL'),
   kbvEndPoint: getEnv('IDENTITY_KBV_URL'),
   addressEndPoint: getEnv('IDENTITY_ADDRESS_URL'),
-  envName: getEnv('ENVIRONMENT')
+  envName: getEnv('ENVIRONMENT'),
+  staticResources: getEnv('K6_NO_STATIC_RESOURCES') !== 'true'
 }
 
 export const stubCreds = {


### PR DESCRIPTION
## QA-484 <!--Jira Ticket Number-->

### What?
Added the static assets to a `http.batch()` request in the Address CRI script.

#### Changes:
Added an `if` flag to the first request in the Address CRI script, with a `http.batch()` of the static assets.

---

### Why?
To only parse the static asset URLs once in the user journey to potentially improve performance. 
