### PR TITLE
target volume changed from 30-15 journeys p/second

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -21,7 +21,7 @@ const profiles: ProfileList = {
     ...createScenario('ninoCheck', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('ninoCheck', LoadProfile.short, 30)
+    ...createScenario('ninoCheck', LoadProfile.short, 15)
   }
 }
 


### PR DESCRIPTION
## QA-572 <!--Jira Ticket Number-->

### What?
Target volume of journeys per second is being reduced. 

#### Changes:
- The script has been changed to reduce the target volume of journeys per second from 30 to 15.

---

### Why?
We have been asked to run this at a lower volume to identify a baseline target at which we can run a successful test and the system can cope up with that volume.

