### PR TITLE
[QA-567] Fix koa-stub userinfo retry mechanism

### DIFF
--- a/koa-stub/src/controllers/callback.controller.js
+++ b/koa-stub/src/controllers/callback.controller.js
@@ -81,23 +81,22 @@ const processCallback = async (ctx) => {
 };
 
 async function getUserInfo(ctx, access_token) {
-  let attempt = 0;
   let maxRetries = 3;
   console.log("Getting the userinfo request");
-  try {
-    let response = await ctx.oneLogin.userinfo(access_token);
-    console.log(response);
-    return response;
-  } catch (error) {
-    if (attempt < maxRetries) {
-      attempt += 1;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const response = await ctx.oneLogin.userinfo(access_token);
+      console.log(`Attempt ${attempt}: Response ${response}`);
+      return response;
+    } catch (error) {
+      console.warn(
+        `Attempt ${attempt}: Request to userinfo failed due to ${error}`
+      );
       const delay = 1000;
-      console.warn(`Request to userinfo failed due to ${error}`);
       await new Promise((resolve) => setTimeout(resolve, delay));
-      return await ctx.oneLogin.userinfo(access_token);
     }
-    throw new Error(`Userinfo endpoint not authorising`);
   }
+  throw new Error(`Userinfo endpoint not authorising`);
 }
 
 module.exports = {

--- a/koa-stub/src/controllers/callback.controller.js
+++ b/koa-stub/src/controllers/callback.controller.js
@@ -86,12 +86,10 @@ async function getUserInfo(ctx, access_token) {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       const response = await ctx.oneLogin.userinfo(access_token);
-      console.log(`Attempt ${attempt}: Response ${response}`);
+      console.log(response);
       return response;
     } catch (error) {
-      console.warn(
-        `Attempt ${attempt}: Request to userinfo failed due to ${error}`
-      );
+      console.warn(`Request to userinfo failed due to ${error}`);
       const delay = 1000;
       await new Promise((resolve) => setTimeout(resolve, delay));
     }

--- a/koa-stub/src/tests/app.test.js
+++ b/koa-stub/src/tests/app.test.js
@@ -101,6 +101,7 @@ describe("Tests against the OIDC Service with errors", () => {
     expect(logoutresponse.data).toBe("TestPage");
   });
   test("The OIDC flow fails, if all calls to userinfo is a 401", async () => {
+    console.warn.mockRestore();
     const spyConsole = jest.spyOn(console, "warn");
     service.on("beforeUserinfo", (userInfoResponse, req) => {
       userInfoResponse.body = {
@@ -115,7 +116,7 @@ describe("Tests against the OIDC Service with errors", () => {
     });
 
     expect(dynamoDBMock).toHaveReceivedCommand(PutItemCommand);
-    expect(spyConsole).toHaveBeenCalledTimes(2);
+    expect(spyConsole).toHaveBeenCalledTimes(3);
     expect(spyConsole).toBeCalledWith(
       "Request to userinfo failed due to OPError: invalid_token"
     );


### PR DESCRIPTION
## QA-567

### What?
Fixes the /userinfo retry mechanism

#### Changes:
- `koa-stub/src/controllers/callback.controller.js`: Add a loop to the `getUserInfo()` function to retry failures up to 2 times (up to 3 calls in total), implementing the original intended functionality
- `koa-stub/src/tests/app.test.js`: Added a restore of the console.warn and updated the expected call count to 3
---

### Why?
The previous code would only retry once and would not handle a second error gracefully. The previous code intended to have up to 3 retries, and this fixes that.

---

### Related:
- #765
