### PR TITLE
[QA-500] Link to ECS dashboard in Slack notifications

### DIFF
--- a/deploy/reporting/slack.sh
+++ b/deploy/reporting/slack.sh
@@ -36,7 +36,8 @@ case $1 in
 esac
 
 if $valid_args; then
-    dynatrace_url="${K6_DYNATRACE_URL}/#dashboard;gtf=${CODEBUILD_START_TIME}%20to%20${dashboard_end};id=${K6_DYNATRACE_DASHBOARD_ID};gf=all;es=CUSTOM_DIMENSION-build_id:${CODEBUILD_BUILD_NUMBER}/"
+    dynatrace_k6="${DYNATRACE_URL}/#dashboard;gtf=${CODEBUILD_START_TIME}%20to%20${dashboard_end};id=${DYNATRACE_K6_ID};gf=all;es=CUSTOM_DIMENSION-build_id:${CODEBUILD_BUILD_NUMBER}/"
+    dynatrace_ecs="${DYNATRACE_URL}/#dashboard;gtf=${CODEBUILD_START_TIME}%20to%20${dashboard_end};id=${DYNATRACE_ECS_ID};gf=all"
     message_id=$(curl https://www.slack.com/api/${api_command} \
             -X POST \
             -H "Authorization: Bearer ${SLACK_OAUTH_TOKEN}" \
@@ -83,7 +84,7 @@ if $valid_args; then
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "• <'"${dynatrace_url}"'|Dynatrace Dashboard>\n• <'"${CODEBUILD_BUILD_URL}"'|CodeBuild>'"${other_info}"'"
+              "text": "• <'"${dynatrace_k6}"'|Dynatrace k6>\n• <'"${dynatrace_ecs}"'|Dynatrace ECS>\n• <'"${CODEBUILD_BUILD_URL}"'|CodeBuild>'"${other_info}"'"
             }
           },
           {

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -418,12 +418,13 @@ Resources:
 
           env:
             variables:
-              WORK_DIR: /home/k6/scripts
-              REPORTING_DIR: /home/k6/reporting
-              OTEL_LOG: otel.log
+              DYNATRACE_ECS_ID: 9c9def17-d1aa-4f67-bf45-17320db60e10
+              DYNATRACE_K6_ID: 1e845440-d013-4472-9d65-2ea21a5cb41a
               JSON_RESULTS: results.gz
-              K6_DYNATRACE_DASHBOARD_ID: 1e845440-d013-4472-9d65-2ea21a5cb41a
+              OTEL_LOG: otel.log
+              REPORTING_DIR: /home/k6/reporting
               SLACK_NOTIFY_CHANNEL: C05J07H48UE
+              WORK_DIR: /home/k6/scripts
             parameter-store:
               ACCOUNT_APP_KEY: "/perfTest/account/accounts/appKey"
               ACCOUNT_APP_PASSWORD_NEW: "/perfTest/account/testUserNewPassword"
@@ -447,6 +448,8 @@ Resources:
               DATA_TXMA_SQS: "/perfTest/data/txma/perfSQS"
               DEMO_NODE_ENDPOINT: "/perfTest/demo/nodeEndpoint"
               DEMO_SAM_ENDPOINT: "/perfTest/demo/samEndpoint"
+              DYNATRACE_APITOKEN: "/perfTest/dynatraceApiToken"
+              DYNATRACE_URL: "/perfTest/dynatraceUrl"
               IDENTITY_ADDRESS_URL: "/perfTest/identity/orange/addressUrl"
               IDENTITY_BUILD_CORE_URL: "/perfTest/identity/build/coreUrl"
               IDENTITY_BUILD_ORCH_STUB_URL: "/perfTest/identity/build/orchStubUrl"
@@ -462,19 +465,17 @@ Resources:
               IDENTITY_FRAUD_URL: "/perfTest/identity/lime/fraudUrl"
               IDENTITY_KBV_ANSWERS: "/perfTest/identity/orange/kbvAnswers"
               IDENTITY_KBV_URL: "/perfTest/identity/orange/kbvUrl"
+              IDENTITY_KIWI_BAV_STUB_URL: "/perfTest/identity/kiwi/bav/stubUrl"
+              IDENTITY_KIWI_BAV_TARGET: "/perfTest/identity/kiwi/bav/target"
               IDENTITY_KIWI_CIC_STUB_URL: "/perfTest/identity/kiwi/cic/stubUrl"
               IDENTITY_KIWI_CIC_TARGET: "/perfTest/identity/kiwi/cic/target"
               IDENTITY_KIWI_F2F_STUB_URL: "/perfTest/identity/kiwi/f2f/stubUrl"
               IDENTITY_KIWI_F2F_TARGET: "/perfTest/identity/kiwi/f2f/target"
               IDENTITY_KIWI_STUB_SQS: "/perfTest/identity/kiwi/stubTxMAConsumer"
-              IDENTITY_KIWI_BAV_STUB_URL: "/perfTest/identity/kiwi/bav/stubUrl"
-              IDENTITY_KIWI_BAV_TARGET: "/perfTest/identity/kiwi/bav/target"
               IDENTITY_ORCH_STUB_PASSWORD: "/perfTest/identity/orchStubPassword"
               IDENTITY_ORCH_STUB_USERNAME: "/perfTest/identity/orchStubUsername"
               IDENTITY_PASSPORT_URL: "/perfTest/identity/lime/passportUrl"
               IDENTITY_SPOT_SQS: "/perfTest/identity/spot/SQS"
-              K6_DYNATRACE_APITOKEN: "/perfTest/dynatraceApiToken"
-              K6_DYNATRACE_URL: "/perfTest/dynatraceUrl"
               MOBILE_BUILD_BACKEND_URL: "/perfTest/mobile/build/backendUrl"
               MOBILE_BUILD_FRONTEND_URL: "/perfTest/mobile/build/frontendUrl"
               MOBILE_BUILD_TEST_CLIENT_URL: "/perfTest/mobile/build/testClientUrl"
@@ -486,7 +487,7 @@ Resources:
             pre_build:
               commands:
                 - |
-                  sed -e "s#{URL}#$K6_DYNATRACE_URL#" -e "s#{APITOKEN}#$K6_DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_NUMBER#" $OTEL_TEMPLATE > $OTEL_CONFIG
+                  sed -e "s#{URL}#$DYNATRACE_URL#" -e "s#{APITOKEN}#$DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_NUMBER#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > $OTEL_LOG 2>&1 &
                 - export EXECUTION_CREDENTIALS=$(aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER)
                 - source ${REPORTING_DIR}/slack.sh POST


### PR DESCRIPTION
## QA-500

### What?
Adds a link to the ECS Dynatrace dashboard in the Slack notifications

#### Changes:
- `deploy/template.yaml`:
  - Adds `DYNATRACE_ECS_ID` dashboard ID variables
  - Renamed some variables with `K6` in the name which were not related to K6
  - Sort variables alphabetically
- `deploy/reporting/slack.sh`:
  - Add extra bullet point in message with a link to the ECS dashboard

---

### Why?
Make it easier to see relevant information for Front End monitoring

---

### Related:
- #236 
