### PR TITLE
[QA-538] Updating the Auth load20 profile to full

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -27,8 +27,8 @@ const profiles: ProfileList = {
     ...createScenario('signUp', LoadProfile.short, 30)
   },
   load20: {
-    ...createScenario('signIn', LoadProfile.short, 380),
-    ...createScenario('signUp', LoadProfile.short, 20)
+    ...createScenario('signIn', LoadProfile.full, 380),
+    ...createScenario('signUp', LoadProfile.full, 20)
   },
   load: {
     ...createScenario('signIn', LoadProfile.full, 500)


### PR DESCRIPTION
## QA-538 <!--Jira Ticket Number-->

### What?
Updated the Auth `load20` profile to a full profile not short 

#### Changes:
- Updates the `load20` profile to `LoadProfile.full`

---

### Why?
To run a test for Auth at 20% NFR volume for a full test duration
