### PR TITLE
[QA-241] Use local docker image for CI unit tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+env:
+  TEST_TAG: user/app:test
+
 defaults:
   run:
     shell: bash
@@ -41,10 +44,17 @@ jobs:
       - name: Transpile TypeScript test scripts
         run: npm start
 
-      - name: Run local k6 unit test script
-        uses: grafana/k6-action@e4714b734f2b0afaabeb7b4a69142745548ab9ec # v0.3.1
+      - name: Build Docker Image
+        uses: docker/build-push-action@31159d49c0d4756269a0940a750801a1ea5d7003 #v6.1.0
         with:
-          filename: ./deploy/scripts/dist/common/unit-tests.js
+          load: true
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Run k6 unit test script in image
+        run: |
+          docker run --rm -it ${{ env.TEST_TAG }}
+          k6 run scripts/common/unit-tests.js
+        working-directory: ./deploy
 
       - run: git fetch origin main
       - name: Run pre-commit action

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -16,8 +16,8 @@ defaults:
     working-directory: ./deploy/scripts
 
 jobs:
-  lint:
-    name: Run linting
+  k6_unit_test:
+    name: Run linting and unit tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run k6 unit test script in image
         run: |
-          docker run --rm -it ${{ env.TEST_TAG }}
+          docker run --rm -i ${{ env.TEST_TAG }}
           k6 run scripts/common/unit-tests.js
         working-directory: ${{ env.DOCKER_PATH }}
 

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  DOCKER_PATH: ./deploy
   TEST_TAG: user/app:test
 
 defaults:
@@ -47,6 +48,7 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@31159d49c0d4756269a0940a750801a1ea5d7003 #v6.1.0
         with:
+          context: ${{ env.DOCKER_PATH }}
           load: true
           tags: ${{ env.TEST_TAG }}
 
@@ -54,7 +56,7 @@ jobs:
         run: |
           docker run --rm -it ${{ env.TEST_TAG }}
           k6 run scripts/common/unit-tests.js
-        working-directory: ./deploy
+        working-directory: ${{ env.DOCKER_PATH }}
 
       - run: git fetch origin main
       - name: Run pre-commit action

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -16,8 +16,8 @@ defaults:
     working-directory: ./deploy/scripts
 
 jobs:
-  k6_unit_test:
-    name: Run linting and unit tests
+  lint:
+    name: Run linting
     runs-on: ubuntu-latest
 
     steps:
@@ -54,8 +54,7 @@ jobs:
 
       - name: Run k6 unit test script in image
         run: |
-          docker run --rm -i ${{ env.TEST_TAG }}
-          k6 run scripts/common/unit-tests.js
+          docker run --rm ${{ env.TEST_TAG }} -c 'k6 run scripts/common/unit-tests.js'
         working-directory: ${{ env.DOCKER_PATH }}
 
       - run: git fetch origin main


### PR DESCRIPTION
## QA-241

### What?
Updates the pre-merge checks github action to use the docker image for running the k6 unit test script, rather than using an external action

#### Changes:
- `.github/workflows/pre-merge-checks.yml`: Replaced the `grafana/k6-action` step with a `docker build` then a `docker run` step

---

### Why?
This adds additional checks to ensure that the Docker image can be built and is working correctly and that the k6 version in this image is working correctly.

