### PR TITLE
[QA-499] Adding static asset testing to the Auth SignUp Journey

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -441,6 +441,7 @@ Resources:
               ACCOUNT_PHONE_OTP: "/perfTest/account/fixedPhoneOTP"
               ACCOUNT_RP_STUB: "/perfTest/account/authentication/rpStub"
               ACCOUNT_SIGNIN_URL: "/perfTest/account/accounts/signInUrl"
+              ACCOUNT_STAGING_URL: "/perfTest/account/authentication/baseUrl"
               DATA_BTM_SQS: "/perfTest/data/btm/perfSQS"
               DATA_BTM_SQS_PAYLOAD_EVENTS: "/perfTest/data/txma/SQSPayloadEvents"
               DATA_TXMA_SQS: "/perfTest/data/txma/perfSQS"


### PR DESCRIPTION
## QA-499 <!--Jira Ticket Number-->

### What?
Adds static asset testing the the Auth SignUp journey, and adds the new `rampOnly` LoadProfile. 

#### Changes:
- Adds the new `rampOnly` LoadProfile to Auth SignUp
- Adds a `http.batch()` of the static assets behind an `if` flag

---

### Why?
To run static asset testing on Auth SignUp 

