### PR TITLE
[QA-543] Add github npm package registry

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  packages: read
+
 env:
   DOCKER_PATH: ./deploy
   TEST_TAG: user/app:test
@@ -41,6 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Run linting checks
         run: npm run lint

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: "deploy/scripts/package-lock.json"
           registry-url: "https://npm.pkg.github.com"
 
       - name: Setup python v3.11

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
           node-version: 20
+          cache: npm
+          registry-url: "https://npm.pkg.github.com"
 
       - name: Setup python v3.11
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
           node-version: 20
+          cache: npm
+          registry-url: "https://npm.pkg.github.com"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -14,6 +14,7 @@ defaults:
 
 permissions:
   contents: read
+  packages: read
   pages: write
   id-token: write
 
@@ -34,6 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Create TypeDoc documentation
         run: npx typedoc ./src/common/utils/**/*.ts

--- a/.github/workflows/typedoc-publish.yml
+++ b/.github/workflows/typedoc-publish.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: "deploy/scripts/package-lock.json"
           registry-url: "https://npm.pkg.github.com"
 
       - name: Install dependencies


### PR DESCRIPTION
## QA-543

### What?
Add github npm package registry

#### Changes:
- Add github registry to node setup for github workflows

---

### Why?
To enable use of github npm packages
