### PR TITLE
[QA-676] feat: Add Mar 2025 load profiles for CRI-Lime

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -67,6 +67,22 @@ const profiles: ProfileList = {
   },
   rampOnly: {
     ...createScenario('passport', LoadProfile.rampOnly, 30)
+  },
+  loadMar2025: {
+    ...createScenario('fraud', LoadProfile.short, 13),
+    ...createScenario('passport', LoadProfile.short, 11)
+  },
+  soakMar2025: {
+    ...createScenario('fraud', LoadProfile.soak, 13),
+    ...createScenario('passport', LoadProfile.soak, 11)
+  },
+  spikeNFR: {
+    ...createScenario('fraud', LoadProfile.spikeNFRSignUp, 13),
+    ...createScenario('passport', LoadProfile.spikeNFRSignIn, 11)
+  },
+  spikeSudden: {
+    ...createScenario('fraud', LoadProfile.spikeSudden, 13),
+    ...createScenario('passport', LoadProfile.spikeSudden, 11)
   }
 }
 

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -78,7 +78,7 @@ const profiles: ProfileList = {
   },
   spikeNFR: {
     ...createScenario('fraud', LoadProfile.spikeNFRSignUp, 13),
-    ...createScenario('passport', LoadProfile.spikeNFRSignIn, 11)
+    ...createScenario('passport', LoadProfile.spikeNFRSignUp, 11)
   },
   spikeSudden: {
     ...createScenario('fraud', LoadProfile.spikeSudden, 13),


### PR DESCRIPTION
## QA-676 <!--Jira Ticket Number-->

### What?
This pull request adds a new load profiles for the CRI-Lime `fraud` and `passport` scenarios based on the Mar 2025 level 1 Revised targets.


#### Changes:
Added four new load profiles: loadMar2025, soakMar2025, spikeNFR, and spikeSudden.

---

### Why?
Simulate expected March 2025 traffic and assess system performance.

