### PR TITLE
[QA-599] Removing the duration metric from the load profile of the CIC scenario

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -26,7 +26,7 @@ const profiles: ProfileList = {
   },
   load: {
     ...createScenario('FaceToFace', LoadProfile.short, 3),
-    ...createScenario('CIC', LoadProfile.short, 3, 3)
+    ...createScenario('CIC', LoadProfile.short, 3)
   }
 }
 


### PR DESCRIPTION
## QA-599 <!--Jira Ticket Number-->

### What?
Removes the duration from the `load` load profile of the `CIC` scenario.

#### Changes:
Removes the duration value of 3 from the `load` load profile of the `CIC` scenario 

---

### Why?
To run a successful load test for CIC CRI
