### PR TITLE
[FPAD-3128] Reduce number of calls to Cognito

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @govuk-one-login/kiwi-devs
 /deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @govuk-one-login/cri-lime-team
 /deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @govuk-one-login/cri-orange-team
+/deploy/scripts/src/fraud @govuk-one-login/performance-testers @govuk-one-login/fraud-platform-team
 /deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @govuk-one-login/core-team
 /deploy/scripts/src/mobile @govuk-one-login/performance-testers @govuk-one-login/mobile-id-check
 /deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/spot-team

--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -28,6 +28,18 @@ const profiles: ProfileList = {
 
 const loadProfile = selectProfile(profiles)
 
+const env = {
+  cognitoURL: getEnv('FRAUD_COGNITO_URL'),
+  clientId: getEnv('FRAUD_CLIENT_ID'),
+  clientSecret: getEnv('FRAUD_CLIENT_SECRET'),
+  ssfInboundUrl: getEnv('FRAUD_SSF_INBOUND_URL'),
+  fraudPayload: getEnv('FRAUD_PAYLOAD')
+}
+
+const groupMap = {
+  fraud: ['B01_fraud_01_GenerateAccessToken', 'B01_fraud_02_SendSignedEventToSSF']
+} as const
+
 export const options: Options = {
   scenarios: loadProfile.scenarios,
   thresholds: {
@@ -69,18 +81,6 @@ export function setup(): RefinedParams<ResponseType> {
     }
   }
 }
-
-const env = {
-  cognitoURL: getEnv('FRAUD_COGNITO_URL'),
-  clientId: getEnv('FRAUD_CLIENT_ID'),
-  clientSecret: getEnv('FRAUD_CLIENT_SECRET'),
-  ssfInboundUrl: getEnv('FRAUD_SSF_INBOUND_URL'),
-  fraudPayload: getEnv('FRAUD_PAYLOAD')
-}
-
-const groupMap = {
-  fraud: ['B01_fraud_01_GenerateAccessToken', 'B01_fraud_02_SendSignedEventToSSF']
-} as const
 
 export function fraud(data: RefinedParams<ResponseType>): void {
   const groups = groupMap.fraud


### PR DESCRIPTION
## FPAD-3128

### What?
Reduces the volumes of calls to AWS Cognito by only calling cognito once at the beggining of the test

#### Changes:
- `deploy/scripts/src/fraud/test.ts`: Moved cognito step to `setup` function

---

### Why?
To better simulate real world behaviour

---

### Related:
- #693 
