### PR TITLE
QA-535 Increase stub and lambda timeout to 30 to allow orchestration a chance to succeed

### DIFF
--- a/koa-stub/src/utils/onelogin.util.js
+++ b/koa-stub/src/utils/onelogin.util.js
@@ -1,7 +1,7 @@
 const { Issuer, custom } = require("openid-client");
 
 custom.setHttpOptionsDefaults({
-  timeout: 7000,
+  timeout: 30000, // Longer than API Gateway
 });
 
 async function setupClient() {

--- a/koa-stub/template.yaml
+++ b/koa-stub/template.yaml
@@ -41,7 +41,7 @@ Globals:
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
-    Timeout: 10
+    Timeout: 30
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary


### PR DESCRIPTION
## QA-X535 <!--Jira Ticket Number-->

### What?
Changes stub lambda timeout and oidc timeouts to 30s.

#### Changes:
- Template change to lambda
- Client change to oidc lib in app


### Why?
Gives orchestration a chance to succeed, even if sub-optimal.

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
