### PR TITLE
[QA-642] Updating the DL CRI low volume profile to 20j/s

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -57,7 +57,7 @@ const profiles: ProfileList = {
   },
   lowVolume: {
     ...createScenario('fraud', LoadProfile.short, 30),
-    ...createScenario('drivingLicence', LoadProfile.short, 15),
+    ...createScenario('drivingLicence', LoadProfile.short, 20),
     ...createScenario('passport', LoadProfile.short, 30)
   },
   stress: {


### PR DESCRIPTION
## QA-642 <!--Jira Ticket Number-->

### What?
Updates the DL CRI low volume load profile to 20 iterations per second. 

#### Changes:
Updates the DL CRI `lowVolume` load profile from 15 to 20 iterations per second. 

---

### Why?
To run a low volume test at 20j/s for DL CRI.
