### PR TITLE
[QA-425] Pin `koa-stub` GitHub actions versions

### DIFF
--- a/.github/workflows/koa-stub-main.yaml
+++ b/.github/workflows/koa-stub-main.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'koa-stub/**'
+      - "koa-stub/**"
 
 jobs:
   run-unit-tests:
@@ -21,12 +21,12 @@ jobs:
         working-directory: koa-stub/
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
 
       - name: Setup nodeJS v20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
 
@@ -53,22 +53,22 @@ jobs:
         working-directory: koa-stub/
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.PERF_STUB_GH_ACTIONS_ROLE_ARN }}
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
 
       - name: Setup nodeJS v20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
       - name: Setup SAM CLI
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@342dcc4899c07fedf41f91cbb1e6c68925a85d37 # v2
 
       - name: SAM Validate
         run: |
@@ -78,10 +78,8 @@ jobs:
         run: |
           sam build
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.5
+        uses: govuk-one-login/devplatform-upload-action@1bf704ccba8eaebea0bd43318321d806b29f9fe4 # v3.5
         with:
           artifact-bucket-name: ${{ secrets.PERF_STUB_ARTIFACT_SOURCE_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.PERF_STUB_SIGNING_PROFILE_NAME }}
           working-directory: ./koa-stub/.aws-sam/build
-
-

--- a/.github/workflows/koa-stub-pr.yaml
+++ b/.github/workflows/koa-stub-pr.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'koa-stub/**'
+      - "koa-stub/**"
 
 jobs:
   # Sonar is enabled through SaaS Integration, so workflow checks not needed to be explicit
@@ -42,12 +42,12 @@ jobs:
         working-directory: koa-stub/
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
 
       - name: Setup nodeJS v20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
 


### PR DESCRIPTION
## QA-425

### What?
Pin the commit SHAs of specific github actions used in deploying and testing changes to the koa-stub

#### Changes:
- Replaced version tags with commit SHAs for koa-stub github actions steps

---

### Why?
Improve security

---

### Related:
- #492 
