### PR TITLE
[QA-501] Specify System Tags in environment variable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[dockerfile]": {
+    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
   }
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,7 +18,7 @@ FROM golang:1.22-alpine AS k6-build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@v0.10.0
-RUN xk6 build v0.49.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --output /k6
+RUN xk6 build v0.51.0 --with github.com/LeonAdato/xk6-output-statsd@v0.1.1 --output /k6
 
 # -----------------------
 # OpenTelemetry Collector
@@ -37,6 +37,7 @@ ENV K6_STATSD_BUFFER_SIZE=100
 ENV K6_STATSD_PUSH_INTERVAL=100ms
 ENV K6_SUMMARY_TIME_UNIT=ms
 ENV K6_SUMMARY_TREND_STATS=avg,min,med,p(95),p(99),max
+ENV K6_SYSTEM_TAGS=status,method,group,check,error,scenario
 ENV K6_WEB_DASHBOARD=true
 ENV K6_WEB_DASHBOARD_EXPORT=report.html
 ENV OTEL_METRIC_EXPORT_INTERVAL=100

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -493,7 +493,7 @@ Resources:
             build:
               commands:
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS --system-tags=status,method,group,check,error,scenario
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS
             post_build:
               commands:
                 - echo "Uploading test results to s3"


### PR DESCRIPTION
## QA-501 

### What?
After a fix in k6 v0.51 we can now use an environment variable rather than a command line flag to specify system tags

#### Changes:
- `.vscode/settings.json`: Added Docker formatter setting
- `deploy/Dockerfile`: Updated xk6 build command to v0.51 and added the `K6_SYSTEM_TAGS` environment variable
- `deploy/template.yaml`: Removed `--system-tags` CLI flag

---

### Why?
Easier to see config when specified as environment variables

---

### Related:
- #550