### PR TITLE
[QA-550] Add debug logging to OLH changeEmail

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -227,7 +227,7 @@ export function changeEmail(): void {
     () => {
       const r = http.get(env.envURL + '/security')
       if (!pageContentCheck('Delete your GOV.UK One Login').validatePageContent(r)) {
-        console.log(' Expected "Delete your GOV.UL One Login", got: ', r.html('h2').eq(3).text())
+        console.log(' Expected "Delete your GOV.UK One Login", got: ', r.html('h2').eq(3).text())
       }
       return r
     },

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -179,7 +179,7 @@ export function changeEmail(): void {
       () => {
         const r = http.get(res.headers.Location)
         if (!pageContentCheck('API Simulation Tool').validatePageContent(r)) {
-          console.log(r.html('h1').first().text())
+          console.log('Expected "API Simulation Tool", got: ', r.html('h1').first().text())
         }
         return r
       },
@@ -207,8 +207,8 @@ export function changeEmail(): void {
       groups[5].split('::')[1],
       () => {
         const r = http.get(res.headers.Location)
-        if (!pageContentCheck('Services you can use with GOV.UK One Login--').validatePageContent(r)) {
-          console.log(r.html('h2').eq(1).text())
+        if (!pageContentCheck('Services you can use with GOV.UK One Login').validatePageContent(r)) {
+          console.log(' Expected "Services you can use with GOV.UK One Login", got: ', r.html('h2').eq(1).text())
         }
         return r
       },
@@ -226,8 +226,8 @@ export function changeEmail(): void {
     groups[6],
     () => {
       const r = http.get(env.envURL + '/security')
-      if (!pageContentCheck('Delete your GOV.UK One Login--').validatePageContent(r)) {
-        console.log(r.html('h2').eq(3).text())
+      if (!pageContentCheck('Delete your GOV.UK One Login').validatePageContent(r)) {
+        console.log(' Expected "Delete your GOV.UL One Login", got: ', r.html('h2').eq(3).text())
       }
       return r
     },
@@ -244,8 +244,8 @@ export function changeEmail(): void {
     groups[7],
     () => {
       const r = http.get(env.envURL + '/enter-password?type=changeEmail')
-      if (!pageContentCheck('Enter your password--').validatePageContent(r)) {
-        console.log(r.html('h1').text())
+      if (!pageContentCheck('Enter your password').validatePageContent(r)) {
+        console.log(' Expected "Enter your password", got: ', r.html('h1').text())
       }
       return r
     },
@@ -268,8 +268,8 @@ export function changeEmail(): void {
           password: credentials.currPassword
         }
       })
-      if (!pageContentCheck('Enter your new email address--').validatePageContent(r)) {
-        console.log(r.html('h1').text())
+      if (!pageContentCheck('Enter your new email address').validatePageContent(r)) {
+        console.log(' Expected "Enter your new email address", got: ', r.html('h1').text())
       }
       return r
     },
@@ -291,8 +291,8 @@ export function changeEmail(): void {
           email: newEmail
         }
       })
-      if (!pageContentCheck('Check your email--').validatePageContent(r)) {
-        console.log(r.html('h1').text())
+      if (!pageContentCheck('Check your email').validatePageContent(r)) {
+        console.log(' Expected "Check your email", got: ', r.html('h1').text())
       }
       return r
     },
@@ -315,8 +315,8 @@ export function changeEmail(): void {
           code: credentials.fixedEmailOTP
         }
       })
-      if (!pageContentCheck('You’ve changed your email address--').validatePageContent(r)) {
-        console.log(r.html('h1').text())
+      if (!pageContentCheck('You’ve changed your email address').validatePageContent(r)) {
+        console.log('Expected "You’ve changed your email address", got: ', r.html('h1').text())
       }
       return r
     },
@@ -335,8 +335,8 @@ export function changeEmail(): void {
       const r = res.submitForm({
         formSelector: "form[action='/sign-out']"
       })
-      if (!pageContentCheck('You have signed out--').validatePageContent(r)) {
-        console.log(r.html('h1').text())
+      if (!pageContentCheck('You have signed out').validatePageContent(r)) {
+        console.log('Expected "You have signed out", got: ', r.html('h1').text())
       }
       return r
     },

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -178,6 +178,9 @@ export function changeEmail(): void {
       isStatusCode200,
       ...pageContentCheck('API Simulation Tool')
     })
+    if (!pageContentCheck('API Simulation Tool').validatePageContent(res)) {
+      console.log(res.html('h1').first().text())
+    }
   })
 
   sleepBetween(1, 3)
