### PR TITLE
[QA-627]: Update TxMA payloads based on latest changes

### DIFF
--- a/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
@@ -1,4 +1,4 @@
-export interface AuthLogInSuccess {
+export interface AuthCreateAccount {
   event_id: string
   event_name: string
   client_id: string
@@ -18,9 +18,20 @@ export interface AuthLogInSuccess {
     phone_number_country_code: number
     rpPairwiseId: string
   }
+  restricted: {
+    device_information: {
+      request_timestamp_ms: number
+      ip_address: string
+      connection_port: number
+      country_code: string
+      user_agent: string
+      accepted_language: number
+      ja3_fingerprint: string
+    }
+  }
 }
 
-export interface AuthCreateAccount {
+export interface AuthLogInSuccess {
   event_id: string
   event_name: string
   client_id: string
@@ -34,11 +45,21 @@ export interface AuthCreateAccount {
     session_id: string
     email: string
     persistent_session_id: string
-    phone: number
+    phone: string
   }
   extensions: {
     phone_number_country_code: number
-    rpPairwiseId: string
+  }
+  restricted: {
+    device_information: {
+      request_timestamp_ms: number
+      ip_address: string
+      connection_port: number
+      country_code: string
+      user_agent: string
+      accepted_language: number
+      ja3_fingerprint: string
+    }
   }
 }
 

--- a/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
@@ -1,16 +1,57 @@
 import { uuidv4 } from '../../common/utils/jslib/index'
 import { AuthLogInSuccess, AuthCreateAccount, AuthAuthorisationReqParsed, DcmawAbortWeb } from './txmaReqFormat'
 
-export function generateAuthLogInSuccess(testID: string, userID: string, emailID: string): AuthLogInSuccess {
+export function generateAuthCreateAccount(
+  testID: string,
+  userID: string,
+  emailID: string,
+  pairWiseID: string
+): AuthCreateAccount {
+  const eventID = `${testID}_${uuidv4()}`
   return {
-    event_id: `${testID}_${uuidv4()}`,
+    event_id: eventID,
+    event_name: 'AUTH_CREATE_ACCOUNT',
+    client_id: 'performanceTestClientId',
+    component_id: 'SharedSignalPerfTest',
+    timestamp: Math.floor(Date.now() / 1000),
+    event_timestamp_ms: Math.floor(Date.now()),
+    user: {
+      user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`
+      govuk_signin_journey_id: uuidv4(),
+      ip_address: '1.2.3.4',
+      email: emailID,
+      session_id: uuidv4(),
+      persistent_session_id: uuidv4(),
+      phone: '07777777777'
+    },
+    extensions: {
+      phone_number_country_code: 44,
+      rpPairwiseId: pairWiseID // `${testID}_performanceTestClientId_${userID}_performanceTestRpPairwiseId`
+    },
+    restricted: {
+      device_information: {
+        request_timestamp_ms: Math.floor(Date.now()),
+        ip_address: '1.2.3.4',
+        connection_port: 12345,
+        country_code: 'GB',
+        user_agent: 'k6/0.52.0 (https://k6.io/)',
+        accepted_language: 24234233,
+        ja3_fingerprint: uuidv4()
+      }
+    }
+  }
+}
+
+export function generateAuthLogInSuccess(eventID: string, userID: string, emailID: string): AuthLogInSuccess {
+  return {
+    event_id: eventID,
     event_name: 'AUTH_LOG_IN_SUCCESS',
     client_id: 'performanceTestClientId',
     component_id: 'SharedSignalPerfTest',
     timestamp: Math.floor(Date.now() / 1000),
     event_timestamp_ms: Math.floor(Date.now()),
     user: {
-      user_id: `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`,
+      user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`,
       govuk_signin_journey_id: uuidv4(),
       ip_address: '1.2.3.4',
       session_id: uuidv4(),
@@ -19,32 +60,18 @@ export function generateAuthLogInSuccess(testID: string, userID: string, emailID
       phone: '07777777777'
     },
     extensions: {
-      phone_number_country_code: 44,
-      rpPairwiseId: `${testID}_performanceTestClientId_${userID}_performanceTestRpPairwiseId`
-    }
-  }
-}
-
-export function generateAuthCreateAccount(testID: string, userID: string, emailID: string): AuthCreateAccount {
-  const evendID = `${testID}_${uuidv4()}`
-  return {
-    event_id: evendID,
-    event_name: 'AUTH_CREATE_ACCOUNT',
-    client_id: 'performanceTestClientId',
-    component_id: 'SharedSignalPerfTest',
-    timestamp: Math.floor(Date.now() / 1000),
-    event_timestamp_ms: Math.floor(Date.now()),
-    user: {
-      user_id: `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`,
-      govuk_signin_journey_id: uuidv4(),
-      ip_address: '1.2.3.4',
-      email: emailID,
-      session_id: uuidv4(),
-      persistent_session_id: uuidv4()
+      phone_number_country_code: 44
     },
-    extensions: {
-      phone_number_country_code: 44,
-      rpPairwiseId: `${testID}_performanceTestClientId_${userID}_performanceTestRpPairwiseId`
+    restricted: {
+      device_information: {
+        request_timestamp_ms: Math.floor(Date.now()),
+        ip_address: '1.2.3.4',
+        connection_port: 12345,
+        country_code: 'GB',
+        user_agent: 'k6/0.52.0 (https://k6.io/)',
+        accepted_language: 24234233,
+        ja3_fingerprint: uuidv4()
+      }
     }
   }
 }

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -98,12 +98,16 @@ export function sendSingleEvent(): void {
 }
 
 export function pairwiseMappingClientEnrichment(): void {
-  const userID = `perfUser${uuidv4()}`
+  const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '') // YYMMDDTHHmmss
+  const testID = `perfTestID${timestamp}`
+  const userID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestCommonSubjectId`
+  const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
+  const eventID = `${testID}_${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
   iterationsStarted.add(1)
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(userID, emailID, journeyID))
-  const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(userID, emailID, journeyID))
+  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID))
+  const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(eventID, userID, emailID))
   const authInitiatedPayload = JSON.stringify(generateAuthReqParsed(journeyID))
   const dcmawAbortPayload = JSON.stringify(generateDcmawAbortWeb(userID, journeyID, emailID))
   sqs.sendMessage(env.sqs_queue, authCreateAccPayload)


### PR DESCRIPTION
## QA-627 <!--Jira Ticket Number-->

### What?
Updated primer and regular event payloads based on the latest changes in the approach.

#### Changes:
- Updated primer event (`AUTH_CREATE_ACCOUNT`) and regular event (`AUTH_LOG_IN_SUCCESS`) to use same user ID and email ID and different event IDs.

---

### Why?
To fix the errors identified in the TxMA smoke testing.