### PR TITLE
[QA-528} Correcting the environment variable name for OTG 

### DIFF
--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -43,7 +43,7 @@ if (!validEnvironments.includes(environment))
   throw new Error(`Environment '${environment}' not in [${validEnvironments.toString()}]`)
 
 const env = {
-  otgURL: getEnv(`IDENTITY_ORANGE_${environment}_OTG_URL`)
+  otgURL: getEnv(`IDENTITY_${environment}_OTG_URL`)
 }
 
 export function otg(): void {


### PR DESCRIPTION
## QA-528 <!--Jira Ticket Number-->

### What?
Corrects the env variable name in the OTG script

#### Changes:
-changes the env variable name from IDENTITY_ORANGE_BUILD_OTG_URL to IDENTITY_BUILD_OTG_URL 

---

### Why?
To run a successful OTG perf test 

