### PR TITLE
[FPAD-3128] Cognito debugging

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -13,7 +13,7 @@ import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assert
 import { getEnv } from '../common/utils/config/environment-variables'
 import { type Response } from 'k6/http'
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { check } from 'k6'
+import { check, fail } from 'k6'
 
 const profiles: ProfileList = {
   smoke: {
@@ -64,7 +64,10 @@ export function setup(): RefinedParams<ResponseType> {
   )
   console.log('Cognito status code:', res.status, res.status_text)
   console.log('Cognito response:', res.body)
-  check(res, { isStatusCode200, ...pageContentCheck('token') })
+  const ok = check(res, { isStatusCode200, ...pageContentCheck('token') })
+  if (!ok) {
+    fail('Failed to get token from Cognito')
+  }
   const accessToken = getAccessToken(res)
   return {
     headers: {

--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -13,6 +13,7 @@ import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assert
 import { getEnv } from '../common/utils/config/environment-variables'
 import { type Response } from 'k6/http'
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
+import { check } from 'k6'
 
 const profiles: ProfileList = {
   smoke: {
@@ -36,10 +37,6 @@ const env = {
   fraudPayload: getEnv('FRAUD_PAYLOAD')
 }
 
-const groupMap = {
-  fraud: ['B01_fraud_01_GenerateAccessToken', 'B01_fraud_02_SendSignedEventToSSF']
-} as const
-
 export const options: Options = {
   scenarios: loadProfile.scenarios,
   thresholds: {
@@ -51,29 +48,23 @@ export const options: Options = {
 export function setup(): RefinedParams<ResponseType> {
   describeProfile(loadProfile)
 
-  const groups = groupMap.fraud
-  const options = {
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+  const res: Response = http.post(
+    env.cognitoURL + '/oauth2/token',
+    {
+      grant_type: 'client_credentials',
+      scope: `messages/write`,
+      client_id: env.clientId,
+      client_secret: env.clientSecret
+    },
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
     }
-  }
-  // B01_fraud_01_GenerateAccessToken
-  const res: Response = timeGroup(
-    groups[0],
-    () =>
-      http.post(
-        env.cognitoURL + '/oauth2/token',
-        {
-          grant_type: 'client_credentials',
-          scope: `messages/write`,
-          client_id: env.clientId,
-          client_secret: env.clientSecret
-        },
-        options
-      ),
-    { isStatusCode200, ...pageContentCheck('token') }
   )
-
+  console.log('Cognito status code:', res.status, res.status_text)
+  console.log('Cognito response:', res.body)
+  check(res, { isStatusCode200, ...pageContentCheck('token') })
   const accessToken = getAccessToken(res)
   return {
     headers: {
@@ -83,11 +74,8 @@ export function setup(): RefinedParams<ResponseType> {
 }
 
 export function fraud(data: RefinedParams<ResponseType>): void {
-  const groups = groupMap.fraud
   iterationsStarted.add(1)
-
-  // B01_fraud_02_SendSignedEventToSSF
-  timeGroup(groups[1], () => http.post(env.ssfInboundUrl, env.fraudPayload, data), {
+  timeGroup('B01_fraud_01_SendSignedEventToSSF', () => http.post(env.ssfInboundUrl, env.fraudPayload, data), {
     isStatusCode202: r => r.status === 202,
     ...pageContentCheck('Id')
   })


### PR DESCRIPTION
## FPAD-3128

### What?
Add debug logging to initial cognito call

#### Changes:
- `deploy/scripts/src/fraud/test.ts`:
  - Removed unused `timeGroup` call
  - Added `console.log` debug statements for Cognito response

---

### Why?
To debug Cognito errors

---

### Related:
- #788 
