### PR TITLE
[QA-633] Auth - Dynamic Stub Selection for Sign-Up, SignIn and UISignIn Journey

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -66,6 +66,9 @@ const groupMap = {
     'B01_SignUp_01_OrchStubSubmit',
     'B01_SignUp_01_OrchStubSubmit::01_OrchStub',
     'B01_SignUp_01_OrchStubSubmit::02_AuthCall',
+    'B01_SignUp_01_RPStubSubmit',
+    'B01_SignUp_01_RPStubSubmit::01_RPStub',
+    'B01_SignUp_01_RPStubSubmit::02_AuthCall',
     'B01_SignUp_02_CreateOneLogin',
     'B01_SignUp_03_EnterEmailAddress',
     'B01_SignUp_04_EnterOTP',
@@ -140,8 +143,12 @@ const credentials = {
   phoneOTP: getEnv('ACCOUNT_PHONE_OTP')
 }
 
+const route = getEnv('ENVIRONMENT').toLocaleUpperCase()
+const validRoute = ['RP', 'ORCH']
+if (!validRoute.includes(route)) throw new Error(`Route '${route}' not in [${validRoute.toString()}]`)
+
 const env = {
-  orchStub: getEnv('ACCOUNT_ORCH_STUB'),
+  stubEndpoint: getEnv('ACCOUNT_${route}_STUB'),
   staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true',
   authStagingURL: getEnv('ACCOUNT_STAGING_URL')
 }
@@ -204,8 +211,14 @@ export function signUp(): void {
   const mfaOption: mfaType = Math.random() <= 0.5 ? 'SMS' : 'AUTH_APP'
   iterationsStarted.add(1)
 
-  // B01_SignUp_01_OrchStubSubmit
-  res = orchStubSubmit(groups)
+  // B01_SignUp_01_StubSubmit based on the route i.e. RP or ORCH
+  if (route === 'ORCH') {
+    res = orchStubSubmit(groups)
+  } else if (route === 'RP') {
+    res = rpStubSubmit(groups)
+  } else {
+    throw new Error(`Invalid route: ${route}`) // Handle invalid route values
+  }
 
   sleep(1)
 
@@ -372,7 +385,7 @@ export function orchStubSubmit(groups: readonly string[]): Response {
       groups[1].split('::')[1],
       () =>
         http.post(
-          env.orchStub,
+          env.stubEndpoint,
           {
             reauthenticate: '',
             level: 'Cl.Cm',
@@ -405,6 +418,29 @@ export function orchStubSubmit(groups: readonly string[]): Response {
         }
         return http.get(res.headers.Location)
       },
+      {
+        isStatusCode200,
+        ...pageContentCheck('Create your GOV.UK One Login or sign in')
+      }
+    )
+  })
+}
+
+export function rpStubSubmit(groups: readonly string[]): Response {
+  let res: Response
+
+  return timeGroup(groups[3], () => {
+    // 01_RPStubCall (Initial Request)
+    res = timeGroup(
+      groups[4].split('::')[1],
+      () => http.get(env.stubEndpoint + '/prod/start', { redirects: 0 }), //changed orchStub to stubEndPoint
+      { isStatusCode302 }
+    )
+
+    // 02_OIDCStubCall (Redirect Handling)
+    return timeGroup(
+      groups[5].split('::')[1],
+      () => http.get(res.headers.Location), // Follow the redirect
       {
         isStatusCode200,
         ...pageContentCheck('Create your GOV.UK One Login or sign in')

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -148,7 +148,7 @@ const validRoute = ['RP', 'ORCH']
 if (!validRoute.includes(route)) throw new Error(`Route '${route}' not in [${validRoute.toString()}]`)
 
 const env = {
-  stubEndpoint: getEnv('ACCOUNT_${route}_STUB'),
+  stubEndpoint: getEnv(`ACCOUNT_${route}_STUB`),
   staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true',
   authStagingURL: getEnv('ACCOUNT_STAGING_URL')
 }
@@ -224,7 +224,7 @@ export function signUp(): void {
 
   // B01_SignUp_02_CreateOneLogin
   res = timeGroup(
-    groups[3],
+    groups[6],
     () =>
       res.submitForm({
         fields: {
@@ -238,7 +238,7 @@ export function signUp(): void {
   sleep(1)
 
   // B01_SignUp_03_EnterEmailAddress
-  res = timeGroup(groups[4], () => res.submitForm({ fields: { email: testEmail } }), {
+  res = timeGroup(groups[7], () => res.submitForm({ fields: { email: testEmail } }), {
     isStatusCode200,
     ...pageContentCheck('Check your email')
   })
@@ -247,7 +247,7 @@ export function signUp(): void {
 
   // B01_SignUp_04_EnterOTP
   res = timeGroup(
-    groups[5],
+    groups[8],
     () =>
       res.submitForm({
         fields: {
@@ -262,7 +262,7 @@ export function signUp(): void {
 
   // B01_SignUp_05_CreatePassword
   res = timeGroup(
-    groups[6],
+    groups[9],
     () =>
       res.submitForm({
         fields: {
@@ -284,7 +284,7 @@ export function signUp(): void {
     case 'AUTH_APP': {
       // B01_SignUp_06_MFA_AuthApp
       res = timeGroup(
-        groups[7],
+        groups[10],
         () =>
           res.submitForm({
             fields: { mfaOptions: mfaOption }
@@ -301,7 +301,7 @@ export function signUp(): void {
 
       // B01_SignUp_07_MFA_EnterTOTP
       res = timeGroup(
-        groups[8],
+        groups[11],
         () =>
           res.submitForm({
             fields: { code: totp.generateTOTP() }
@@ -316,7 +316,7 @@ export function signUp(): void {
     case 'SMS': {
       // B01_SignUp_08_MFA_SMS
       res = timeGroup(
-        groups[9],
+        groups[12],
         () =>
           res.submitForm({
             fields: { mfaOptions: mfaOption }
@@ -331,7 +331,7 @@ export function signUp(): void {
 
       // B01_SignUp_09_MFA_EnterPhoneNum
       res = timeGroup(
-        groups[10],
+        groups[13],
         () =>
           res.submitForm({
             fields: { phoneNumber }
@@ -343,7 +343,7 @@ export function signUp(): void {
 
       // B01_SignUp_10_MFA_EnterSMSOTP
       res = timeGroup(
-        groups[11],
+        groups[14],
         () =>
           res.submitForm({
             fields: { code: credentials.phoneOTP }
@@ -360,13 +360,13 @@ export function signUp(): void {
   sleep(1)
 
   // B01_SignUp_11_ContinueAccountCreated
-  timeGroup(groups[12], () => {
+  timeGroup(groups[15], () => {
     // 01_AuthCall
-    res = timeGroup(groups[13].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
+    res = timeGroup(groups[16].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
       isStatusCode302
     })
     // 02_OrchStub
-    res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck(testEmail.toLowerCase())
     })

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -475,7 +475,7 @@ export function signIn(): void {
   iterationsStarted.add(1)
 
   // B02_SignIn_01_StubSubmit
-  res = route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
+  route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
 
   sleep(1)
 

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -453,7 +453,7 @@ export function signIn(): void {
   const userData = dataSignIn[execution.vu.idInTest - 1]
   iterationsStarted.add(1)
 
-  // B02_SignIn_01_OrchStubSubmit
+  // B02_SignIn_01_StubSubmit
   res = route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
 
   sleep(1)

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -1,4 +1,3 @@
-// just to verfy the ssh
 import { check, sleep } from 'k6'
 import { SharedArray } from 'k6/data'
 import execution from 'k6/execution'
@@ -86,6 +85,9 @@ const groupMap = {
     'B02_SignIn_01_OrchStubSubmit',
     'B02_SignIn_01_OrchStubSubmit::01_OrchStub',
     'B02_SignIn_01_OrchStubSubmit::02_AuthCall',
+    'B02_SignIn_01_RPStubSubmit',
+    'B02_SignIn_01_RPStubSubmit::01_RPStub',
+    'B02_SignIn_01_RPStubSubmit::02_AuthCall',
     'B02_SignIn_02_ClickSignIn',
     'B02_SignIn_03_EnterEmailAddress',
     'B02_SignIn_04_EnterPassword',
@@ -94,9 +96,11 @@ const groupMap = {
     'B02_SignIn_05_EnterOTP::02_AuthAcceptTerms',
     'B02_SignIn_05_EnterOTP::03_AuthCall',
     'B02_SignIn_05_EnterOTP::04_OrchStub',
+    'B02_SignIn_05_EnterOTP::04_RPStub',
     'B02_SignIn_06_AcceptTermsConditions',
     'B02_SignIn_06_AcceptTermsConditions::01_AuthCall',
-    'B02_SignIn_06_AcceptTermsConditions::02_OrchStub'
+    'B02_SignIn_06_AcceptTermsConditions::02_OrchStub',
+    'B02_SignIn_06_AcceptTermsConditions::02_RPStub'
   ],
   uiSignIn: []
 } as const
@@ -164,7 +168,7 @@ export async function uiSignIn() {
 
   const page: Page = await browser.newPage()
   try {
-    await page.goto(env.orchStub + '/start')
+    await page.goto(env.stubEndpoint + '/start')
     await ClickButton(page, 'button#sign-in-button')
 
     page.locator('input[name="email"]').type(userData.email)
@@ -211,14 +215,8 @@ export function signUp(): void {
   const mfaOption: mfaType = Math.random() <= 0.5 ? 'SMS' : 'AUTH_APP'
   iterationsStarted.add(1)
 
-  // B01_SignUp_01_StubSubmit based on the route i.e. RP or ORCH
-  if (route === 'ORCH') {
-    res = orchStubSubmit(groups)
-  } else if (route === 'RP') {
-    res = rpStubSubmit(groups)
-  } else {
-    throw new Error(`Invalid route: ${route}`) // Handle invalid route values
-  }
+  // B01_SignUp_01_StubSubmit
+  res = route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
 
   sleep(1)
 
@@ -456,12 +454,18 @@ export function signIn(): void {
   iterationsStarted.add(1)
 
   // B02_SignIn_01_OrchStubSubmit
-  res = orchStubSubmit(groups)
+  if (route === 'ORCH') {
+    res = orchStubSubmit(groups)
+  } else if (route === 'RP') {
+    res = rpStubSubmit(groups)
+  } else {
+    throw new Error(`Invalid route: ${route}`) // Handle invalid route values
+  }
 
   sleep(1)
 
   // B02_SignIn_02_ClickSignIn
-  res = timeGroup(groups[3], () => res.submitForm(), {
+  res = timeGroup(groups[6], () => res.submitForm(), {
     isStatusCode200,
     ...pageContentCheck('Enter your email address to sign in to your GOV.UK One Login')
   })
@@ -470,7 +474,7 @@ export function signIn(): void {
 
   // B02_SignIn_03_EnterEmailAddress
   res = timeGroup(
-    groups[4],
+    groups[7],
     () =>
       res.submitForm({
         fields: { email: userData.email }
@@ -500,7 +504,7 @@ export function signIn(): void {
 
   // B02_SignIn_04_EnterPassword
   res = timeGroup(
-    groups[5],
+    groups[8],
     () =>
       res.submitForm({
         fields: { password: credentials.password }
@@ -513,10 +517,10 @@ export function signIn(): void {
   sleep(1)
 
   // B02_SignIn_05_EnterOTP
-  timeGroup(groups[6], () => {
+  timeGroup(groups[9], () => {
     //01_AuthCall
     res = timeGroup(
-      groups[7].split('::')[1],
+      groups[10].split('::')[1],
       () =>
         res.submitForm({
           fields: { code: getOTP() },
@@ -528,48 +532,63 @@ export function signIn(): void {
     acceptNewTerms = res.headers.Location.endsWith('updated-terms-and-conditions')
     if (acceptNewTerms) {
       // 02_AuthAcceptTerms
-      res = timeGroup(groups[8].split('::')[1], () => http.get(env.authStagingURL + res.headers.Location), {
+      res = timeGroup(groups[11].split('::')[1], () => http.get(env.authStagingURL + res.headers.Location), {
         isStatusCode200,
         ...pageContentCheck('terms of use update')
       })
     } else {
       // 03_AuthCall
       res = timeGroup(
-        groups[9].split('::')[1],
+        groups[12].split('::')[1],
         () => http.get(env.authStagingURL + res.headers.Location, { redirects: 0 }),
         {
           isStatusCode302
         }
       )
       // 04_OrchStub
-      res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck(userData.email.toLowerCase())
+      if (route === 'ORCH') {
+        res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location), {
+          isStatusCode200,
+          ...pageContentCheck(userData.email.toLowerCase())
+        })
+        // 04_RPStub
+      } else if (route === 'RP') {
+        res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+          isStatusCode200,
+          ...pageContentCheck(userData.email.toLowerCase())
+        })
+      }
+    }
+
+    if (acceptNewTerms) {
+      // B02_SignIn_06_AcceptTermsConditions
+      timeGroup(groups[15], () => {
+        // 01_AuthCall
+        res = timeGroup(
+          groups[16].split('::')[1],
+          () =>
+            res.submitForm({
+              fields: { termsAndConditionsResult: 'accept' },
+              params: { redirects: 1 }
+            }),
+          { isStatusCode302 }
+        )
+
+        // 02_OrchStub
+        if (route === 'ORCH') {
+          res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck(userData.email.toLowerCase())
+          })
+          // 02_RPStub
+        } else if (route === 'RP') {
+          res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+            isStatusCode200,
+            ...pageContentCheck(userData.email.toLowerCase())
+          })
+        }
       })
+      iterationsCompleted.add(1)
     }
   })
-
-  if (acceptNewTerms) {
-    // B02_SignIn_06_AcceptTermsConditions
-    timeGroup(groups[11], () => {
-      // 01_AuthCall
-      res = timeGroup(
-        groups[12].split('::')[1],
-        () =>
-          res.submitForm({
-            fields: { termsAndConditionsResult: 'accept' },
-            params: { redirects: 1 }
-          }),
-        { isStatusCode302 }
-      )
-
-      // 02_OrchStub
-      res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location), {
-        isStatusCode200,
-        ...pageContentCheck(userData.email.toLowerCase())
-      })
-    })
-  }
-
-  iterationsCompleted.add(1)
 }

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -454,13 +454,7 @@ export function signIn(): void {
   iterationsStarted.add(1)
 
   // B02_SignIn_01_OrchStubSubmit
-  if (route === 'ORCH') {
-    res = orchStubSubmit(groups)
-  } else if (route === 'RP') {
-    res = rpStubSubmit(groups)
-  } else {
-    throw new Error(`Invalid route: ${route}`) // Handle invalid route values
-  }
+  res = route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
 
   sleep(1)
 

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -143,7 +143,7 @@ const credentials = {
   phoneOTP: getEnv('ACCOUNT_PHONE_OTP')
 }
 
-const route = getEnv('ENVIRONMENT').toLocaleUpperCase()
+const route = getEnv('ROUTE').toLocaleUpperCase()
 const validRoute = ['RP', 'ORCH']
 if (!validRoute.includes(route)) throw new Error(`Route '${route}' not in [${validRoute.toString()}]`)
 

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -1,3 +1,4 @@
+// just to verfy the ssh
 import { check, sleep } from 'k6'
 import { SharedArray } from 'k6/data'
 import execution from 'k6/execution'

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -98,11 +98,13 @@ const groupMap = {
     'B02_SignIn_05_EnterOTP::02_AuthAcceptTerms',
     'B02_SignIn_05_EnterOTP::03_AuthCall',
     'B02_SignIn_05_EnterOTP::04_OrchStub',
-    'B02_SignIn_05_EnterOTP::04_RPStub',
+    'B02_SignIn_05_EnterOTP::04_OIDCCall',
+    'B02_SignIn_05_EnterOTP::05_RPStub',
     'B02_SignIn_06_AcceptTermsConditions',
     'B02_SignIn_06_AcceptTermsConditions::01_AuthCall',
     'B02_SignIn_06_AcceptTermsConditions::02_OrchStub',
-    'B02_SignIn_06_AcceptTermsConditions::02_RPStub'
+    'B02_SignIn_06_AcceptTermsConditions::02_OIDCCall',
+    'B02_SignIn_06_AcceptTermsConditions::03_RPStub'
   ],
   uiSignIn: []
 } as const
@@ -558,15 +560,20 @@ export function signIn(): void {
           isStatusCode302
         }
       )
-      // 04_OrchStub
+
       if (route === 'ORCH') {
+        // 04_OrchStub
         res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location), {
           isStatusCode200,
           ...pageContentCheck(userData.email.toLowerCase())
         })
-        // 04_RPStub
       } else if (route === 'RP') {
-        res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
+        // 04_OIDCCall
+        res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+          isStatusCode302
+        })
+        //05_RPStub
+        res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location), {
           isStatusCode200,
           ...pageContentCheck(userData.email.toLowerCase())
         })
@@ -575,10 +582,10 @@ export function signIn(): void {
 
     if (acceptNewTerms) {
       // B02_SignIn_06_AcceptTermsConditions
-      timeGroup(groups[15], () => {
+      timeGroup(groups[16], () => {
         // 01_AuthCall
         res = timeGroup(
-          groups[16].split('::')[1],
+          groups[17].split('::')[1],
           () =>
             res.submitForm({
               fields: { termsAndConditionsResult: 'accept' },
@@ -587,15 +594,19 @@ export function signIn(): void {
           { isStatusCode302 }
         )
 
-        // 02_OrchStub
         if (route === 'ORCH') {
-          res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
+          // 02_OrchStub
+          res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
             isStatusCode200,
             ...pageContentCheck(userData.email.toLowerCase())
           })
-          // 02_RPStub
         } else if (route === 'RP') {
-          res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+          // 02_OIDCCall
+          res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+            isStatusCode302
+          })
+          //03_RPStub
+          res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location), {
             isStatusCode200,
             ...pageContentCheck(userData.email.toLowerCase())
           })

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -49,8 +49,8 @@ const profiles: ProfileList = {
     uiSignIn: {
       executor: 'per-vu-iterations',
       exec: 'uiSignIn',
-      vus: 2,
-      iterations: 10,
+      vus: 1,
+      iterations: 1,
       options: {
         browser: {
           type: 'chromium'
@@ -167,8 +167,15 @@ export async function uiSignIn() {
   const userData = dataSignIn[execution.vu.idInTest - 1]
 
   const page: Page = await browser.newPage()
+
+  let targetUrl = env.stubEndpoint
+  if (route === 'RP') {
+    targetUrl += '/prod/start'
+  } else if (route === 'ORCH') {
+    targetUrl += '?reauthenticate=&level=Cl.Cm&authenticated=no&authenticatedLevel=Cl.Cm&channel=none'
+  }
   try {
-    await page.goto(env.stubEndpoint + '/start')
+    await page.goto(targetUrl)
     await ClickButton(page, 'button#sign-in-button')
 
     page.locator('input[name="email"]').type(userData.email)

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -79,7 +79,9 @@ const groupMap = {
     'B01_SignUp_10_MFA_EnterSMSOTP',
     'B01_SignUp_11_ContinueAccountCreated',
     'B01_SignUp_11_ContinueAccountCreated::01_AuthCall',
-    'B01_SignUp_11_ContinueAccountCreated::02_OrchStub'
+    'B01_SignUp_11_ContinueAccountCreated::02_OrchStubCall',
+    'B01_SignUp_11_ContinueAccountCreated::02_OIDCCall',
+    'B01_SignUp_11_ContinueAccountCreated::03_RPStubCall'
   ],
   signIn: [
     'B02_SignIn_01_OrchStubSubmit',
@@ -223,8 +225,7 @@ export function signUp(): void {
   iterationsStarted.add(1)
 
   // B01_SignUp_01_StubSubmit
-  res = route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
-
+  route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
   sleep(1)
 
   // B01_SignUp_02_CreateOneLogin
@@ -366,17 +367,28 @@ export function signUp(): void {
 
   // B01_SignUp_11_ContinueAccountCreated
   timeGroup(groups[15], () => {
-    // 01_AuthCall
+    // 01_AuthCall (common for ORCH and RP route)
     res = timeGroup(groups[16].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
       isStatusCode302
     })
-    // 02_OrchStub
-    res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
-      isStatusCode200,
-      ...pageContentCheck(testEmail.toLowerCase())
-    })
+    if (route === 'ORCH') {
+      // 02_OrchStub
+      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck(testEmail.toLowerCase())
+      })
+    } else if (route === 'RP') {
+      // 02_OIDCCall
+      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        isStatusCode302
+      })
+      //03_RPStub
+      res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location), {
+        isStatusCode200,
+        ...pageContentCheck(testEmail.toLowerCase())
+      })
+    }
   })
-
   iterationsCompleted.add(1)
 }
 

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -227,7 +227,12 @@ export function signUp(): void {
   iterationsStarted.add(1)
 
   // B01_SignUp_01_StubSubmit
-  route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
+  if (route === 'RP') {
+    res = rpStubSubmit(groups)
+  } else if (route === 'ORCH') {
+    res = orchStubSubmit(groups)
+  }
+
   sleep(1)
 
   // B01_SignUp_02_CreateOneLogin
@@ -475,7 +480,11 @@ export function signIn(): void {
   iterationsStarted.add(1)
 
   // B02_SignIn_01_StubSubmit
-  route == 'ORCH' ? (res = orchStubSubmit(groups)) : (res = rpStubSubmit(groups))
+  if (route === 'RP') {
+    res = rpStubSubmit(groups)
+  } else if (route === 'ORCH') {
+    res = orchStubSubmit(groups)
+  }
 
   sleep(1)
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -441,6 +441,7 @@ Resources:
               ACCOUNT_NEW_PHONE: "/perfTest/account/accounts/newPhone"
               ACCOUNT_PHONE_OTP: "/perfTest/account/fixedPhoneOTP"
               ACCOUNT_ORCH_STUB: "/perfTest/account/authentication/orchStub"
+              ACCOUNT_RP_STUB: "/perfTest/account/authentication/rpStub"
               ACCOUNT_SIGNIN_URL: "/perfTest/account/accounts/signInUrl"
               ACCOUNT_STAGING_URL: "/perfTest/account/authentication/baseUrl"
               DATA_BTM_SQS: "/perfTest/data/btm/perfSQS"


### PR DESCRIPTION
## QA-633 <!--Jira Ticket Number-->

### What?
This pull request enables seamless switching between ORCH and RP stubs for the SignUp, SignIn, and UISignIn journeys using a single environment variable, improving flexibility and maintainability.


#### Changes:
- Introduced a new environment variable `ROUTE` to specify either "ORCH" or "RP" for stub selection.
- Modified the `env` object to use distinct environment variables for `orchStubEndpoint` and `rpStubEndpoint`, dynamically selected based on the `ROUTE` value.
- Updated the `groupMap` included transaction names for rpStubSubmit and added index in the rpStubSubmit accordingly.
- Added conditional logic in the `SignUp` and `SignIn` and `UISignIn` functions to call the appropriate stub submission function (`orchStubSubmit` or `rpStubSubmit`) based on the `ROUTE` value.
- Included error handling in `SignUp` and `SignIn to catch and report invalid `ROUTE` values.

---

### Why?
These changes provide greater flexibility and maintainability by allowing users to select the desired stub (ORCH or RP) at runtime using the `ROUTE` environment variable. This eliminates the need for separate scripts or hardcoded stub endpoints, making the script more adaptable to different testing environments.

