### PR TITLE
[QA-631] Updating the low volume profile for NiNO CRI to 5 iterations per second

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -21,7 +21,7 @@ const profiles: ProfileList = {
     ...createScenario('ninoCheck', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('ninoCheck', LoadProfile.short, 15)
+    ...createScenario('ninoCheck', LoadProfile.short, 5)
   }
 }
 


### PR DESCRIPTION
## QA-631 <!--Jira Ticket Number-->

### What?
Updates the low volume profile for NINO CRI to 5 iterations per second.

#### Changes:
Updates the `lowVolume` load profile for `ninoCheck` in `cri-orange/nino-check.ts` from 15 to 5 iterations per second. 

---

### Why?
To run a low volume test for NINO CRI at 5 iterations per second
