### PR TITLE
[QA-485] Remove empty object declarations in check set parameters for `timeGroup()` and `timeRequest()`

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -144,25 +144,21 @@ export function signUp(): void {
   iterationsStarted.add(1)
 
   // B01_SignUp_01_InitializeJourney
-  timeGroup(
-    groups[0],
-    () => {
-      // 01_RPStub
-      res = timeGroup(groups[1].split('::')[1], () => http.get(env.rpStub + '/start', { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 02_OIDCCall
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_AuthCall
-      res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Create your GOV.UK One Login or sign in')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[0], () => {
+    // 01_RPStub
+    res = timeGroup(groups[1].split('::')[1], () => http.get(env.rpStub + '/start', { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 02_OIDCCall
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_AuthCall
+    res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Create your GOV.UK One Login or sign in')
+    })
+  })
 
   sleep(1)
 
@@ -304,50 +300,42 @@ export function signUp(): void {
   sleep(1)
 
   // B01_SignUp_11_ContinueAccountCreated
-  timeGroup(
-    groups[13],
-    () => {
-      // 01_AuthCall
-      res = timeGroup(groups[14].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
-        isStatusCode302
-      })
-      // 02_OIDCCall
-      res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_RPStub
-      res = timeGroup(groups[16].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck(testEmail.toLowerCase())
-      })
-    },
-    {}
-  )
+  timeGroup(groups[13], () => {
+    // 01_AuthCall
+    res = timeGroup(groups[14].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
+      isStatusCode302
+    })
+    // 02_OIDCCall
+    res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_RPStub
+    res = timeGroup(groups[16].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck(testEmail.toLowerCase())
+    })
+  })
 
   // 25% of users logout
   if (Math.random() <= 0.25) {
     sleep(1)
 
     // B01_SignUp_12_Logout
-    timeGroup(
-      groups[17],
-      () => {
-        // 01_RPStub
-        res = timeGroup(groups[18].split('::')[1], () => http.get(env.rpStub + '/logout', { redirects: 0 }), {
-          isStatusCode302
-        })
-        // 02_OIDCCall
-        res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-        // 03_AuthCall
-        res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('You have signed out')
-        })
-      },
-      {}
-    )
+    timeGroup(groups[17], () => {
+      // 01_RPStub
+      res = timeGroup(groups[18].split('::')[1], () => http.get(env.rpStub + '/logout', { redirects: 0 }), {
+        isStatusCode302
+      })
+      // 02_OIDCCall
+      res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
+      // 03_AuthCall
+      res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('You have signed out')
+      })
+    })
   }
 
   iterationsCompleted.add(1)
