### PR TITLE
[QA-496] New Loadprofile for Static Asset Testing

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -94,7 +94,7 @@ export enum LoadProfile {
   short,
   full,
   deployment,
-  extendedRampUp
+  rampOnly
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -120,7 +120,7 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target, duration: '20m' }, // Maintain steady state at target throughput for 20 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ]
-    case LoadProfile.extendedRampUp:
+    case LoadProfile.rampOnly:
       return [
         { target, duration: '15m' }, // Ramp up to target throughput over 15 minutes
         { target, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -93,7 +93,8 @@ export enum LoadProfile {
   smoke,
   short,
   full,
-  deployment
+  deployment,
+  extendedRampUp
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -118,6 +119,12 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target, duration: '5m' }, // Ramp up to target throughput over 5 minutes
         { target, duration: '20m' }, // Maintain steady state at target throughput for 20 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    case LoadProfile.extendedRampUp:
+      return [
+        { target, duration: '15m' }, // Ramp up to target throughput over 15 minutes
+        { target, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes
+        { target, duration: '5m' } // Ramp down over 5 minutes
       ]
   }
 }

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -64,6 +64,9 @@ const profiles: ProfileList = {
     ...createScenario('fraud', LoadProfile.full, 63),
     ...createScenario('drivingLicence', LoadProfile.full, 55),
     ...createScenario('passport', LoadProfile.full, 55)
+  },
+  extendedRampUp: {
+    ...createScenario('passport', LoadProfile.extendedRampUp, 30)
   }
 }
 

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -66,7 +66,7 @@ const profiles: ProfileList = {
     ...createScenario('passport', LoadProfile.full, 55)
   },
   extendedRampUp: {
-    ...createScenario('passport', LoadProfile.extendedRampUp, 30)
+    ...createScenario('passport', LoadProfile.rampOnly, 30)
   }
 }
 


### PR DESCRIPTION
## QA-496 <!--Jira Ticket Number-->

### What?
Added a new loadProfile with an extended ramp-up and reduced steady state for static asset testing

#### Changes:
Added a new LoadProfile for static asset testing of:
- Target volume: 30 iterations per second 
- Ramp-up: 15 minutes
- Steady-state: 5 minutes
- Ramp-down: 5 minutes

---

### Why?
To allow for more accurate static asset testing

---