### PR TITLE
[QA-513]: Update permissions for PerformanceTesterRole to allow AssumeRole

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -171,7 +171,7 @@ Resources:
               ArnLike:
                 "aws:PrincipalArn":
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-admin_*" # Prod Admin Control Tower Role
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-poweruser_*" # Prod Power User Control Tower Role
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_AWSPowerUserAccess_*" # Prod Power User Control Tower Role
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-testers_*" # Prod Tester Control Tower Role
       PermissionsBoundary:
         !If [


### PR DESCRIPTION
## QA-513 <!--Jira Ticket Number-->

### What?
Update permissions for PerformanceTesterRole to allow AssumeRole

#### Changes:
- Updated the condition in PerformanceTesterRole to reflect correct prefix of power user role.

---

### Why?
Perf team are not able to assume Performance Tester role due to the condition. This PR should fix this issue.