### PR TITLE
[QA-520] Changing the Auth signIn load profile to 500j/s

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -31,7 +31,7 @@ const profiles: ProfileList = {
     ...createScenario('signUp', LoadProfile.short, 10)
   },
   load: {
-    ...createScenario('signIn', LoadProfile.full, 1000)
+    ...createScenario('signIn', LoadProfile.full, 500)
   },
   stress: {
     ...createScenario('signIn', LoadProfile.full, 2000),


### PR DESCRIPTION
## QA-520 <!--Jira Ticket Number-->

### What?
Changes the `signIn` `load` profile in `authentication/test.ts` to 500 iterations per second. 

#### Changes:
Changes the `signIn` `load` profile in `authentication/test.ts` to 500 iterations per second from 100j/s.

---

### Why?
To run a regression test for authentication at 500 j/s

