### PR TITLE
[QA-517]: Adhoc load profile added for passport scenario in IPV core

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -49,6 +49,21 @@ const profiles: ProfileList = {
       maxDuration: '120m',
       exec: 'passport'
     }
+  },
+  adhocLoadTest: {
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1000,
+      maxVUs: 3000,
+      stages: [
+        { target: 100, duration: '15m' }, // Ramp up to target throughput over 15 minutes
+        { target: 100, duration: '30m' }, // Maintain steady state at target throughput for 30 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ],
+      exec: 'passport'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-517 <!--Jira Ticket Number-->

### What?
Adhoc load profile added for passport scenario in IPV core

#### Changes:
- Adhoc load profile added for passport scenario in IPV core with 30 minutes steady state.

---

### Why?
Previous IPV core tests have shown FE scaling completion in 20-25 minutes thereby impacting the results of the first half of the steady state. The steady state is being increased to maintain consistency in this regression test with previous tests.