### PR TITLE
[QA-609] Updating the DL lowVolume scenario to 15 iterations per second

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -57,7 +57,7 @@ const profiles: ProfileList = {
   },
   lowVolume: {
     ...createScenario('fraud', LoadProfile.short, 30),
-    ...createScenario('drivingLicence', LoadProfile.short, 5),
+    ...createScenario('drivingLicence', LoadProfile.short, 15),
     ...createScenario('passport', LoadProfile.short, 30)
   },
   stress: {


### PR DESCRIPTION
## QA-609 <!--Jira Ticket Number-->

### What?
Updates the `DrivingLicence` `lowVolume` scenario to have a target volume of 15 iterations per second. 

#### Changes:
Changes the `DrivingLicence` `lowVolume` scenario's target volume to 15 iterations per second. 

---

### Why?
To run a low volume test at 15 iterations per second.

