### PR TITLE
[QA-664]: Added load profiles for March 2025 PT for Auth scenarios

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -57,6 +57,22 @@ const profiles: ProfileList = {
         }
       }
     }
+  },
+  loadMar2025: {
+    ...createScenario('signUp', LoadProfile.short, 45),
+    ...createScenario('signIn', LoadProfile.short, 50)
+  },
+  soakMar2025: {
+    ...createScenario('signUp', LoadProfile.soak, 45),
+    ...createScenario('signIn', LoadProfile.soak, 50)
+  },
+  spikeNFR: {
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 45),
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 50)
+  },
+  spikeSudden: {
+    ...createScenario('signUp', LoadProfile.spikeSudden, 45),
+    ...createScenario('signIn', LoadProfile.spikeSudden, 50)
   }
 }
 const loadProfile = selectProfile(profiles)

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -147,7 +147,7 @@ function createStages(type: LoadProfile, target: number): Stage[] {
     case LoadProfile.soak:
       return [
         { target, duration: '10m' }, // Ramp up to target throughput over 10 minutes
-        { target, duration: '60m' }, // Maintain steady state at target throughput for 5 minutes
+        { target, duration: '60m' }, // Maintain steady state at target throughput for 60 minutes
         { target, duration: '5m' } // Ramp down over 5 minutes
       ]
     case LoadProfile.spikeNFRSignUp: {
@@ -175,7 +175,7 @@ function createStages(type: LoadProfile, target: number): Stage[] {
       return [
         { target: step, duration: '5m' }, // Ramp up to 33% target throughput over 5 minutes
         { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
-        { target: step * 3, duration: '1s' }, // Ramp up to 100% target throughput over 1 seconds
+        { target: step * 3, duration: '1s' }, // Ramp up to 100% target throughput over 1 second
         { target: step * 3, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ]

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -95,7 +95,11 @@ export enum LoadProfile {
   full,
   deployment,
   rampOnly,
-  incremental
+  incremental,
+  soak,
+  spikeNFRSignUp,
+  spikeNFRSignIn,
+  spikeSudden
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -138,6 +142,42 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target: step * 3, duration: '10m' }, // Maintain steady state at 75% target throughput for 10 minutes
         { target, duration: '4m' }, // Ramp up to target throughput over 4 minutes
         { target, duration: '10m' } // Maintain steady state at target throughput for 10 minutes
+      ]
+    }
+    case LoadProfile.soak:
+      return [
+        { target, duration: '10m' }, // Ramp up to target throughput over 10 minutes
+        { target, duration: '60m' }, // Maintain steady state at target throughput for 5 minutes
+        { target, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    case LoadProfile.spikeNFRSignUp: {
+      const step = target / 2
+      return [
+        { target: step, duration: '4m' }, // Ramp up to 50% target throughput over 4 minutes
+        { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 2, duration: '4m' }, // Ramp up to 100% target throughput over 4 minutes
+        { target: step * 2, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    }
+    case LoadProfile.spikeNFRSignIn: {
+      const step = target / 2
+      return [
+        { target: step, duration: '15s' }, // Ramp up to 50% target throughput over 15 seconds
+        { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 2, duration: '15s' }, // Ramp up to 100% target throughput over 15 seconds
+        { target: step * 2, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    }
+    case LoadProfile.spikeSudden: {
+      const step = target / 3
+      return [
+        { target: step, duration: '5m' }, // Ramp up to 33% target throughput over 5 minutes
+        { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 3, duration: '1s' }, // Ramp up to 100% target throughput over 1 seconds
+        { target: step * 3, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ]
     }
   }


### PR DESCRIPTION
## QA-664 <!--Jira Ticket Number-->

### What?
Added load profiles for March 2025 PT for Auth scenarios

#### Changes:
Added below load profiles for March 2025 PT for Auth sign up and sign in scenarios
- Load
- Soak
- Spike NFR
- Spike Sudden

---

### Why?
To conduct performance tests for Auth at March 2025 volumes