### PR TITLE
[QA-494] Static Asset testing of Passport CRI

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -449,7 +449,7 @@ export function passport(): void {
     )
 
     // 02_CRICall
-    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.location), {
+    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Enter your details exactly as they appear on your UK passport')
     })

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -449,10 +449,28 @@ export function passport(): void {
     )
 
     // 02_CRICall
-    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-      isStatusCode200,
-      ...pageContentCheck('Enter your details exactly as they appear on your UK passport')
-    })
+    res = timeGroup(
+      groups[2].split('::')[1],
+      () => {
+        if (env.staticResources) {
+          const paths = [
+            '/public/fonts/light-94a07e06a1-v2.woff2',
+            '/public/fonts/bold-b542beb274-v2.woff2',
+            '/public/images/govuk-crest-2x.png',
+            '/public/javascripts/analytics.js',
+            '/public/javascripts/all.js',
+            '/public/stylesheets/application.css'
+          ]
+          const batchRequests = paths.map(path => env.passportURL + path)
+          http.batch(batchRequests)
+        }
+        return http.get(res.headers.Location)
+      },
+      {
+        isStatusCode200,
+        ...pageContentCheck('Enter your details exactly as they appear on your UK passport')
+      }
+    )
   })
 
   sleepBetween(1, 3)


### PR DESCRIPTION
## QA-494 <!--Jira Ticket Number-->

### What?
- Splits the first call of the passport CRI user journey into 2, the CoreStubCall and CRICall. 
- Add a `http.batch()` of static assets behind an `if` flag to the passport CRI script.

#### Changes:
- Split `B03_Passport_01_PassportCRIEntryFromStub` into two separate calls:   `B03_Passport_01_PassportCRIEntryFromStub::01_CoreStubCall` and    `B03_Passport_01_PassportCRIEntryFromStub::02_CRICall`. 
- Add a `http.batch()` of all the passport CRI static assets behind an `if` flag.
---

### Why?
To allow static asset testing of passport CRI
---
