### PR TITLE
[Qa-498] Correcting the groupMap name in ninoCheck scenario

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -116,7 +116,7 @@ export function ninoCheck(): void {
           headers: { Authorization: `Basic ${encodedCredentials}` }
         }
       }),
-    { isStatusCode200, ...pageContentCheck('national insurance number') }
+    { isStatusCode200, ...pageContentCheck('Enter your National Insurance number') }
   )
 
   sleepBetween(1, 3)

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -27,7 +27,7 @@ const profiles: ProfileList = {
 
 const loadProfile = selectProfile(profiles)
 const groupMap = {
-  ninoScenario1: [
+  ninoCheck: [
     'B02_Nino_01_EntryFromStub',
     'B02_Nino_02_AddUser',
     'B02_Nino_03_SearchNiNo',
@@ -80,7 +80,7 @@ const csvData1: Nino[] = new SharedArray('csvDataNino', () => {
 })
 
 export function ninoCheck(): void {
-  const groups = groupMap.ninoScenario1
+  const groups = groupMap.ninoCheck
   let res: Response
   const credentials = `${stubCreds.userName}:${stubCreds.password}`
   const encodedCredentials = encoding.b64encode(credentials)


### PR DESCRIPTION
## QA-498 <!--Jira Ticket Number-->

### What?
Corrects the `groupMap` name in the `ninoCheck` scenario

#### Changes:
- Changes the `groupMap` name from `ninoScenario1` to `ninoCheck`

---

### Why?
To accurately run a `ninoCheck` performance test

