### PR TITLE
[QA-512] changing TxMA sendSingleEvent from AUTH_LOG_IN_SUCCESS to AUTH_AUTHOR…

### DIFF
--- a/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
@@ -16,6 +16,24 @@ export interface AuthLogInSuccess {
   }
 }
 
+export interface AuthAuthorisationInitiated {
+  event_id: string
+  event_name: string
+  client_id: string
+  component_id: string
+  timestamp: number
+  event_timestamp_ms: number
+  user: {
+    user_id: string
+    govuk_signin_journey_id: string
+    ip_address: string
+    session_id: string
+    email: string
+    persistent_session_id: string
+    phone: string
+  }
+}
+
 export interface AuthCreateAccount {
   event_id: string
   event_name: string

--- a/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
@@ -17,20 +17,22 @@ export interface AuthLogInSuccess {
 }
 
 export interface AuthAuthorisationInitiated {
-  event_id: string
   event_name: string
+  event_id: string
   client_id: string
   component_id: string
   timestamp: number
   event_timestamp_ms: number
+  event_timestamp_ms_formatted: string
+  timestamp_formatted: string
+  extensions: {
+    'client-name': string
+  }
   user: {
-    user_id: string
     govuk_signin_journey_id: string
     ip_address: string
     session_id: string
-    email: string
     persistent_session_id: string
-    phone: string
   }
 }
 

--- a/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
@@ -29,28 +29,26 @@ export function generateAuthLogInSuccess(userID: string, emailID: string, journe
   }
 }
 
-export function generateAuthAuthorisationInitiated(
-  userID: string,
-  emailID: string,
-  journeyID: string
-): AuthAuthorisationInitiated {
-  const eventID = `perfAuthInitiated${uuidv4()}`
-  const eventTime = Math.floor(Date.now() / 1000)
+export function generateAuthAuthorisationInitiated(journeyID: string): AuthAuthorisationInitiated {
+  const eventID = `perfAuthInitiate${uuidv4()}`
+  const eventTime = new Date().toISOString()
   return {
+    client_id: 'testclientId',
+    component_id: 'https://oidc.account.gov.uk/',
     event_id: eventID,
     event_name: 'AUTH_AUTHORISATION_INITIATED',
-    client_id: 'e2eTestClientId',
-    component_id: 'SharedSignalPerfTest',
-    timestamp: eventTime,
-    event_timestamp_ms: eventTime,
+    event_timestamp_ms: Math.floor(Date.now()),
+    event_timestamp_ms_formatted: eventTime,
+    extensions: {
+      'client-name': 'testtest'
+    },
+    timestamp: Math.floor(Date.now() / 1000),
+    timestamp_formatted: eventTime,
     user: {
-      user_id: userID,
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
-      session_id: uuidv4(),
-      email: emailID,
+      ip_address: '01.01.01.001',
       persistent_session_id: uuidv4(),
-      phone: '07777777777'
+      session_id: uuidv4()
     }
   }
 }

--- a/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
@@ -1,5 +1,11 @@
 import { uuidv4 } from '../../common/utils/jslib/index'
-import { AuthLogInSuccess, AuthCreateAccount, AuthAuthorisationReqParsed, DcmawAbortWeb } from './txmaReqFormat'
+import {
+  AuthLogInSuccess,
+  AuthCreateAccount,
+  AuthAuthorisationReqParsed,
+  DcmawAbortWeb,
+  AuthAuthorisationInitiated
+} from './txmaReqFormat'
 
 export function generateAuthLogInSuccess(userID: string, emailID: string, journeyID: string): AuthLogInSuccess {
   const eventID = `perfAuthLogin${uuidv4()}`
@@ -7,6 +13,32 @@ export function generateAuthLogInSuccess(userID: string, emailID: string, journe
   return {
     event_id: eventID,
     event_name: 'AUTH_LOG_IN_SUCCESS',
+    client_id: 'e2eTestClientId',
+    component_id: 'SharedSignalPerfTest',
+    timestamp: eventTime,
+    event_timestamp_ms: eventTime,
+    user: {
+      user_id: userID,
+      govuk_signin_journey_id: journeyID,
+      ip_address: '1.2.3.4',
+      session_id: uuidv4(),
+      email: emailID,
+      persistent_session_id: uuidv4(),
+      phone: '07777777777'
+    }
+  }
+}
+
+export function generateAuthAuthorisationInitiated(
+  userID: string,
+  emailID: string,
+  journeyID: string
+): AuthAuthorisationInitiated {
+  const eventID = `perfAuthInitiated${uuidv4()}`
+  const eventTime = Math.floor(Date.now() / 1000)
+  return {
+    event_id: eventID,
+    event_name: 'AUTH_AUTHORISATION_INITIATED',
     client_id: 'e2eTestClientId',
     component_id: 'SharedSignalPerfTest',
     timestamp: eventTime,

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -15,7 +15,8 @@ import {
   generateAuthLogInSuccess,
   generateAuthCreateAccount,
   generateAuthReqParsed,
-  generateDcmawAbortWeb
+  generateDcmawAbortWeb,
+  generateAuthAuthorisationInitiated
 } from './requestGenerator/txmaReqGen'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 
@@ -71,8 +72,10 @@ export function sendSingleEvent(): void {
   const emailID = `perfEmailSE${uuidv4()}@digital.cabinet-office.gov.uk`
   const journeyID = `perfJourney${uuidv4()}`
   iterationsStarted.add(1)
-  const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(userID, emailID, journeyID))
-  sqs.sendMessage(env.sqs_queue, authLogInSuccessPayload)
+  const authAuthorisationInitiatedPayload = JSON.stringify(
+    generateAuthAuthorisationInitiated(userID, emailID, journeyID)
+  )
+  sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -68,13 +68,9 @@ const awsConfig = new AWSConfig({
 const sqs = new SQSClient(awsConfig)
 
 export function sendSingleEvent(): void {
-  const userID = `perfUserSE${uuidv4()}`
-  const emailID = `perfEmailSE${uuidv4()}@digital.cabinet-office.gov.uk`
   const journeyID = `perfJourney${uuidv4()}`
   iterationsStarted.add(1)
-  const authAuthorisationInitiatedPayload = JSON.stringify(
-    generateAuthAuthorisationInitiated(userID, emailID, journeyID)
-  )
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
   iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-512 <!--Jira Ticket Number-->

### What?
changes the TxMA `sendSingleEvent` scenario from `AUTH_LOG_IN_SUCCESS` to `AUTH_AUTHORISATION_INITIATED`.

#### Changes:
- Add the `AUTH_AUTHORISATION_INITIATED` interface to `txma/requestgenerator/txmareqformat.ts`
- add the request generator to `txma/requestgenerator/txmareqgen.ts`
- update the `sendSingleEvent` scenario to call the `generateAuthAuthorisationInitiated()` function.

---

### Why?
To run a successful TxMA `sendSingleEvent` performance test 