@@ -360,25 +348,21 @@ export function signIn(): void {
   iterationsStarted.add(1)
 
   // B02_SignIn_01_InitializeJourney
-  timeGroup(
-    groups[0],
-    () => {
-      // 01_RPStub
-      res = timeGroup(groups[1].split('::')[1], () => http.get(env.rpStub + '/start', { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 02_OIDCCall
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_AuthCall
-      res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Create your GOV.UK One Login or sign in')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[0], () => {
+    // 01_RPStub
+    res = timeGroup(groups[1].split('::')[1], () => http.get(env.rpStub + '/start', { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 02_OIDCCall
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_AuthCall
+    res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Create your GOV.UK One Login or sign in')
+    })
+  })
 
   sleep(1)
 
@@ -422,41 +406,37 @@ export function signIn(): void {
 
       const totp = new TOTP(credentials.authAppKey)
       // B02_SignIn_05_AuthMFA_EnterTOTP
-      timeGroup(
-        groups[7],
-        () => {
-          // 01_AuthCall
-          res = timeGroup(
-            groups[8].split('::')[1],
-            () =>
-              res.submitForm({
-                fields: { code: totp.generateTOTP() },
-                params: { redirects: 1 }
-              }),
-            { isStatusCode302 }
-          )
-          // 02_OIDCCall
-          res = timeGroup(groups[9].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-            isStatusCode302
-          })
+      timeGroup(groups[7], () => {
+        // 01_AuthCall
+        res = timeGroup(
+          groups[8].split('::')[1],
+          () =>
+            res.submitForm({
+              fields: { code: totp.generateTOTP() },
+              params: { redirects: 1 }
+            }),
+          { isStatusCode302 }
+        )
+        // 02_OIDCCall
+        res = timeGroup(groups[9].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+          isStatusCode302
+        })
 
-          acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
-          if (acceptNewTerms) {
-            // 03_AuthAcceptTerms
-            res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
-              isStatusCode200,
-              ...pageContentCheck('terms of use update')
-            })
-          } else {
-            // 03_RPStub
-            res = timeGroup(groups[11].split('::')[1], () => http.get(res.headers.Location), {
-              isStatusCode200,
-              ...pageContentCheck(userData.email.toLowerCase())
-            })
-          }
-        },
-        {}
-      )
+        acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
+        if (acceptNewTerms) {
+          // 03_AuthAcceptTerms
+          res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck('terms of use update')
+          })
+        } else {
+          // 03_RPStub
+          res = timeGroup(groups[11].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck(userData.email.toLowerCase())
+          })
+        }
+      })
       break
     }
     case 'SMS': {
@@ -473,42 +453,38 @@ export function signIn(): void {
       sleep(1)
 
       // B02_SignIn_07_SMSMFA_EnterOTP
-      timeGroup(
-        groups[13],
-        () => {
-          // 01_AuthCall
-          res = timeGroup(
-            groups[14].split('::')[1],
-            () =>
-              res.submitForm({
-                fields: { code: credentials.phoneOTP },
-                params: { redirects: 1 }
-              }),
-            { isStatusCode302 }
-          )
-          // 02_OIDCCall
-          res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-            isStatusCode302
+      timeGroup(groups[13], () => {
+        // 01_AuthCall
+        res = timeGroup(
+          groups[14].split('::')[1],
+          () =>
+            res.submitForm({
+              fields: { code: credentials.phoneOTP },
+              params: { redirects: 1 }
+            }),
+          { isStatusCode302 }
+        )
+        // 02_OIDCCall
+        res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+          isStatusCode302
+        })
+
+        acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
+
+        if (acceptNewTerms) {
+          // 03_AuthAcceptTerms
+          res = timeGroup(groups[16].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck('terms of use update')
           })
-
-          acceptNewTerms = res.headers.Location.includes('updated-terms-and-conditions')
-
-          if (acceptNewTerms) {
-            // 03_AuthAcceptTerms
-            res = timeGroup(groups[16].split('::')[1], () => http.get(res.headers.Location), {
-              isStatusCode200,
-              ...pageContentCheck('terms of use update')
-            })
-          } else {
-            // 03_RPStub
-            res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
-              isStatusCode200,
-              ...pageContentCheck(userData.email.toLowerCase())
-            })
-          }
-        },
-        {}
-      )
+        } else {
+          // 03_RPStub
+          res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck(userData.email.toLowerCase())
+          })
+        }
+      })
       break
     }
   }
