### PR TITLE
[QA-552] Add Fraud SSF team to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @govuk-one-login/kiwi-devs
 /deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @govuk-one-login/cri-lime-team
 /deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @govuk-one-login/cri-orange-team
-/deploy/scripts/src/fraud @govuk-one-login/performance-testers @govuk-one-login/fraud-platform-team
+/deploy/scripts/src/fraud @govuk-one-login/performance-testers @govuk-one-login/fraud-ssf-team
 /deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @govuk-one-login/core-team
 /deploy/scripts/src/mobile @govuk-one-login/performance-testers @govuk-one-login/mobile-id-check
 /deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/spot-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /deploy/scripts/src/cri-kiwi @govuk-one-login/performance-testers @govuk-one-login/kiwi-devs
 /deploy/scripts/src/cri-lime @govuk-one-login/performance-testers @govuk-one-login/cri-lime-team
 /deploy/scripts/src/cri-orange @govuk-one-login/performance-testers @govuk-one-login/cri-orange-team
+/deploy/scripts/src/fraud @govuk-one-login/performance-testers @govuk-one-login/fraud-platform-team
 /deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @govuk-one-login/core-team
 /deploy/scripts/src/mobile @govuk-one-login/performance-testers @govuk-one-login/mobile-id-check
 /deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/spot-team


### PR DESCRIPTION
## QA-552

### What?
Adds `fraud-ssf-team` to `fraud` test script directory

#### Changes:
- `.github/CODEOWNERS`: Add `@govuk-one-login/fraud-ssf-team` team to `/deploy/scripts/src/fraud`

---

### Why?
Allow teams to manage own test scripts
