### PR TITLE
[QA-577] Changing the Address CRI lowVolume profile to 5 j/s

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -22,7 +22,7 @@ const profiles: ProfileList = {
     ...createScenario('address', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('address', LoadProfile.short, 15)
+    ...createScenario('address', LoadProfile.short, 5)
   },
   stress: {
     ...createScenario('address', LoadProfile.full, 65)


### PR DESCRIPTION
## QA-577 <!--Jira Ticket Number-->

### What?
Changes the Address CRI `lowVolume` test scenario to have a target volume of 5 iterations per seocnd. 

#### Changes:
- Changes the target volume for the `lowVolume` profile of the `cri-orange/address.ts` test script to 5 iterations per second from 15. 
