### PR TITLE
[QA-571] Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,21 @@ updates:
     directory: "/deploy/scripts"
     schedule:
       interval: "weekly"
+    groups:
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "eslint-*"
+          - "eslint"
+      esbuild:
+        patterns:
+          - "esbuild-*"
+          - "esbuild"
+      k6:
+        patterns:
+          - "@types/k6"
+          - "k6"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -24,3 +39,21 @@ updates:
     directory: "/koa-stub/src"
     schedule:
       interval: "weekly"
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+          - "aws-sdk-*"
+      axios:
+        patterns:
+          - "axios-*"
+          - "axios"
+      koa:
+        patterns:
+          - "@koa/*"
+          - "koa-*"
+          - "koa"
+      supertest:
+        patterns:
+          - "supertest-*"
+          - "supertest"


### PR DESCRIPTION
## QA-571

### What?
Groups certain dependabot updates

#### Changes:
- `.github/dependabot.yml`: 
  - Groups `eslint`, `esbuild` and `k6` updates for the `/deploy/scripts` npm project
  - Groups `aws-sdk`, `axios`, `koa` and `supertest` updates for the `/koa-stub/src` npm project
---

### Why?
Reduce number of dependabot PRs
