### PR TITLE
[QA-503] Reduce `full` load profile steady state duration to 15m

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -111,7 +111,7 @@ function createStages(type: LoadProfile, target: number): Stage[] {
     case LoadProfile.full:
       return [
         { target, duration: '15m' }, // Ramps up to target throughput in 15 minutes
-        { target, duration: '30m' }, // Maintain steady state at target throughput for 30 minutes
+        { target, duration: '15m' }, // Maintain steady state at target throughput for 15 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ]
     case LoadProfile.deployment:


### PR DESCRIPTION
## QA-503

### What?
Reduces the steady state duration of the `LoadProfile.full` load profile from 30 minutes to 15 minutes

#### Changes:
- `deploy/scripts/src/common/utils/config/load-profiles.ts`: `LoadProfile.full` steady state duration from `30m` to `15m`

---

### Why?
The last 15 minutes of steady state is not currently providing us with any more information that we aren't already capturing in the first 15 minutes. This change will reduce request volume and hence cloud costs and log volumes by roughly 40%.

---

### Related:
- #532 
