### PR TITLE
[QA-677] Updated AddressCRI load profiles

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -26,6 +26,18 @@ const profiles: ProfileList = {
   },
   stress: {
     ...createScenario('address', LoadProfile.full, 65)
+  },
+  loadMar2025: {
+    ...createScenario('address', LoadProfile.short, 13),
+  },
+  soakMar2025: {
+    ...createScenario('address', LoadProfile.soak, 13),
+  },
+  spikeNFR: {
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 13),
+  },
+  spikeSudden: {
+    ...createScenario('address', LoadProfile.spikeSudden, 13),
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -28,16 +28,16 @@ const profiles: ProfileList = {
     ...createScenario('address', LoadProfile.full, 65)
   },
   loadMar2025: {
-    ...createScenario('address', LoadProfile.short, 13),
+    ...createScenario('address', LoadProfile.short, 13)
   },
   soakMar2025: {
-    ...createScenario('address', LoadProfile.soak, 13),
+    ...createScenario('address', LoadProfile.soak, 13)
   },
   spikeNFR: {
-    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 13),
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 13)
   },
   spikeSudden: {
-    ...createScenario('address', LoadProfile.spikeSudden, 13),
+    ...createScenario('address', LoadProfile.spikeSudden, 13)
   }
 }
 


### PR DESCRIPTION
## QA-677 <!--Jira Ticket Number-->

### What?
Added new profiles for March 2025 Volumes to the existing Orange(Address) script


#### Changes:
- Added loadMar2025, soakMar2025, spikeNFR & spikeSudden profiles

---

### Why?
For the March 2025 Volumes