@@ -197,6 +200,9 @@ export function changeEmail(): void {
       isStatusCode200,
       ...pageContentCheck('Services you can use with GOV.UK One Login')
     })
+    if (!pageContentCheck('Services you can use with GOV.UK One Login').validatePageContent(res)) {
+      console.log(res.html('h2').eq(1).text())
+    }
   })
 
   sleepBetween(1, 3)
@@ -206,6 +212,9 @@ export function changeEmail(): void {
     isStatusCode200,
     ...pageContentCheck('Delete your GOV.UK One Login')
   })
+  if (!pageContentCheck('Delete your GOV.UK One Login').validatePageContent(res)) {
+    console.log(res.html('h2').eq(3).text())
+  }
 
   sleepBetween(1, 3)
 
@@ -214,6 +223,9 @@ export function changeEmail(): void {
     isStatusCode200,
     ...pageContentCheck('Enter your password')
   })
+  if (!pageContentCheck('Enter your password').validatePageContent(res)) {
+    console.log(res.html('h1').text())
+  }
 
   sleepBetween(1, 3)
 
@@ -230,6 +242,9 @@ export function changeEmail(): void {
       }),
     { isStatusCode200, ...pageContentCheck('Enter your new email address') }
   )
+  if (!pageContentCheck('Enter your new email address').validatePageContent(res)) {
+    console.log(res.html('h1').text())
+  }
 
   sleepBetween(1, 3)
 
@@ -245,6 +260,9 @@ export function changeEmail(): void {
       }),
     { isStatusCode200, ...pageContentCheck('Check your email') }
   )
+  if (!pageContentCheck('Check your email').validatePageContent(res)) {
+    console.log(res.html('h1').text())
+  }
 
   sleepBetween(1, 3)
 
@@ -264,6 +282,9 @@ export function changeEmail(): void {
       ...pageContentCheck('You’ve changed your email address')
     }
   )
+  if (!pageContentCheck('You’ve changed your email address').validatePageContent(res)) {
+    console.log(res.html('h1').text())
+  }
 
   sleepBetween(1, 3)
 
@@ -276,6 +297,9 @@ export function changeEmail(): void {
       }),
     { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
+  if (!pageContentCheck('You have signed out').validatePageContent(res)) {
+    console.log(res.html('h1').text())
+  }
 
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -174,13 +174,20 @@ export function changeEmail(): void {
     res = timeGroup(groups[1].split('::')[1], () => http.get(env.envURL, { redirects: 0 }), { isStatusCode302 })
 
     //02_OIDCStubCall
-    res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
-      isStatusCode200,
-      ...pageContentCheck('API Simulation Tool')
-    })
-    if (!pageContentCheck('API Simulation Tool').validatePageContent(res)) {
-      console.log(res.html('h1').first().text())
-    }
+    res = timeGroup(
+      groups[2].split('::')[1],
+      () => {
+        const r = http.get(res.headers.Location)
+        if (!pageContentCheck('--API Simulation Tool--').validatePageContent(r)) {
+          console.log(r.html('h1').first().text())
+        }
+        return r
+      },
+      {
+        isStatusCode200,
+        ...pageContentCheck('API Simulation Tool')
+      }
+    )
   })
 
   sleepBetween(1, 3)
@@ -196,110 +203,145 @@ export function changeEmail(): void {
     )
 
     //02_OLHCall
