### PR TITLE
[QA-680] Capture OIDC call response time in rpStubSubmit function

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -99,7 +99,8 @@ const groupMap = {
     'B01_SignUp_01_OrchStubSubmit::02_AuthCall',
     'B01_SignUp_01_RPStubSubmit',
     'B01_SignUp_01_RPStubSubmit::01_RPStub',
-    'B01_SignUp_01_RPStubSubmit::02_AuthCall',
+    'B01_SignUp_01_RPStubSubmit::02_OIDCCall',
+    'B01_SignUp_01_RPStubSubmit::03_AuthCall',
     'B01_SignUp_02_CreateOneLogin',
     'B01_SignUp_03_EnterEmailAddress',
     'B01_SignUp_04_EnterOTP',
@@ -121,7 +122,8 @@ const groupMap = {
     'B02_SignIn_01_OrchStubSubmit::02_AuthCall',
     'B02_SignIn_01_RPStubSubmit',
     'B02_SignIn_01_RPStubSubmit::01_RPStub',
-    'B02_SignIn_01_RPStubSubmit::02_AuthCall',
+    'B02_SignIn_01_RPStubSubmit::02_OIDCCall',
+    'B02_SignIn_01_RPStubSubmit::03_AuthCall',
     'B02_SignIn_02_ClickSignIn',
     'B02_SignIn_03_EnterEmailAddress',
     'B02_SignIn_04_EnterPassword',
@@ -269,7 +271,7 @@ export function signUp(): void {
 
   // B01_SignUp_02_CreateOneLogin
   res = timeGroup(
-    groups[6],
+    groups[7],
     () =>
       res.submitForm({
         fields: {
@@ -283,7 +285,7 @@ export function signUp(): void {
   sleep(1)
 
   // B01_SignUp_03_EnterEmailAddress
-  res = timeGroup(groups[7], () => res.submitForm({ fields: { email: testEmail } }), {
+  res = timeGroup(groups[8], () => res.submitForm({ fields: { email: testEmail } }), {
     isStatusCode200,
     ...pageContentCheck('Check your email')
   })
@@ -292,7 +294,7 @@ export function signUp(): void {
 
   // B01_SignUp_04_EnterOTP
   res = timeGroup(
-    groups[8],
+    groups[9],
     () =>
       res.submitForm({
         fields: {
@@ -307,7 +309,7 @@ export function signUp(): void {
 
   // B01_SignUp_05_CreatePassword
   res = timeGroup(
-    groups[9],
+    groups[10],
     () =>
       res.submitForm({
         fields: {
@@ -329,7 +331,7 @@ export function signUp(): void {
     case 'AUTH_APP': {
       // B01_SignUp_06_MFA_AuthApp
       res = timeGroup(
-        groups[10],
+        groups[11],
         () =>
           res.submitForm({
             fields: { mfaOptions: mfaOption }
@@ -346,7 +348,7 @@ export function signUp(): void {
 
       // B01_SignUp_07_MFA_EnterTOTP
       res = timeGroup(
-        groups[11],
+        groups[12],
         () =>
           res.submitForm({
             fields: { code: totp.generateTOTP() }
@@ -361,7 +363,7 @@ export function signUp(): void {
     case 'SMS': {
       // B01_SignUp_08_MFA_SMS
       res = timeGroup(
-        groups[12],
+        groups[13],
         () =>
           res.submitForm({
             fields: { mfaOptions: mfaOption }
@@ -376,7 +378,7 @@ export function signUp(): void {
 
       // B01_SignUp_09_MFA_EnterPhoneNum
       res = timeGroup(
-        groups[13],
+        groups[14],
         () =>
           res.submitForm({
             fields: { phoneNumber }
@@ -388,7 +390,7 @@ export function signUp(): void {
 
       // B01_SignUp_10_MFA_EnterSMSOTP
       res = timeGroup(
-        groups[14],
+        groups[15],
         () =>
           res.submitForm({
             fields: { code: credentials.phoneOTP }
@@ -405,24 +407,24 @@ export function signUp(): void {
   sleep(1)
 
   // B01_SignUp_11_ContinueAccountCreated
-  timeGroup(groups[15], () => {
+  timeGroup(groups[16], () => {
     // 01_AuthCall (common for ORCH and RP route)
-    res = timeGroup(groups[16].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
+    res = timeGroup(groups[17].split('::')[1], () => res.submitForm({ params: { redirects: 1 } }), {
       isStatusCode302
     })
     if (route === 'ORCH') {
       // 02_OrchStub
-      res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location), {
+      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
         isStatusCode200,
         ...pageContentCheck(testEmail.toLowerCase())
       })
     } else if (route === 'RP') {
       // 02_OIDCCall
-      res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+      res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
         isStatusCode302
       })
       //03_RPStub
-      res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location), {
+      res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location), {
         isStatusCode200,
         ...pageContentCheck(testEmail.toLowerCase())
       })
@@ -487,21 +489,24 @@ export function rpStubSubmit(groups: readonly string[]): Response {
 
   return timeGroup(groups[3], () => {
     // 01_RPStubCall (Initial Request)
-    res = timeGroup(
-      groups[4].split('::')[1],
-      () => http.get(env.stubEndpoint + '/prod/start', { redirects: 0 }), //changed orchStub to stubEndPoint
-      { isStatusCode302 }
-    )
+    res = timeGroup(groups[4].split('::')[1], () => http.get(env.stubEndpoint + '/prod/start', { redirects: 0 }), {
+      //changed orchStub to stubEndPoint
+      isStatusCode302
+    })
 
     // 02_OIDCStubCall (Redirect Handling)
-    return timeGroup(
+    res = timeGroup(
       groups[5].split('::')[1],
-      () => http.get(res.headers.Location), // Follow the redirect
+      () => http.get(res.headers.Location, { redirects: 0 }), // Follow the redirect
       {
-        isStatusCode200,
-        ...pageContentCheck('Create your GOV.UK One Login or sign in')
+        isStatusCode302
       }
     )
+    // 03_AuthCall
+    return timeGroup(groups[6].split('::')[1], () => http.get(res.headers.Location), {
+      isStatusCode200,
+      ...pageContentCheck('Create your GOV.UK One Login or sign in')
+    })
   })
 }
 
@@ -521,7 +526,7 @@ export function signIn(): void {
   sleep(1)
 
   // B02_SignIn_02_ClickSignIn
-  res = timeGroup(groups[6], () => res.submitForm(), {
+  res = timeGroup(groups[7], () => res.submitForm(), {
     isStatusCode200,
     ...pageContentCheck('Enter your email address to sign in to your GOV.UK One Login')
   })
@@ -530,7 +535,7 @@ export function signIn(): void {
 
   // B02_SignIn_03_EnterEmailAddress
   res = timeGroup(
-    groups[7],
+    groups[8],
     () =>
       res.submitForm({
         fields: { email: userData.email }
@@ -560,7 +565,7 @@ export function signIn(): void {
 
   // B02_SignIn_04_EnterPassword
   res = timeGroup(
-    groups[8],
+    groups[9],
     () =>
       res.submitForm({
         fields: { password: credentials.password }
@@ -573,10 +578,10 @@ export function signIn(): void {
   sleep(1)
 
   // B02_SignIn_05_EnterOTP
-  timeGroup(groups[9], () => {
+  timeGroup(groups[10], () => {
     //01_AuthCall
     res = timeGroup(
-      groups[10].split('::')[1],
+      groups[11].split('::')[1],
       () =>
         res.submitForm({
           fields: { code: getOTP() },
@@ -588,14 +593,14 @@ export function signIn(): void {
     acceptNewTerms = res.headers.Location.endsWith('updated-terms-and-conditions')
     if (acceptNewTerms) {
       // 02_AuthAcceptTerms
-      res = timeGroup(groups[11].split('::')[1], () => http.get(env.authStagingURL + res.headers.Location), {
+      res = timeGroup(groups[12].split('::')[1], () => http.get(env.authStagingURL + res.headers.Location), {
         isStatusCode200,
         ...pageContentCheck('terms of use update')
       })
     } else {
       // 03_AuthCall
       res = timeGroup(
-        groups[12].split('::')[1],
+        groups[13].split('::')[1],
         () => http.get(env.authStagingURL + res.headers.Location, { redirects: 0 }),
         {
           isStatusCode302
@@ -604,17 +609,17 @@ export function signIn(): void {
 
       if (route === 'ORCH') {
         // 04_OrchStub
-        res = timeGroup(groups[13].split('::')[1], () => http.get(res.headers.Location), {
+        res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location), {
           isStatusCode200,
           ...pageContentCheck(userData.email.toLowerCase())
         })
       } else if (route === 'RP') {
         // 04_OIDCCall
-        res = timeGroup(groups[14].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+        res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
           isStatusCode302
         })
         //05_RPStub
-        res = timeGroup(groups[15].split('::')[1], () => http.get(res.headers.Location), {
+        res = timeGroup(groups[16].split('::')[1], () => http.get(res.headers.Location), {
           isStatusCode200,
           ...pageContentCheck(userData.email.toLowerCase())
         })
@@ -624,10 +629,10 @@ export function signIn(): void {
 
     if (acceptNewTerms) {
       // B02_SignIn_06_AcceptTermsConditions
-      timeGroup(groups[16], () => {
+      timeGroup(groups[17], () => {
         // 01_AuthCall
         res = timeGroup(
-          groups[17].split('::')[1],
+          groups[18].split('::')[1],
           () =>
             res.submitForm({
               fields: { termsAndConditionsResult: 'accept' },
@@ -638,17 +643,17 @@ export function signIn(): void {
 
         if (route === 'ORCH') {
           // 02_OrchStub
-          res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+          res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location), {
             isStatusCode200,
             ...pageContentCheck(userData.email.toLowerCase())
           })
         } else if (route === 'RP') {
           // 02_OIDCCall
-          res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+          res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
             isStatusCode302
           })
           //03_RPStub
-          res = timeGroup(groups[20].split('::')[1], () => http.get(res.headers.Location), {
+          res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location), {
             isStatusCode200,
             ...pageContentCheck(userData.email.toLowerCase())
           })


### PR DESCRIPTION
## QA-680 <!--Jira Ticket Number-->

### What?
To enhance the `rpStubSubmit` function in the authentication performance test suite to accurately capture and report the response time of the `OIDC` call.

#### Changes:
- Added a timeGroup block specifically around the http.get request for the `OIDC` call within the `rpStubSubmit` function.
- This change ensures that the response time of the `OIDC` call is measured and reported separately in the k6 test results.

---

### Why?
- Isolate and measure the performance of the OIDC call


