### PR TITLE
[QA-573]: Reduced the low volume target for Address CRI to 15

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -22,7 +22,7 @@ const profiles: ProfileList = {
     ...createScenario('address', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('address', LoadProfile.short, 30)
+    ...createScenario('address', LoadProfile.short, 15)
   },
   stress: {
     ...createScenario('address', LoadProfile.full, 65)


### PR DESCRIPTION
## QA-573 <!--Jira Ticket Number-->

### What?
Reduced the low volume target for Address CRI to 15

#### Changes:
- Reduced the low volume target for Address CRI to 15 journeys/second

---

### Why?
To conduct a baseline test for address CRI