-    res = timeGroup(groups[5].split('::')[1], () => http.get(res.headers.Location), {
-      isStatusCode200,
-      ...pageContentCheck('Services you can use with GOV.UK One Login')
-    })
-    if (!pageContentCheck('Services you can use with GOV.UK One Login').validatePageContent(res)) {
-      console.log(res.html('h2').eq(1).text())
-    }
+    res = timeGroup(
+      groups[5].split('::')[1],
+      () => {
+        const r = http.get(res.headers.Location)
+        if (!pageContentCheck('Services you can use with GOV.UK One Login--').validatePageContent(r)) {
+          console.log(r.html('h2').eq(1).text())
+        }
+        return r
+      },
+      {
+        isStatusCode200,
+        ...pageContentCheck('Services you can use with GOV.UK One Login')
+      }
+    )
   })
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_03_ClickSecurityTab
-  res = timeGroup(groups[6], () => http.get(env.envURL + '/security'), {
-    isStatusCode200,
-    ...pageContentCheck('Delete your GOV.UK One Login')
-  })
-  if (!pageContentCheck('Delete your GOV.UK One Login').validatePageContent(res)) {
-    console.log(res.html('h2').eq(3).text())
-  }
+  res = timeGroup(
+    groups[6],
+    () => {
+      const r = http.get(env.envURL + '/security')
+      if (!pageContentCheck('Delete your GOV.UK One Login--').validatePageContent(r)) {
+        console.log(r.html('h2').eq(3).text())
+      }
+      return r
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Delete your GOV.UK One Login')
+    }
+  )
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_04_ClickChangeEmailLink
-  res = timeGroup(groups[7], () => http.get(env.envURL + '/enter-password?type=changeEmail'), {
-    isStatusCode200,
-    ...pageContentCheck('Enter your password')
-  })
-  if (!pageContentCheck('Enter your password').validatePageContent(res)) {
-    console.log(res.html('h1').text())
-  }
+  res = timeGroup(
+    groups[7],
+    () => {
+      const r = http.get(env.envURL + '/enter-password?type=changeEmail')
+      if (!pageContentCheck('Enter your password--').validatePageContent(r)) {
+        console.log(r.html('h1').text())
+      }
+      return r
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your password')
+    }
+  )
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_05_EnterCurrentPassword
   res = timeGroup(
     groups[8],
-    () =>
-      res.submitForm({
+    () => {
+      const r = res.submitForm({
         formSelector: "form[action='/enter-password']",
         fields: {
           requestType: 'changeEmail',
           password: credentials.currPassword
         }
-      }),
-    { isStatusCode200, ...pageContentCheck('Enter your new email address') }
+      })
+      if (!pageContentCheck('Enter your new email address--').validatePageContent(r)) {
+        console.log(r.html('h1').text())
+      }
+      return r
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Enter your new email address')
+    }
   )
-  if (!pageContentCheck('Enter your new email address').validatePageContent(res)) {
-    console.log(res.html('h1').text())
-  }
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_06_EnterNewEmailID
   res = timeGroup(
     groups[9],
-    () =>
-      res.submitForm({
+    () => {
+      const r = res.submitForm({
         formSelector: "form[action='/change-email']",
         fields: {
           email: newEmail
         }
-      }),
-    { isStatusCode200, ...pageContentCheck('Check your email') }
+      })
+      if (!pageContentCheck('Check your email--').validatePageContent(r)) {
+        console.log(r.html('h1').text())
+      }
+      return r
+    },
+    {
+      isStatusCode200,
+      ...pageContentCheck('Check your email')
+    }
   )
-  if (!pageContentCheck('Check your email').validatePageContent(res)) {
-    console.log(res.html('h1').text())
-  }
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_07_EnterEmailOTP
   res = timeGroup(
     groups[10],
-    () =>
-      res.submitForm({
+    () => {
+      const r = res.submitForm({
         formSelector: "form[action='/check-your-email']",
         fields: {
           email: newEmail,
           code: credentials.fixedEmailOTP
         }
-      }),
+      })
+      if (!pageContentCheck('You’ve changed your email address--').validatePageContent(r)) {
+        console.log(r.html('h1').text())
+      }
+      return r
+    },
     {
       isStatusCode200,
       ...pageContentCheck('You’ve changed your email address')
     }
   )
-  if (!pageContentCheck('You’ve changed your email address').validatePageContent(res)) {
-    console.log(res.html('h1').text())
-  }
 
   sleepBetween(1, 3)
 
   // B01_ChangeEmail_08_SignOut
   res = timeGroup(
     groups[11],
-    () =>
-      res.submitForm({
+    () => {
+      const r = res.submitForm({
         formSelector: "form[action='/sign-out']"
-      }),
+      })
+      if (!pageContentCheck('You have signed out--').validatePageContent(r)) {
+        console.log(r.html('h1').text())
+      }
+      return r
+    },
     { isStatusCode200, ...pageContentCheck('You have signed out') }
   )
-  if (!pageContentCheck('You have signed out').validatePageContent(res)) {
-    console.log(res.html('h1').text())
-  }
 
   iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -178,7 +178,7 @@ export function changeEmail(): void {
       groups[2].split('::')[1],
       () => {
         const r = http.get(res.headers.Location)
-        if (!pageContentCheck('--API Simulation Tool--').validatePageContent(r)) {
+        if (!pageContentCheck('API Simulation Tool').validatePageContent(r)) {
           console.log(r.html('h1').first().text())
         }
         return r


### PR DESCRIPTION
## QA-550 <!--Jira Ticket Number-->

### What?
Add debug logging to the OLH `changeEmail` test script

#### Changes:
- Add and `if` statement where if the `pageContentCheck` fails, the unexpected page content will be returned.

---

### Why?
- If we get response validation failures, we will be able to see the content of the incorrect page returned to help with debugging.
