### PR TITLE
[QA-546]: Reduce steady state duration of the IPV core adhoc tests in dev

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -61,7 +61,7 @@ const profiles: ProfileList = {
       maxVUs: 3000,
       stages: [
         { target: 100, duration: '15m' }, // Ramp up to target throughput over 15 minutes
-        { target: 100, duration: '30m' }, // Maintain steady state at target throughput for 30 minutes
+        { target: 100, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ],
       exec: 'passport'


### PR DESCRIPTION
## QA-546 <!--Jira Ticket Number-->

### What?
Reduce steady state duration of the IPV core adhoc tests in dev

#### Changes:
- Reduce steady state duration of the IPV core adhoc tests to 5 minutes for testing in dev environment

---

### Why?
To run a smaller load test in dev environment 
