### PR TITLE
[QA-569] Updating the OLH scenarios to use the 'userPerformanceTest' user.

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -198,7 +198,7 @@ export function changeEmail(): void {
     //01_OIDCStubCall
     res = timeGroup(
       groups[4].split('::')[1],
-      () => res.submitForm({ fields: { scenario: 'default' }, params: { redirects: 0 } }),
+      () => res.submitForm({ fields: { scenario: 'userPerformanceTest' }, params: { redirects: 0 } }),
       { isStatusCode302 }
     )
 
@@ -369,7 +369,7 @@ export function changePassword(): void {
     //01_OIDCStubCall
     res = timeGroup(
       groups[4].split('::')[1],
-      () => res.submitForm({ fields: { scenario: 'default' }, params: { redirects: 0 } }),
+      () => res.submitForm({ fields: { scenario: 'userPerformanceTest' }, params: { redirects: 0 } }),
       { isStatusCode302 }
     )
 
@@ -476,7 +476,7 @@ export function changePhone(): void {
     //01_OIDCStubCall
     res = timeGroup(
       groups[4].split('::')[1],
-      () => res.submitForm({ fields: { scenario: 'default' }, params: { redirects: 0 } }),
+      () => res.submitForm({ fields: { scenario: 'userPerformanceTest' }, params: { redirects: 0 } }),
       { isStatusCode302 }
     )
 
@@ -600,7 +600,7 @@ export function deleteAccount(): void {
     //01_OIDCStubCall
     res = timeGroup(
       groups[4].split('::')[1],
-      () => res.submitForm({ fields: { scenario: 'default' }, params: { redirects: 0 } }),
+      () => res.submitForm({ fields: { scenario: 'userPerformanceTest' }, params: { redirects: 0 } }),
       { isStatusCode302 }
     )
 


### PR DESCRIPTION
## QA-569 <!--Jira Ticket Number-->

### What?
Updated the OLH scenarios to use the new `userPerformanceTest` user instead of the `default` user in the OIDC stub.

#### Changes:
- Updated the OIDC scenario to `userPerformanceTestUser` from `default` in `changeEmail`, `changePhone`, `changePassword`, and `deleteAccount` scenarios. 

---

### Why?
So the OLH team can see activity history from the performance test.

