### PR TITLE
[QA-531] Adding a stress test load profile for OTG

### DIFF
--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -19,6 +19,9 @@ const profiles: ProfileList = {
   },
   load: {
     ...createScenario('otg', LoadProfile.full, 10)
+  },
+  stress: {
+    ...createScenario('otg', LoadProfile.full, 44)
   }
 }
 


### PR DESCRIPTION
## QA-531 <!--Jira Ticket Number-->

### What?
Adds an additional load profile for stress testing of OTG

#### Changes:
- Adds a 'stress' load profile at a target volume of 44 iterations per second. 

---

### Why?
To run a stress test for OTG at a target of 44 iterations per second. 

