### PR TITLE
DCMAW-8764: Updates mobile fe test following changes to routing and content

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -12,10 +12,8 @@ import {
   postSelectSmartphone,
   postValidPassport,
   postBiometricChip,
-  postFlashingWarning,
   postIphoneModel,
   getRedirect,
-  postWorkingCamera,
   postIdCheckApp,
   getAbortCommand,
   startJourney,
@@ -126,10 +124,6 @@ export function mamIphonePassport(): void {
   postIphoneModel()
   simulateUserWait()
   postIdCheckApp()
-  simulateUserWait()
-  postWorkingCamera()
-  simulateUserWait()
-  postFlashingWarning()
   simulateUserWait()
   if (Math.random() <= 0.8) {
     // Approximately 80% of users complete journey successfully

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -132,7 +132,7 @@ export function postIdCheckApp(): void {
     timeRequest(() => http.post(buildFrontendUrl('/idCheckApp'), {}, { tags: { name: 'POST /idCheckApp' } }), {
       isStatusCode200,
       ...validatePageRedirect('/downloadApp'),
-      ...pageContentCheck('Download the GOV.UK ID Check app')
+      ...pageContentCheck('Download or open the GOV.UK ID Check app')
     })
   )
 }

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -131,45 +131,9 @@ export function postIdCheckApp(): void {
   group('POST /idCheckApp', () =>
     timeRequest(() => http.post(buildFrontendUrl('/idCheckApp'), {}, { tags: { name: 'POST /idCheckApp' } }), {
       isStatusCode200,
-      ...validatePageRedirect('/workingCamera'),
-      ...pageContentCheck('Does your smartphone have a working camera?')
+      ...validatePageRedirect('/downloadApp'),
+      ...pageContentCheck('Download the GOV.UK ID Check app')
     })
-  )
-}
-
-export function postWorkingCamera(): void {
-  group('POST /workingCamera', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/workingCamera'),
-          { 'working-camera-choice': 'yes' },
-          { tags: { name: 'POST /workingCamera' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/flashingWarning'),
-        ...pageContentCheck('The app uses flashing colours. Do you want to continue?')
-      }
-    )
-  )
-}
-
-export function postFlashingWarning(): void {
-  group('POST /flashingWarning', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/flashingWarning'),
-          { 'flashing-colours-choice': 'yes' },
-          { tags: { name: 'POST /flashingWarning' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/downloadApp'),
-        ...pageContentCheck('Download the GOV.UK ID Check app')
-      }
-    )
   )
 }
 


### PR DESCRIPTION
## DCMAW-8764<!--Jira Ticket Number-->

### What?
Updates a response assertion using the page content within the mobile/frontend-e2e.test.ts script
Removes requests to /flashingColours and /workingCamera

### Why?
Aligning test script with recent changes to the user journey

### Evidence
Passing when running locally:

<img width="1344" alt="image" src="https://github.com/govuk-one-login/performance-testing/assets/115020902/4fdc5e19-6abf-4e59-b64d-32050970c6a2">

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
