### PR TITLE
[QA-241] Add cache to docker build

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 #v6.2.0
         with:
+          cache-from: gha
+          cache-to: gha
           context: ${{ env.DOCKER_PATH }}
           load: true
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 #v6.2.0
         with:
-          cache-from: gha
-          cache-to: gha
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: ${{ env.DOCKER_PATH }}
           load: true
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Transpile TypeScript test scripts
         run: npm start
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb #v3.3.0
+
       - name: Build Docker Image
         uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 #v6.2.0
         with:


### PR DESCRIPTION
## QA-241

### What?
Add Github Actions cache to docker build

#### Changes:
- `.github/workflows/pre-merge-checks.yml`: Add a `docker buildx` setup step and add settings to use the GHA cache

---

### Why?
To speed up CI checks

---

### Related:
- #713 
