### PR TITLE
[QA-566] Updating the changeEmail OLH load profile to 30 iterations per second

### DIFF
--- a/deploy/scripts/src/accounts/test.ts
+++ b/deploy/scripts/src/accounts/test.ts
@@ -28,7 +28,7 @@ const profiles: ProfileList = {
     ...createScenario('contactsPage', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('changeEmail', LoadProfile.full, 15),
+    ...createScenario('changeEmail', LoadProfile.full, 30),
     ...createScenario('changePassword', LoadProfile.full, 15),
     ...createScenario('changePhone', LoadProfile.full, 15),
     ...createScenario('deleteAccount', LoadProfile.full, 15),


### PR DESCRIPTION
## QA-566 <!--Jira Ticket Number-->

### What?
Updating the `changeEmail` load profile to 30 iterations per second.

#### Changes:
Updating the target volume of the OLH `changeEmail` load profile to 30 iterations per second from 15.

---

### Why?
To run a load test for OLH changeEmail at the current NFR volume we are working to, 30 iterations per second. 
