### PR TITLE
[QA-555]: Reduce target volume of adhoc load test profile in IPV core passport

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -60,8 +60,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 1000,
       maxVUs: 3000,
       stages: [
-        { target: 100, duration: '15m' }, // Ramp up to target throughput over 15 minutes
-        { target: 100, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes
+        { target: 35, duration: '15m' }, // Ramp up to target throughput over 15 minutes
+        { target: 35, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ],
       exec: 'passport'


### PR DESCRIPTION
## QA-555 <!--Jira Ticket Number-->

### What?
Reduce target volume of adhoc load test profile in IPV core passport

#### Changes:
-  Reduce target volume of adhoc load test profile in IPV core passport scenario to 35 iterations per second.

---

### Why?
We are hitting SSM rate limits in the 100/s test so need to reduce the volume for a clean run.