### PR TITLE
[QA-632]: Add a low volume load profile for TxMA

### DIFF
--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -27,6 +27,7 @@ const profiles: ProfileList = {
   },
   lowVolume: {
     ...createScenario('sendSingleEvent', LoadProfile.short, 30, 2),
+    ...createScenario('sendRegularEvent', LoadProfile.short, 30, 2),
     ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.short, 30, 4)
   },
   load: {


### PR DESCRIPTION
## QA-632 <!--Jira Ticket Number-->

### What?
Add a low volume load profile for TxMA regular event scenario

#### Changes:
- Add a low volume load profile for TxMA regular event scenario with  a target volume of 30 journeys per second.

---

### Why?
To conduct a low volume test for TxMA.