### PR TITLE
[QA-581] Align ID Check Scripts

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -94,7 +94,8 @@ export enum LoadProfile {
   short,
   full,
   deployment,
-  rampOnly
+  rampOnly,
+  incremental
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -126,6 +127,19 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target, duration: '5m' }, // Maintain steady state at target throughput for 5 minutes
         { target, duration: '5m' } // Ramp down over 5 minutes
       ]
+    case LoadProfile.incremental: {
+      const step = target / 4
+      return [
+        { target: step, duration: '4m' }, // Ramp up to 25% target throughput over 4 minutes
+        { target: step, duration: '10m' }, // Maintain steady state at 25% target throughput for 10 minutes
+        { target: step * 2, duration: '4m' }, // Ramp up to 50% target throughput over 4 minutes
+        { target: step * 2, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 3, duration: '4m' }, // Ramp up to 75% target throughput over 4 minutes
+        { target: step * 3, duration: '10m' }, // Maintain steady state at 75% target throughput for 10 minutes
+        { target, duration: '4m' }, // Ramp up to target throughput over 4 minutes
+        { target, duration: '10m' } // Maintain steady state at target throughput for 10 minutes
+      ]
+    }
   }
 }
 

--- a/deploy/scripts/src/mobile/authorize.test.ts
+++ b/deploy/scripts/src/mobile/authorize.test.ts
@@ -7,6 +7,7 @@ import {
   LoadProfile
 } from '../common/utils/config/load-profiles'
 import { startJourney } from './testSteps/frontend'
