### PR TITLE
[QA-490] Updating the Address CRI script with the res variable

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -88,7 +88,7 @@ export function address(): void {
       { isStatusCode302 }
     )
     // 02_AddCRICall
-    timeGroup(
+    res = timeGroup(
       groups[2].split('::')[1],
       () => {
         if (env.staticResources) {


### PR DESCRIPTION
## QA-490 <!--Jira Ticket Number-->

### What?
Assigns the new response to the `res` variable in the address CRI script

#### Changes:
change `timeGroup(` to  `res = timeGroup(`

---

### Why?
For successful completion of the Address CRI user journey.
