### PR TITLE
[QA-678]: Add load profiles for March-25 L2 targets

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -58,21 +58,37 @@ const profiles: ProfileList = {
       }
     }
   },
-  loadMar2025: {
+  loadMar2025_L1: {
     ...createScenario('signUp', LoadProfile.short, 45),
     ...createScenario('signIn', LoadProfile.short, 60)
   },
-  soakMar2025: {
+  soakMar2025_L1: {
     ...createScenario('signUp', LoadProfile.soak, 45),
     ...createScenario('signIn', LoadProfile.soak, 60)
   },
-  spikeNFR: {
+  spikeNFR_L1: {
     ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 45),
     ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 60)
   },
-  spikeSudden: {
+  spikeSudden_L1: {
     ...createScenario('signUp', LoadProfile.spikeSudden, 45),
     ...createScenario('signIn', LoadProfile.spikeSudden, 60)
+  },
+  loadMar2025_L2: {
+    ...createScenario('signUp', LoadProfile.short, 90),
+    ...createScenario('signIn', LoadProfile.short, 120)
+  },
+  soakMar2025_L2: {
+    ...createScenario('signUp', LoadProfile.soak, 90),
+    ...createScenario('signIn', LoadProfile.soak, 120)
+  },
+  spikeNFR_L2: {
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 90),
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 120)
+  },
+  spikeSudden_L2: {
+    ...createScenario('signUp', LoadProfile.spikeSudden, 90),
+    ...createScenario('signIn', LoadProfile.spikeSudden, 120)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-678 <!--Jira Ticket Number-->

### What?
This pull request adds new load profiles to the authentication performance test script to simulate Level 2 traffic targets for March 2025.

#### Changes:
- Added four new load profiles: `loadMar2025_L2`, `soakMar2025_L2`, `spikeNFR_L2`, and `spikeSudden_L2`.
- Configured these profiles to target 90 and 120 iterations per second for `signUp` and `signIn` scenarios respectively.
- Updated Level1 profile names with suffix as `L1`.

---

### Why?
To evaluate the performance at level2 targets.

---

