### PR TITLE
[QA-537] Updating Auth load profile to 20% of NFR volume

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -26,9 +26,9 @@ const profiles: ProfileList = {
     ...createScenario('signIn', LoadProfile.short, 30),
     ...createScenario('signUp', LoadProfile.short, 30)
   },
-  load10: {
-    ...createScenario('signIn', LoadProfile.short, 190),
-    ...createScenario('signUp', LoadProfile.short, 10)
+  load20: {
+    ...createScenario('signIn', LoadProfile.short, 380),
+    ...createScenario('signUp', LoadProfile.short, 20)
   },
   load: {
     ...createScenario('signIn', LoadProfile.full, 500)


### PR DESCRIPTION
## QA-537 <!--Jira Ticket Number-->

### What?
Updating the Auth load profile to 20% of the NFR volumes

#### Changes:
Creates a `load20` load profile for Auth with a target volume of 20j/s for `signUp` and 380j/s for `signIn`. 
---

### Why?
To run a combined load test for Auth at a target volume of 20% of the NFR volumes. 

