### PR TITLE
[QA-649]: Reduce BAV target to 5

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -23,7 +23,7 @@ const profiles: ProfileList = {
     ...createScenario('BAV', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('BAV', LoadProfile.full, 10)
+    ...createScenario('BAV', LoadProfile.full, 5)
   }
 }
 


### PR DESCRIPTION
## QA-649 <!--Jira Ticket Number-->

### What?
Reduce the target volume for BAV scenario

#### Changes:
- Reduce the target volume for BAV scenario to 5 journeys per second

---

### Why?
To run a performance test at the revised target volume.