### PR TITLE
[QA-682]: Increase TxMA load profile to 500/s

### DIFF
--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -31,6 +31,7 @@ const profiles: ProfileList = {
     ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.short, 30, 4)
   },
   load: {
+    ...createScenario('sendRegularEvent', LoadProfile.full, 500, 2),
     ...createScenario('sendSingleEvent', LoadProfile.full, 750, 2),
     ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.full, 100, 4)
   },


### PR DESCRIPTION
## QA-682 <!--Jira Ticket Number-->

### What?
Increase TxMA load profile to 500 messages per second

#### Changes:
- Increase the load profile for `sendRegularEvent` scenario to 500 messages per second.

---

### Why?
To conduct perf tests for TxMA shared signals at 500 messages per second.