### PR TITLE
[QA-497] Fixing LoadProfile name in cri-lime/test.ts

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -65,7 +65,7 @@ const profiles: ProfileList = {
     ...createScenario('drivingLicence', LoadProfile.full, 55),
     ...createScenario('passport', LoadProfile.full, 55)
   },
-  extendedRampUp: {
+  rampOnly: {
     ...createScenario('passport', LoadProfile.rampOnly, 30)
   }
 }


### PR DESCRIPTION
## QA-497 <!--Jira Ticket Number-->

### What?
Fixes the new LoadProfile name in `cri-lime/test.ts` script 

#### Changes:
- changes the new LoadProfile name from extendedRampUp to rampOnly in the `cri-lime.test.ts` script. 

---

### Why?
To correctly execute a rampOnly test for passport CRI

---