### PR TITLE
[QA-487]: Corrected transaction name in sign-in scenario

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -61,7 +61,7 @@ const groupMap = {
   ],
   signIn: [
     'B02_SignIn_01_InitializeJourney',
-    'B01_SignUp_01_InitializeJourney::01_RPStub',
+    'B02_SignIn_01_InitializeJourney::01_RPStub',
     'B02_SignIn_01_InitializeJourney::02_OIDCCall',
     'B02_SignIn_01_InitializeJourney::03_AuthCall',
     'B02_SignIn_02_ClickSignIn',


### PR DESCRIPTION
## QA-487 <!--Jira Ticket Number-->

### What?
Corrected transaction name in sign-in scenario.

#### Changes:
- `B02_SignIn_01_InitializeJourney::01_RPStub` was incorrect

---

### Why?
To ensure correct transaction name is used in the scenarios.