### PR TITLE
Auth - Add load profiles for testing Sign In and Sign Up at 10% of NFR

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -26,6 +26,10 @@ const profiles: ProfileList = {
     ...createScenario('signIn', LoadProfile.short, 30),
     ...createScenario('signUp', LoadProfile.short, 30)
   },
+  load10: {
+    ...createScenario('signIn', LoadProfile.short, 190),
+    ...createScenario('signUp', LoadProfile.short, 10)
+  },
   load: {
     ...createScenario('signIn', LoadProfile.full, 500)
   },


### PR DESCRIPTION
## QA-495 <!--Jira Ticket Number-->

### What?
Added load profiles for testing Sign In and Sign Up at 10% of NFR volumes

#### Changes:
- Added load profile for Sign In and Sign Up journey

---

### Why?
The Auth team has asked us to conduct a combined test for Sign In and Sign Up with a target load of 10% of the NFR

---