@@ -530,25 +506,21 @@ export function signIn(): void {
     sleep(1)
 
     // B02_SignIn_09_Logout
-    timeGroup(
-      groups[19],
-      () => {
-        // 01_RPStub
-        res = timeGroup(groups[20].split('::')[1], () => http.get(env.rpStub + '/logout', { redirects: 0 }), {
-          isStatusCode302
-        })
-        // 02_OIDCCall
-        res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-          isStatusCode302
-        })
-        // 03_AuthCall
-        res = timeGroup(groups[22].split('::')[1], () => http.get(res.headers.Location), {
-          isStatusCode200,
-          ...pageContentCheck('You have signed out')
-        })
-      },
-      {}
-    )
+    timeGroup(groups[19], () => {
+      // 01_RPStub
+      res = timeGroup(groups[20].split('::')[1], () => http.get(env.rpStub + '/logout', { redirects: 0 }), {
+        isStatusCode302
+      })
+      // 02_OIDCCall
+      res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
+      // 03_AuthCall
+      res = timeGroup(groups[22].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck('You have signed out')
+      })
+    })
   }
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/common/utils/request/timing.ts
+++ b/deploy/scripts/src/common/utils/request/timing.ts
@@ -28,7 +28,7 @@ export function timeFunction<T>(fn: () => T): [T, number] {
  * If the checks are succesful: the duration is added to the trend.
  * If the checks fail: the iteration is aborted.
  * @param {() => T} fn - Code to be executed and timed
- * @param {Checkers<T>} checks Set of checker functions to use as assertions
+ * @param {Checkers<T>} [checks] Set of checker functions to use as assertions, defaults to none
  * @returns Returns the return value from calling `fn`
  * @example
  * const res = timeRequest(
@@ -36,7 +36,7 @@ export function timeFunction<T>(fn: () => T): [T, number] {
  *   { 'status is 200': (r) => r.status === 200 }
  * )
  */
-export function timeRequest<T>(fn: () => T, checks: Checkers<T>): T {
+export function timeRequest<T>(fn: () => T, checks: Checkers<T> = {}): T {
   const [res, duration] = timeFunction(fn)
   check(res, checks) ? durations.add(duration) : fail('Response validation failed')
   return res
@@ -46,7 +46,7 @@ export function timeRequest<T>(fn: () => T, checks: Checkers<T>): T {
  * Creates a k6 `group` and runs `timeRequest` within it
  * @param {string} name Group name to be used as a `group` tag
  * @param {() => T} fn - Code to be executed and timed
- * @param {Checkers<T>} checks Checkers object to assert against the response of `fn`
+ * @param {Checkers<T>} [checks] Checkers object to assert against the response of `fn`, defaults to empty object
  * @returns Returns the return value from calling `fn`
  * @example
  * const res = timeGroup(
@@ -55,6 +55,6 @@ export function timeRequest<T>(fn: () => T, checks: Checkers<T>): T {
  *   { 'status is 200': (r) => r.status === 200 }
  * )
  */
-export function timeGroup<T>(name: string, fn: () => T, checks: Checkers<T>): T {
+export function timeGroup<T>(name: string, fn: () => T, checks: Checkers<T> = {}): T {
   return group(name, () => timeRequest(fn, checks))
 }

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -236,90 +236,82 @@ export function fraud(): void {
   iterationsStarted.add(1)
 
   // B01_Fraud_01_CoreStubEditUserContinue
-  timeGroup(
-    groups[0],
-    () => {
-      // 01_CoreStubCall
-      res = timeGroup(
-        groups[1].split('::')[1],
-        () =>
-          http.post(
-            env.ipvCoreStub + '/edit-user',
-            {
-              cri: `fraud-cri-${env.envName}`,
-              rowNumber: '197',
-              firstName: userDetails.firstName,
-              surname: userDetails.lastName,
-              'dateOfBirth-day': `${userDetails.day}`,
-              'dateOfBirth-month': `${userDetails.month}`,
-              'dateOfBirth-year': `${userDetails.year}`,
-              buildingNumber: `${userDetails.buildNum}`,
-              buildingName: userDetails.buildName,
-              street: userDetails.street,
-              townCity: userDetails.city,
-              postCode: userDetails.postCode,
-              validFromDay: '26',
-              validFromMonth: '02',
-              validFromYear: '2021',
-              validUntilDay: '',
-              validUntilMonth: '',
-              validUntilYear: '',
-              'SecondaryUKAddress.buildingNumber': '',
-              'SecondaryUKAddress.buildingName': '',
-              'SecondaryUKAddress.street': '',
-              'SecondaryUKAddress.townCity': '',
-              'SecondaryUKAddress.postCode': '',
-              'SecondaryUKAddress.validFromDay': '',
-              'SecondaryUKAddress.validFromMonth': '',
-              'SecondaryUKAddress.validFromYear': '',
-              'SecondaryUKAddress.validUntilDay': '',
-              'SecondaryUKAddress.validUntilMonth': '',
-              'SecondaryUKAddress.validUntilYear': ''
-            },
-            {
-              headers: { Authorization: `Basic ${encodedCredentials}` },
-              redirects: 0
-            }
-          ),
-        { isStatusCode302 }
-      )
-      // 01_CRICall
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('We need to check your details')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[0], () => {
+    // 01_CoreStubCall
+    res = timeGroup(
+      groups[1].split('::')[1],
+      () =>
+        http.post(
+          env.ipvCoreStub + '/edit-user',
+          {
+            cri: `fraud-cri-${env.envName}`,
+            rowNumber: '197',
+            firstName: userDetails.firstName,
+            surname: userDetails.lastName,
+            'dateOfBirth-day': `${userDetails.day}`,
+            'dateOfBirth-month': `${userDetails.month}`,
+            'dateOfBirth-year': `${userDetails.year}`,
+            buildingNumber: `${userDetails.buildNum}`,
+            buildingName: userDetails.buildName,
+            street: userDetails.street,
+            townCity: userDetails.city,
+            postCode: userDetails.postCode,
+            validFromDay: '26',
+            validFromMonth: '02',
+            validFromYear: '2021',
+            validUntilDay: '',
+            validUntilMonth: '',
+            validUntilYear: '',
+            'SecondaryUKAddress.buildingNumber': '',
+            'SecondaryUKAddress.buildingName': '',
+            'SecondaryUKAddress.street': '',
+            'SecondaryUKAddress.townCity': '',
+            'SecondaryUKAddress.postCode': '',
+            'SecondaryUKAddress.validFromDay': '',
+            'SecondaryUKAddress.validFromMonth': '',
+            'SecondaryUKAddress.validFromYear': '',
+            'SecondaryUKAddress.validUntilDay': '',
+            'SecondaryUKAddress.validUntilMonth': '',
+            'SecondaryUKAddress.validUntilYear': ''
+          },
+          {
+            headers: { Authorization: `Basic ${encodedCredentials}` },
+            redirects: 0
+          }
+        ),
+      { isStatusCode302 }
+    )
+    // 01_CRICall
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('We need to check your details')
+    })
+  })
 
   sleepBetween(1, 3)
 
   // B01_Fraud_02_ContinueToCheckFraudDetails
-  timeGroup(
-    groups[3],
-    () => {
-      // 01_CRICall
-      res = timeGroup(
-        groups[4].split('::')[1],
-        () =>
-          res.submitForm({
-            params: { redirects: 1 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[5].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[3], () => {
+    // 01_CRICall
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () =>
+        res.submitForm({
+          params: { redirects: 1 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[5].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 
@@ -407,32 +399,28 @@ export function drivingLicence(): void {
   sleepBetween(1, 3)
 
   // B02_Driving_03_${licenceIssuer}_EnterDetailsConfirm
-  timeGroup(
-    groups[2],
-    () => {
-      // 01_CRICall
-      res = timeGroup(
-        groups[3].split('::')[1],
-        () =>
-          res.submitForm({
-            fields,
-            params: { redirects: 2 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[4].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[2], () => {
+    // 01_CRICall
+    res = timeGroup(
+      groups[3].split('::')[1],
+      () =>
+        res.submitForm({
+          fields,
+          params: { redirects: 2 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 
@@ -460,43 +448,39 @@ export function passport(): void {
   sleepBetween(1, 3)
 
   // B03_Passport_02_EnterPassportDetailsAndContinue
-  timeGroup(
-    groups[1],
-    () => {
-      // 01_CRICall
-      res = timeGroup(
-        groups[2].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              passportNumber: userPassport.passportNumber,
-              surname: userPassport.surname,
-              firstName: userPassport.firstName,
-              middleNames: userPassport.middleName,
-              'dateOfBirth-day': userPassport.birthday,
-              'dateOfBirth-month': userPassport.birthmonth,
-              'dateOfBirth-year': userPassport.birthyear,
-              'expiryDate-day': userPassport.expiryDay,
-              'expiryDate-month': userPassport.expiryMonth,
-              'expiryDate-year': userPassport.expiryYear
-            },
-            params: { redirects: 2 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[3].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[1], () => {
+    // 01_CRICall
+    res = timeGroup(
+      groups[2].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            passportNumber: userPassport.passportNumber,
+            surname: userPassport.surname,
+            firstName: userPassport.firstName,
+            middleNames: userPassport.middleName,
+            'dateOfBirth-day': userPassport.birthday,
+            'dateOfBirth-month': userPassport.birthmonth,
+            'dateOfBirth-year': userPassport.birthyear,
+            'expiryDate-day': userPassport.expiryDay,
+            'expiryDate-month': userPassport.expiryMonth,
+            'expiryDate-year': userPassport.expiryYear
+          },
+          params: { redirects: 2 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[3].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -76,27 +76,23 @@ export function address(): void {
   iterationsStarted.add(1)
 
   // B02_Address_01_AddressCRIEntryFromStub
-  timeGroup(
-    groups[0],
-    () => {
-      // 01_CoreStubCall
-      res = timeGroup(
-        groups[1].split('::')[1],
-        () =>
-          http.get(env.ipvCoreStub + '/credential-issuer?cri=address-cri-' + env.envName, {
-            redirects: 0,
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_AddCRICall
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Find your address')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[0], () => {
+    // 01_CoreStubCall
+    res = timeGroup(
+      groups[1].split('::')[1],
+      () =>
+        http.get(env.ipvCoreStub + '/credential-issuer?cri=address-cri-' + env.envName, {
+          redirects: 0,
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_AddCRICall
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Find your address')
+    })
+  })
 
   sleepBetween(1, 3)
 
@@ -140,24 +136,20 @@ export function address(): void {
   sleepBetween(1, 3)
 
   // B02_Address_05_ConfirmDetails
-  timeGroup(
-    groups[6],
-    () => {
-      // 01_AddCRICall
-      res = timeGroup(groups[7].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
-        isStatusCode302
-      })
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[8].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[6], () => {
+    // 01_AddCRICall
+    res = timeGroup(groups[7].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
+      isStatusCode302
+    })
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[8].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
+    )
+  })
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -109,34 +109,30 @@ export function kbv(): void {
   sleepBetween(1, 3)
 
   // B01_KBV_04_KBVQuestion3
-  timeGroup(
-    groups[3],
-    () => {
-      // 01_KBVCRICall
-      res = timeGroup(
-        groups[4].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { Q00018: kbvAnsJSON.kbvAns3 },
-            params: { redirects: 2 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[5].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        {
-          isStatusCode200,
-          ...pageContentCheck('verificationScore&quot;: 2')
-        }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[3], () => {
+    // 01_KBVCRICall
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { Q00018: kbvAnsJSON.kbvAns3 },
+          params: { redirects: 2 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[5].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      {
+        isStatusCode200,
+        ...pageContentCheck('verificationScore&quot;: 2')
+      }
+    )
+  })
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -122,31 +122,27 @@ export function ninoCheck(): void {
   sleepBetween(1, 3)
 
   // B02_Nino_03_SearchNiNo
-  timeGroup(
-    groups[2],
-    () => {
-      // 01_NiNOCRICall
-      res = timeGroup(
-        groups[3].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { nationalInsuranceNumber: userNino.niNumber },
-            params: { redirects: 1 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreStubCall
-      res = timeGroup(
-        groups[4].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('Verifiable') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[2], () => {
+    // 01_NiNOCRICall
+    res = timeGroup(
+      groups[3].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { nationalInsuranceNumber: userNino.niNumber },
+          params: { redirects: 1 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreStubCall
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable') }
+    )
+  })
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -217,250 +217,214 @@ export function passport(): void {
   sleepBetween(0.5, 1)
 
   // B01_Passport_03_ClickContinueStartPage
-  timeGroup(
-    groups[2],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[3].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { journey: 'next' },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_DCMAWStub
-      res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('DOC Checking App (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[2], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[3].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { journey: 'next' },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_DCMAWStub
+    res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('DOC Checking App (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_04_DCMAWContinue
-  timeGroup(
-    groups[5],
-    () => {
-      // 01_DCMAWStub
-      res = timeGroup(
-        groups[6].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              requested_oauth_error_endpoint: 'auth',
-              requested_oauth_error: 'access_denied'
-            },
-            params: { redirects: 1 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Enter your UK passport details and answer security questions online')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[5], () => {
+    // 01_DCMAWStub
+    res = timeGroup(
+      groups[6].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            requested_oauth_error_endpoint: 'auth',
+            requested_oauth_error: 'access_denied'
+          },
+          params: { redirects: 1 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Enter your UK passport details and answer security questions online')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_05_ContinueOnPYIStartPage
-  timeGroup(
-    groups[8],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[9].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { journey: 'next/passport' },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_PassStub
-      res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('UK Passport (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[8], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[9].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { journey: 'next/passport' },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_PassStub
+    res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('UK Passport (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_06_PassportDataContinue
-  timeGroup(
-    groups[11],
-    () => {
-      // 01_PassStub
-      res = timeGroup(
-        groups[12].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: passportPayload,
-              strengthScore: '4',
-              validityScore: '2'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_AddStub
-      res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Address (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[11], () => {
+    // 01_PassStub
+    res = timeGroup(
+      groups[12].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: passportPayload,
+            strengthScore: '4',
+            validityScore: '2'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_AddStub
+    res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Address (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_07_AddrDataContinue
-  timeGroup(
-    groups[15],
-    () => {
-      // 01_AddStub
-      res = timeGroup(
-        groups[16].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { jsonPayload: addressPayloadP },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_FraudStub
-      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Fraud Check (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[15], () => {
+    // 01_AddStub
+    res = timeGroup(
+      groups[16].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { jsonPayload: addressPayloadP },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_FraudStub
+    res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Fraud Check (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_08_FraudDataContinue
-  timeGroup(
-    groups[19],
-    () => {
-      // 01_FraudStub
-      res = timeGroup(
-        groups[20].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: fraudPayloadP,
-              identityFraudScore: '2'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Answer security questions')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[19], () => {
+    // 01_FraudStub
+    res = timeGroup(
+      groups[20].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: fraudPayloadP,
+            identityFraudScore: '2'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Answer security questions')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_09_PreKBVTransition
-  timeGroup(
-    groups[22],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[23].split('::')[1],
-        () =>
-          res.submitForm({
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_KBVStub
-      res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Knowledge Based Verification (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[22], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[23].split('::')[1],
+      () =>
+        res.submitForm({
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_KBVStub
+    res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Knowledge Based Verification (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_10_KBVDataContinue
-  timeGroup(
-    groups[25],
-    () => {
-      // 01_KBVStub
-      res = timeGroup(
-        groups[26].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: kbvPayloadP,
-              verificationScore: '2'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('You’ve successfully proved your identity')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[25], () => {
+    // 01_KBVStub
+    res = timeGroup(
+      groups[26].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: kbvPayloadP,
+            verificationScore: '2'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('You’ve successfully proved your identity')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B01_Passport_11_ContinuePYISuccessPage
-  timeGroup(
-    groups[28],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[29].split('::')[1],
-        () =>
-          res.submitForm({
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_OrchStub
-      res = timeGroup(
-        groups[30].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('User information') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[28], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[29].split('::')[1],
+      () =>
+        res.submitForm({
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_OrchStub
+    res = timeGroup(
+      groups[30].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('User information') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 
@@ -510,252 +474,216 @@ export function drivingLicence(): void {
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_03_ContinueStartPage
-  timeGroup(
-    groups[2],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[3].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { journey: 'next' },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_DCMAWStub
-      res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('DOC Checking App (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[2], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[3].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { journey: 'next' },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_DCMAWStub
+    res = timeGroup(groups[4].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('DOC Checking App (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_04_DCMAWContinue
-  timeGroup(
-    groups[5],
-    () => {
-      // 01_DCMAWStub
-      res = timeGroup(
-        groups[6].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              requested_oauth_error_endpoint: 'auth',
-              requested_oauth_error: 'access_denied'
-            },
-            params: { redirects: 1 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Enter your UK photocard driving licence details and answer security questions online')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[5], () => {
+    // 01_DCMAWStub
+    res = timeGroup(
+      groups[6].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            requested_oauth_error_endpoint: 'auth',
+            requested_oauth_error: 'access_denied'
+          },
+          params: { redirects: 1 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[7].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Enter your UK photocard driving licence details and answer security questions online')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_05_ContinueOnPYIStartPage
-  timeGroup(
-    groups[8],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[9].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { journey: 'next/driving-licence' },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_DLStub
-      res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Driving Licence (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[8], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[9].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { journey: 'next/driving-licence' },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_DLStub
+    res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Driving Licence (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_06_DrivingLicenceDataContinue
-  timeGroup(
-    groups[11],
-    () => {
-      // 01_DLStub
-      res = timeGroup(
-        groups[12].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: drivingLicencePayload,
-              strengthScore: '3',
-              validityScore: '2',
-              activityHistoryScore: '1'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_AddStub
-      res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Address (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[11], () => {
+    // 01_DLStub
+    res = timeGroup(
+      groups[12].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: drivingLicencePayload,
+            strengthScore: '3',
+            validityScore: '2',
+            activityHistoryScore: '1'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_AddStub
+    res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Address (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_07_AddrDataContinue
-  timeGroup(
-    groups[15],
-    () => {
-      // 01_AddStub
-      res = timeGroup(
-        groups[16].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { jsonPayload: addressPayloadDL },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
-        isStatusCode302
-      })
-      // 03_FraudStub
-      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Fraud Check (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[15], () => {
+    // 01_AddStub
+    res = timeGroup(
+      groups[16].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { jsonPayload: addressPayloadDL },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      isStatusCode302
+    })
+    // 03_FraudStub
+    res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Fraud Check (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_08_FraudDataContinue
-  timeGroup(
-    groups[19],
-    () => {
-      // 01_FraudStub
-      res = timeGroup(
-        groups[20].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: fraudPayloadDL,
-              identityFraudScore: '2',
-              activityHistoryScore: '2'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Answer security questions')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[19], () => {
+    // 01_FraudStub
+    res = timeGroup(
+      groups[20].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: fraudPayloadDL,
+            identityFraudScore: '2',
+            activityHistoryScore: '2'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Answer security questions')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_09_PreKBVTransition
-  timeGroup(
-    groups[22],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[23].split('::')[1],
-        () =>
-          res.submitForm({
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_KBVStub
-      res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Knowledge Based Verification (Stub)')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[22], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[23].split('::')[1],
+      () =>
+        res.submitForm({
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_KBVStub
+    res = timeGroup(groups[24].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Knowledge Based Verification (Stub)')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_10_KBVDataContinue
-  timeGroup(
-    groups[25],
-    () => {
-      // 01_KBVStub
-      res = timeGroup(
-        groups[26].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: {
-              jsonPayload: kbvPayloaDL,
-              verificationScore: '2'
-            },
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('Continue to the service you want to use')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[25], () => {
+    // 01_KBVStub
+    res = timeGroup(
+      groups[26].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: {
+            jsonPayload: kbvPayloaDL,
+            verificationScore: '2'
+          },
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[27].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Continue to the service you want to use')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B02_DrivingLicence_11_ContinueDrivingLicenceSuccessPage
-  timeGroup(
-    groups[28],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[29].split('::')[1],
-        () =>
-          res.submitForm({
-            params: { redirects: 0 }
-          }),
-        { isStatusCode302 }
-      )
-      // 02_OrchStub
-      res = timeGroup(
-        groups[30].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('User information') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[28], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[29].split('::')[1],
+      () =>
+        res.submitForm({
+          params: { redirects: 0 }
+        }),
+      { isStatusCode302 }
+    )
+    // 02_OrchStub
+    res = timeGroup(
+      groups[30].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('User information') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 
@@ -769,61 +697,53 @@ export function idReuse(): void {
   const signInJourneyId = uuidv4()
 
   // B03_IDReuse_01_LoginToCore
-  timeGroup(
-    groups[0],
-    () => {
-      // 01_OrchStub
-      res = timeGroup(
-        groups[1].split('::')[1],
-        () =>
-          http.get(
-            env.orchStubEndPoint +
-              `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${idReuseUserID.emailID}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
-            {
-              headers: { Authorization: `Basic ${encodedCredentials}` },
-              redirects: 0
-            }
-          ),
-        { isStatusCode302 }
-      )
-      // 02_CoreCall
-      res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck('You have already proved your identity')
-      })
-    },
-    {}
-  )
+  timeGroup(groups[0], () => {
+    // 01_OrchStub
+    res = timeGroup(
+      groups[1].split('::')[1],
+      () =>
+        http.get(
+          env.orchStubEndPoint +
+            `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=P2&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${idReuseUserID.emailID}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
+          {
+            headers: { Authorization: `Basic ${encodedCredentials}` },
+            redirects: 0
+          }
+        ),
+      { isStatusCode302 }
+    )
+    // 02_CoreCall
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('You have already proved your identity')
+    })
+  })
 
   sleepBetween(0.5, 1)
 
   // B03_IDReuse_02_ClickContinue
-  timeGroup(
-    groups[3],
-    () => {
-      // 01_CoreCall
-      res = timeGroup(
-        groups[4].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { submitButton: '' },
-            params: { redirects: 0 },
-            submitSelector: '#continue'
-          }),
-        { isStatusCode302 }
-      )
-      // 02_OrchStub
-      res = timeGroup(
-        groups[5].split('::')[1],
-        () =>
-          http.get(res.headers.Location, {
-            headers: { Authorization: `Basic ${encodedCredentials}` }
-          }),
-        { isStatusCode200, ...pageContentCheck('User information') }
-      )
-    },
-    {}
-  )
+  timeGroup(groups[3], () => {
+    // 01_CoreCall
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () =>
+        res.submitForm({
+          fields: { submitButton: '' },
+          params: { redirects: 0 },
+          submitSelector: '#continue'
+        }),
+      { isStatusCode302 }
+    )
+    // 02_OrchStub
+    res = timeGroup(
+      groups[5].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('User information') }
+    )
+  })
   iterationsCompleted.add(1)
 }
 


### PR DESCRIPTION
## QA-485

### What?
Removes empty objects declarations for when calling `timeGroup()` and `timeRequest` without any checks to run

#### Changes:
- `deploy/scripts/src/common/utils/request/timing.ts`: Update the `checks` parameters to default to an empty object `{}`
- `deploy/scripts/src/*/*.ts`: Removed empty object parameters `{}` from function calls

---

### Why?
Simplify code and improve maintainability
