### PR TITLE
[QA-651] fixing a pageContentCheck for the IPVCore Identity scenario

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -416,7 +416,7 @@ export function identity(stubOnly: boolean = false): void {
     // 02_CoreCall
     res = timeGroup(groups[31].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('You’ve successfully proved your identity')
+      ...pageContentCheck('Continue to the service you need to use')
     })
   })
 


### PR DESCRIPTION
## QA-651 <!--Jira Ticket Number-->

### What?
Fixes a `pageContentCheck` for the IPVCore Identity scenario

#### Changes:
- fixes the pageContentCheck for `B01_Identity_10_KBVDataContinue::02_CoreCall`

---

### Why?
To run a successful performance test for the IPV Core Identity scenario.
