### PR TITLE
[QA-504] Pre-commit evergreening and beautysh fix

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup python v3.11
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.11"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,4 @@ repos:
     rev: "v6.2.1"
     hooks:
       - id: beautysh
+        language_version: "3.11"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,55 +2,55 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: detect-private-key
       - id: detect-aws-credentials
-        args: ['--allow-missing-credentials']
+        args: ["--allow-missing-credentials"]
       - id: mixed-line-ending
       - id: trailing-whitespace
       - id: check-merge-conflict
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+        args: ["--baseline", ".secrets.baseline"]
         exclude: .*/keys/.*|
-              (
-                     ^package-lock.json$|
-                     ^Pipfile|
-                     ^pyproject.toml
-              )
+          (
+          ^package-lock.json$|
+          ^Pipfile|
+          ^pyproject.toml
+          )
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
       - id: remove-tabs
       - id: remove-crlf
   - repo: https://github.com/mattlqx/pre-commit-search-and-replace
-    rev: v1.0.5
+    rev: v1.1.2
     hooks:
       - id: search-and-replace
         stages: [commit-msg, commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.11.0
+    rev: v9.16.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
-        args: ['--verbose']
+        args: ["--verbose"]
         verbose: true
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.85.0
+    rev: v1.2.5a9
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$
-        args: ['--ignore-checks', 'W3045']
+        args: ["--ignore-checks", "W3045"]
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.3'
+    rev: "3.2.92"
     hooks:
       - id: checkov
-        args: ['--framework', 'cloudformation', '--quiet']
+        args: ["--framework", "cloudformation", "--quiet"]
         files: ^(.*/)?template\.(yml|yaml)$
   - repo: https://github.com/lovesegfault/beautysh
-    rev: 'v6.2.1'
+    rev: "v6.2.1"
     hooks:
       - id: beautysh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,4 +54,4 @@ repos:
     rev: "v6.2.1"
     hooks:
       - id: beautysh
-        language_version: "3.11"
+        language_version: "python3.11"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args: ["--verbose"]
         verbose: true
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v1.2.5a9
+    rev: v0.87.2
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$


### PR DESCRIPTION
## QA-504

### What?
Evergreening pre-commit versions with `pre-commit autoupdate` and pinning the python version in the beautysh pre-commit virtual environment to `v3.11`

#### Changes:
- `.pre-commit-config.yaml`:
  - Linting changes
  - [pre-commit/pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.6.0) `v4.5.0` ↦ `v4.6.0`
  - [Yelp/detect-secrets](https://github.com/Yelp/detect-secrets/releases/tag/v1.5.0) `v1.4.0` ↦ `v1.5.0`
  - [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks/releases/tag/v1.5.5) `v1.5.4` ↦ `v1.5.5`
  - [mattlqx/pre-commit-search-and-replace](https://github.com/mattlqx/pre-commit-search-and-replace/releases/tag/v1.1.2) `v1.0.5` ↦ `v1.1.2`
  - [alessandrojcm/commitlint-pre-commit-hook](https://github.com/alessandrojcm/commitlint-pre-commit-hook/releases/tag/v9.16.0) `v9.11.0` ↦ `v9.16.0`
  - [aws-cloudformation/cfn-python-lint](https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.87.2) `v0.85.0` ↦ `v0.87.2`
  - [bridgecrewio/checkov.git](https://github.com/bridgecrewio/checkov/releases/tag/3.2.91) `3.2.3` ↦ `3.2.92`
  - Pin python version for `beautysh` virtual environment to `v3.11`
- `.github/workflows/pre-merge-checks.yml`:
  - Add a step to setup python v3.11 to the pre-merge check github action

---

### Why?
Evergreening for security and pinning the python version to fix an incompatibility with `beautysh` with python version `v3.12+`

---

### Related:
- #13 
