### PR TITLE
[QA-486] Use `setup-node` workflow to set node version

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Run linting checks
         run: npm run lint
@@ -42,7 +42,7 @@ jobs:
           filename: ./deploy/scripts/dist/common/unit-tests.js
 
       - run: git fetch origin main
-      - name:  Run pre-commit action
+      - name: Run pre-commit action
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --from-ref FETCH_HEAD --to-ref HEAD

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -20,7 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20
 
       - name: Install dependencies
         run: npm i

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: npm i
 

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'deploy/scripts/src/common/utils/**'
+      - "deploy/scripts/src/common/utils/**"
 
 defaults:
   run:
@@ -30,7 +30,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Create TypeDoc documentation
         run: npx typedoc ./src/common/utils/**/*.ts


### PR DESCRIPTION
## QA-486

### What?
Add `setup-node` step in Github actions workflow to fix node version

#### Changes:
- `.github/workflows/pre-merge-checks.yml` & `.github/workflows/typedoc-publish.yml`:
  - Added `setup-node` workflow
  - Updated `npm i` to `npm ci`

---

### Why?
More control over node versions