+import { getThresholds } from '../common/utils/config/thresholds'
 
 const profiles: ProfileList = {
   smoke: {
@@ -18,13 +19,14 @@ const profiles: ProfileList = {
 }
 
 const loadProfile = selectProfile(profiles)
+const groupMap = {
+  authorize: ['POST test client /start', 'GET /authorize']
+} as const
 
 export const options: Options = {
   scenarios: loadProfile.scenarios,
-  thresholds: {
-    http_req_duration: ['p(95)<=1000', 'p(99)<=2500'], // 95th percentile response time <=1000ms, 99th percentile response time <=2500ms
-    http_req_failed: ['rate<0.05'] // Error rate <5%
-  }
+  thresholds: getThresholds(groupMap),
+  tags: { name: '' }
 }
 
 export function setup(): void {

--- a/deploy/scripts/src/mobile/authorize.test.ts
+++ b/deploy/scripts/src/mobile/authorize.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../common/utils/config/load-profiles'
 import { startJourney } from './testSteps/frontend'
 import { getThresholds } from '../common/utils/config/thresholds'
+import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
 
 const profiles: ProfileList = {
   smoke: {
@@ -34,5 +35,7 @@ export function setup(): void {
 }
 
 export function authorize(): void {
+  iterationsStarted.add(1)
   startJourney()
+  iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -16,6 +16,7 @@ import {
   postUserInfoV2
 } from './testSteps/backend'
 import { sleep } from 'k6'
+import { getThresholds } from '../common/utils/config/thresholds'
 
 const profiles: ProfileList = {
   smoke: {
@@ -33,13 +34,23 @@ const profiles: ProfileList = {
 }
 
 const loadProfile = selectProfile(profiles)
+const groupMap = {
+  backendJourney: [
+    'POST test client /start',
+    'POST /verifyAuthorizeRequest',
+    'POST /resourceOwner/documentGroups',
+    'GET /biometricToken/v2',
+    'POST /finishBiometricSession',
+    'GET /redirect',
+    'POST /token',
+    'POST /userinfo/v2'
+  ]
+} as const
 
 export const options: Options = {
   scenarios: loadProfile.scenarios,
-  thresholds: {
-    http_req_duration: ['p(95)<=1000', 'p(99)<=2500'], // 95th percentile response time <=1000ms, 99th percentile response time <=2500ms
-    http_req_failed: ['rate<0.05'] // Error rate <5%
-  }
+  thresholds: getThresholds(groupMap),
+  tags: { name: '' }
 }
 
 export function setup(): void {

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -21,33 +21,14 @@ const profiles: ProfileList = {
   smoke: {
     ...createScenario('backendJourney', LoadProfile.smoke)
   },
-  load: {
-    ...createScenario('backendJourney', LoadProfile.full, 40, 37)
+  lowVolume: {
+    ...createScenario('backendJourney', LoadProfile.full, 10)
   },
-  loadSelfAssessment: {
-    backendJourney: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 60,
-      maxVUs: 450,
-      stages: [
-        { target: 10, duration: '15m' },
-        { target: 10, duration: '10m' }
-      ],
-      exec: 'backendJourney'
-    }
+  load: {
+    ...createScenario('backendJourney', LoadProfile.full, 40)
   },
   deploy: {
-    backendJourney: {
-      executor: 'constant-arrival-rate',
-      rate: 1,
-      timeUnit: '1s',
-      duration: '25m',
-      preAllocatedVUs: 10, // Calculation: 1 journeys / second * 10 seconds average journey time
-      maxVUs: 65, // Calculation: 1 journeys / second * 14 seconds maximum journey time + 50 buffer
-      exec: 'backendJourney'
-    }
+    ...createScenario('backendJourney', LoadProfile.deployment, 1)
   }
 }
 

--- a/deploy/scripts/src/mobile/backend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/backend-e2e.test.ts
@@ -17,6 +17,7 @@ import {
 } from './testSteps/backend'
 import { sleep } from 'k6'
 import { getThresholds } from '../common/utils/config/thresholds'
+import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
 
 const profiles: ProfileList = {
   smoke: {
@@ -58,6 +59,7 @@ export function setup(): void {
 }
 
 export function backendJourney(): void {
+  iterationsStarted.add(1)
   const sessionId = postVerifyAuthorizeRequest()
   sleep(1)
   postResourceOwnerDocumentGroups(sessionId)
@@ -71,4 +73,5 @@ export function backendJourney(): void {
   const accessToken = postToken(authorizationCode, redirectUri)
   sleep(1)
   postUserInfoV2(accessToken)
+  iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -22,6 +22,7 @@ import {
 import { getBiometricTokenV2, postFinishBiometricSession } from './testSteps/backend'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getThresholds } from '../common/utils/config/thresholds'
+import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
 
 const profiles: ProfileList = {
   smoke: {
@@ -72,6 +73,7 @@ export function setup(): void {
 }
 
 export function mamIphonePassport(): void {
+  iterationsStarted.add(1)
   startJourney()
   simulateUserWait()
   postSelectDevice()
@@ -98,6 +100,7 @@ export function mamIphonePassport(): void {
     // Approximately 20% of users abort journey
     getAbortCommand()
   }
+  iterationsCompleted.add(1)
 }
 
 function simulateUserWait(): void {

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -21,6 +21,7 @@ import {
 } from './testSteps/frontend'
 import { getBiometricTokenV2, postFinishBiometricSession } from './testSteps/backend'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
+import { getThresholds } from '../common/utils/config/thresholds'
 
 const profiles: ProfileList = {
   smoke: {
@@ -44,13 +45,26 @@ const profiles: ProfileList = {
 }
 
 const loadProfile = selectProfile(profiles)
+const groupMap = {
+  mamIphonePassport: [
+    'POST test client /start',
+    'GET /authorize',
+    'POST /selectDevice',
+    'POST /selectSmartphone',
+    'POST /validPassport',
+    'POST /biometricChip',
+    'POST /iphoneModel',
+    'POST /idCheckApp',
+    'GET /biometricToken/v2',
+    'POST /finishBiometricSession',
+    'GET /redirect'
+  ]
+} as const
 
 export const options: Options = {
   scenarios: loadProfile.scenarios,
-  thresholds: {
-    http_req_duration: ['p(95)<=1000', 'p(99)<=2500'], // 95th percentile response time <=1000ms, 99th percentile response time <=2500ms
-    http_req_failed: ['rate<0.05'] // Error rate <5%
-  }
+  thresholds: getThresholds(groupMap),
+  tags: { name: '' }
 }
 
 export function setup(): void {

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -26,33 +26,14 @@ const profiles: ProfileList = {
   smoke: {
     ...createScenario('mamIphonePassport', LoadProfile.smoke)
   },
-  load: {
-    ...createScenario('mamIphonePassport', LoadProfile.full, 40, 37)
+  lowVolume: {
+    ...createScenario('mamIphonePassport', LoadProfile.full, 10, 40)
   },
-  loadSelfAssessment: {
-    mamIphonePassport: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 100,
-      maxVUs: 450,
-      stages: [
-        { target: 10, duration: '15m' },
-        { target: 10, duration: '10m' }
-      ],
-      exec: 'mamIphonePassport'
-    }
+  load: {
+    ...createScenario('mamIphonePassport', LoadProfile.full, 40, 40)
   },
   deploy: {
-    mamIphonePassport: {
-      executor: 'constant-arrival-rate',
-      rate: 1,
-      timeUnit: '1s',
-      duration: '25m',
-      preAllocatedVUs: 15, // Calculation: 1 journeys / second * 15 seconds average journey time
-      maxVUs: 75, // Calculation: 1 journeys / second * 24 seconds maximum journey time + 50 buffer
-      exec: 'mamIphonePassport'
-    }
+    ...createScenario('mamIphonePassport', LoadProfile.deployment, 1, 40)
   },
   incrementalLoad: {
     mamIphonePassport: {

--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -35,45 +35,11 @@ const profiles: ProfileList = {
   deploy: {
     ...createScenario('mamIphonePassport', LoadProfile.deployment, 1, 40)
   },
-  incrementalLoad: {
-    mamIphonePassport: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 1700, // Calculation: 100 journeys / second * 17 seconds average journey time
-      maxVUs: 3000, // Calculation: 100 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
-      stages: [
-        { target: 25, duration: '4m' }, // linear increase from 0 iteration per second to 25 iterations per second for 4 mins -> 0.1 t/s/s
-        { target: 25, duration: '10m' }, // maintain 25 iterations per second for 10 min
-        { target: 50, duration: '4m' }, // linear increase from 25 iteration per second to 50 iterations per second for 4 mins -> 0.1 t/s/s
-        { target: 50, duration: '10m' }, // maintain 50 iterations per second for 10 min
-        { target: 75, duration: '4m' }, // linear increase from 50 iteration per second to 75 iterations per second for 4 mins -> 0.1 t/s/s
-        { target: 75, duration: '10m' }, // maintain 75 iterations per second for 10 min
-        { target: 100, duration: '4m' }, // linear increase from 75 iteration per second to 100 iterations per second for 4 mins -> 0.1 t/s/s
-        { target: 100, duration: '10m' } // maintain 100 iterations per second for 10 min
-      ],
-      exec: 'mamIphonePassport'
-    }
-  },
   incrementalSmallVolumes: {
-    mamIphonePassport: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '1s',
-      preAllocatedVUs: 700, // Calculation: 40 journeys / second * 17 seconds average journey time
-      maxVUs: 1500, // Calculation: 40 journeys / second * 2.5 seconds maximum expected from NFR (2.5 per request, 10 user-facing requests + safety)
-      stages: [
-        { target: 5, duration: '4m' }, // linear increase from 0 iteration per second to 5 iterations per second for 4 mins
-        { target: 5, duration: '10m' }, // maintain 5 iterations per second for 10 min
-        { target: 15, duration: '4m' }, // linear increase from 15 iteration per second to 50 iterations per second for 4 mins
-        { target: 15, duration: '10m' }, // maintain 15 iterations per second for 10 min
-        { target: 30, duration: '4m' }, // linear increase from 15 iteration per second to 30 iterations per second for 4 mins
-        { target: 30, duration: '10m' }, // maintain 30 iterations per second for 10 min
-        { target: 40, duration: '4m' }, // linear increase from 30 iteration per second to 40 iterations per second for 4 mins
-        { target: 40, duration: '10m' } // maintain 40 iterations per second for 10 min
-      ],
-      exec: 'mamIphonePassport'
-    }
+    ...createScenario('mamIphonePassport', LoadProfile.incremental, 40)
+  },
+  incrementalLoad: {
+    ...createScenario('mamIphonePassport', LoadProfile.incremental, 100)
   }
 }
 

--- a/deploy/scripts/src/mobile/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/testSteps/backend.ts
@@ -4,10 +4,10 @@ import { uuidv4 } from '../../common/utils/jslib/index'
 import { buildBackendUrl } from '../utils/url'
 import { parseTestClientResponse, postTestClientStart } from '../utils/test-client'
 import { timeRequest } from '../../common/utils/request/timing'
-import { isStatusCode200, isStatusCode201 } from '../../common/utils/checks/assertions'
+import { isStatusCode200 } from '../../common/utils/checks/assertions'
 
 export function postVerifyAuthorizeRequest(): string {
-  const testClientRes = group('POST test client /start', () => timeRequest(postTestClientStart, { isStatusCode201 }))
+  const testClientRes = postTestClientStart()
   const verifyUrl = parseTestClientResponse(testClientRes, 'ApiLocation')
 
   const verifyRes = group('POST /verifyAuthorizeRequest', () =>

--- a/deploy/scripts/src/mobile/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/testSteps/backend.ts
@@ -11,13 +11,7 @@ export function postVerifyAuthorizeRequest(): string {
   const verifyUrl = parseTestClientResponse(testClientRes, 'ApiLocation')
 
   const verifyRes = group('POST /verifyAuthorizeRequest', () =>
-    timeRequest(
-      () =>
-        http.post(verifyUrl, null, {
-          tags: { name: 'POST /verifyAuthorizeRequest' }
-        }),
-      { isStatusCode200 }
-    )
+    timeRequest(() => http.post(verifyUrl), { isStatusCode200 })
   )
   return verifyRes.json('sessionId') as string
 }
@@ -36,13 +30,7 @@ export function postResourceOwnerDocumentGroups(sessionId: string): void {
     }
     const documentGroupsUrl = buildBackendUrl(`/resourceOwner/documentGroups/${sessionId}`)
 
-    timeRequest(
-      () =>
-        http.post(documentGroupsUrl, JSON.stringify(documentGroupsData), {
-          tags: { name: 'POST /resourceOwner/documentGroups' }
-        }),
-      { isStatusCode200 }
-    )
+    timeRequest(() => http.post(documentGroupsUrl, JSON.stringify(documentGroupsData)), { isStatusCode200 })
   })
 }
 
@@ -52,13 +40,7 @@ export function getBiometricTokenV2(sessionId: string): void {
       authSessionId: sessionId
     })
 
-    timeRequest(
-      () =>
-        http.get(biometricTokenUrl, {
-          tags: { name: 'GET /biometricToken/v2' }
-        }),
-      { isStatusCode200 }
-    )
+    timeRequest(() => http.get(biometricTokenUrl), { isStatusCode200 })
   })
 }
 
@@ -69,13 +51,7 @@ export function postFinishBiometricSession(sessionId: string): void {
       biometricSessionId: uuidv4()
     })
 
-    timeRequest(
-      () =>
-        http.post(finishBiometricSessionUrl, null, {
-          tags: { name: 'POST /finishBiometricSession' }
-        }),
-      { isStatusCode200 }
-    )
+    timeRequest(() => http.post(finishBiometricSessionUrl), { isStatusCode200 })
   })
 }
 
@@ -86,13 +62,7 @@ export function getRedirect(sessionId: string): {
   return group('GET /redirect', () => {
     const redirectUrl = buildBackendUrl('/redirect', { sessionId })
 
-    const redirectRes = timeRequest(
-      () =>
-        http.get(redirectUrl, {
-          tags: { name: 'GET /redirect' }
-        }),
-      { isStatusCode200 }
-    )
+    const redirectRes = timeRequest(() => http.get(redirectUrl), { isStatusCode200 })
 
     return {
       authorizationCode: redirectRes.json('authorizationCode') as string,
@@ -107,15 +77,11 @@ export function postToken(authorizationCode: string, redirectUri: string): strin
 
     const tokenResponse = timeRequest(
       () =>
-        http.post(
-          tokenUrl,
-          {
-            code: authorizationCode,
-            grant_type: 'authorization_code',
-            redirect_uri: redirectUri
-          },
-          { tags: { name: 'POST /token' } }
-        ),
+        http.post(tokenUrl, {
+          code: authorizationCode,
+          grant_type: 'authorization_code',
+          redirect_uri: redirectUri
+        }),
       { isStatusCode200 }
     )
     return tokenResponse.json('access_token') as string
@@ -132,8 +98,7 @@ export function postUserInfoV2(accessToken: string): void {
           headers: {
             'Content-Type': 'application/json',
             Authorization: 'Bearer ' + accessToken
-          },
-          tags: { name: 'POST /userinfo/v2' }
+          }
         }),
       { isStatusCode200 }
     )

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -23,107 +23,61 @@ export function startJourney(): void {
   const authorizeUrl = parseTestClientResponse(testClientRes, 'WebLocation')
 
   group('GET /authorize', () =>
-    timeRequest(
-      () =>
-        http.get(authorizeUrl, {
-          tags: { name: 'GET /authorize' }
-        }),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/selectDevice'),
-        ...pageContentCheck('Are you on a computer or a tablet right now?')
-      }
-    )
+    timeRequest(() => http.get(authorizeUrl), {
+      isStatusCode200,
+      ...validatePageRedirect('/selectDevice'),
+      ...pageContentCheck('Are you on a computer or a tablet right now?')
+    })
   )
 }
 
 export function postSelectDevice(): void {
   group('POST /selectDevice', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/selectDevice'),
-          { 'select-device-choice': 'smartphone' },
-          { tags: { name: 'POST /selectDevice' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/selectSmartphone'),
-        ...pageContentCheck('Which smartphone are you using?')
-      }
-    )
+    timeRequest(() => http.post(buildFrontendUrl('/selectDevice'), { 'select-device-choice': 'smartphone' }), {
+      isStatusCode200,
+      ...validatePageRedirect('/selectSmartphone'),
+      ...pageContentCheck('Which smartphone are you using?')
+    })
   )
 }
 
 export function postSelectSmartphone(): void {
   group('POST /selectSmartphone', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/selectSmartphone'),
-          { 'smartphone-choice': 'iphone' },
-          { tags: { name: 'POST /selectSmartphone' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/validPassport'),
-        ...pageContentCheck('Do you have a valid passport?')
-      }
-    )
+    timeRequest(() => http.post(buildFrontendUrl('/selectSmartphone'), { 'smartphone-choice': 'iphone' }), {
+      isStatusCode200,
+      ...validatePageRedirect('/validPassport'),
+      ...pageContentCheck('Do you have a valid passport?')
+    })
   )
 }
 
 export function postValidPassport(): void {
   group('POST /validPassport', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/validPassport'),
-          { 'select-option': 'yes' },
-          { tags: { name: 'POST /validPassport' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/biometricChip'),
-        ...pageContentCheck('Does your passport have this symbol on the cover?')
-      }
-    )
+    timeRequest(() => http.post(buildFrontendUrl('/validPassport'), { 'select-option': 'yes' }), {
+      isStatusCode200,
+      ...validatePageRedirect('/biometricChip'),
+      ...pageContentCheck('Does your passport have this symbol on the cover?')
+    })
   )
 }
 
 export function postBiometricChip(): void {
   group('POST /biometricChip', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/biometricChip'),
-          { 'select-option': 'yes' },
-          { tags: { name: 'POST /biometricChip' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/iphoneModel'),
-        ...pageContentCheck('Which iPhone model do you have?')
-      }
-    )
+    timeRequest(() => http.post(buildFrontendUrl('/biometricChip'), { 'select-option': 'yes' }), {
+      isStatusCode200,
+      ...validatePageRedirect('/iphoneModel'),
+      ...pageContentCheck('Which iPhone model do you have?')
+    })
   )
 }
 
 export function postIphoneModel(): void {
   group('POST /iphoneModel', () =>
-    timeRequest(
-      () =>
-        http.post(
-          buildFrontendUrl('/iphoneModel'),
-          { 'select-option': 'iphone7OrNewer' },
-          { tags: { name: 'POST /iphoneModel' } }
-        ),
-      {
-        isStatusCode200,
-        ...validatePageRedirect('/idCheckApp'),
-        ...pageContentCheck('Use your passport and a GOV.UK app to confirm your identity')
-      }
-    )
+    timeRequest(() => http.post(buildFrontendUrl('/iphoneModel'), { 'select-option': 'iphone7OrNewer' }), {
+      isStatusCode200,
+      ...validatePageRedirect('/idCheckApp'),
+      ...pageContentCheck('Use your passport and a GOV.UK app to confirm your identity')
+    })
   )
 }
 
@@ -146,8 +100,7 @@ export function getRedirect(): void {
     timeRequest(
       () =>
         http.get(redirectUrl, {
-          redirects: 0,
-          tags: { name: 'GET /redirect' }
+          redirects: 0
         }),
       {
         isStatusCode302,
@@ -167,8 +120,7 @@ export function getAbortCommand(): void {
     timeRequest(
       () =>
         http.get(abortCommandUrl, {
-          redirects: 0,
-          tags: { name: 'GET /abortCommand' }
+          redirects: 0
         }),
       {
         isStatusCode302,

--- a/deploy/scripts/src/mobile/testSteps/frontend.ts
+++ b/deploy/scripts/src/mobile/testSteps/frontend.ts
@@ -4,12 +4,7 @@ import { buildFrontendUrl } from '../utils/url'
 import { validatePageRedirect, validateLocationHeader, validateQueryParam } from '../utils/assertions'
 import { parseTestClientResponse, postTestClientStart } from '../utils/test-client'
 import { timeRequest } from '../../common/utils/request/timing'
-import {
-  isStatusCode200,
-  isStatusCode201,
-  isStatusCode302,
-  pageContentCheck
-} from '../../common/utils/checks/assertions'
+import { isStatusCode200, isStatusCode302, pageContentCheck } from '../../common/utils/checks/assertions'
 
 export function getSessionIdFromCookieJar(): string {
   const jar = http.cookieJar()
@@ -17,9 +12,7 @@ export function getSessionIdFromCookieJar(): string {
 }
 
 export function startJourney(): void {
-  const testClientRes = group('POST test client /start', () =>
-    timeRequest(() => postTestClientStart(), { isStatusCode201 })
-  )
+  const testClientRes = postTestClientStart()
   const authorizeUrl = parseTestClientResponse(testClientRes, 'WebLocation')
 
   group('GET /authorize', () =>

--- a/deploy/scripts/src/mobile/utils/test-client.ts
+++ b/deploy/scripts/src/mobile/utils/test-client.ts
@@ -1,18 +1,26 @@
 import http, { type Response } from 'k6/http'
 import { buildBackendUrl, buildUrl } from './url'
 import { config } from './config'
+import { isStatusCode201 } from '../../common/utils/checks/assertions'
+import { timeRequest } from '../../common/utils/request/timing'
+import { group } from 'k6'
 
 export function postTestClientStart(): Response {
-  return http.post(
-    buildUrl('start', config.testClientExecuteUrl),
-    JSON.stringify({
-      target: config.backendUrl,
-      frontendUri: config.frontendUrl
-    }),
-    {
-      tags: { name: 'POST /start' },
-      headers: { 'Content-Type': 'application/json' }
-    }
+  return group('POST test client /start', () =>
+    timeRequest(
+      () =>
+        http.post(
+          buildUrl('start', config.testClientExecuteUrl),
+          JSON.stringify({
+            target: config.backendUrl,
+            frontendUri: config.frontendUrl
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' }
+          }
+        ),
+      { isStatusCode201 }
+    )
   )
 }
 


### PR DESCRIPTION
## QA-581

### What?
Aligns ID check scripts to central approach, including load profile definition and adding response time thresholds for groups

#### Changes:
- `deploy/scripts/src/common/utils/config/load-profiles.ts`: Added new `LoadProfile.incremental` load profile - a load profile which slowly ramps up in 25% of the load target every 14 minutes.
   ```mermaid
   xychart-beta
       title "Incremental load profile"
       x-axis "Minutes" 0 --> 56
       y-axis "Load (%)" 0 --> 100
       line [0, 12.5, 25, 25, 25, 25, 25, 25, 37.5, 50, 50, 50, 50, 50, 50, 62.5, 75, 75, 75, 75, 75, 75, 87.5, 100, 100, 100, 100, 100, 100]
   ```
- `deploy/scripts/src/mobile/authorize.test.ts`: 
  - Add response time thresholds
  - Add iterations started and iterations completed metric counters
- `deploy/scripts/src/mobile/backend-e2e.test.ts`:
  - Update load profiles to use `createScenario()`
  - Add response time thresholds
  - Add iterations started and iterations completed metric counters
- `deploy/scripts/src/mobile/frontend-e2e.test.ts`:
  - Update load profiles to use `createScenario()`
  - Add response time thresholds
  - Add iterations started and iterations completed metric counters
- `deploy/scripts/src/mobile/testSteps/backend.ts`: Remove `name` metric tags (group tags are accomplishing the same things)
- `deploy/scripts/src/mobile/testSteps/frontend.ts`: Remove `name` metric tags (group tags are accomplishing the same things)
- `deploy/scripts/src/mobile/utils/test-client.ts`: Added group name and timing boiler-plate to the function definition to reduce duplication elsewhere

---

### Why?
To align scripts approach and improve maintainability and reporting
