### PR TITLE
[QA-683]: Update Orange config to remove dependency on K6_NO_STATIC_RESOURCES

### DIFF
--- a/deploy/scripts/src/cri-orange/utils/config.ts
+++ b/deploy/scripts/src/cri-orange/utils/config.ts
@@ -6,7 +6,7 @@ export const env = {
   kbvEndPoint: getEnv('IDENTITY_KBV_URL'),
   addressEndPoint: getEnv('IDENTITY_ADDRESS_URL'),
   envName: getEnv('ENVIRONMENT'),
-  staticResources: getEnv('K6_NO_STATIC_RESOURCES') !== 'true'
+  staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true'
 }
 
 export const stubCreds = {


### PR DESCRIPTION
## QA-683 <!--Jira Ticket Number-->

### What?
Update Orange CRI script config to remove dependency on `K6_NO_STATIC_RESOURCES`

#### Changes:
- Remove calling the `getEnv()` for `K6_NO_STATIC_RESOURCES` 

---

### Why?
This is so that the the value of this environment variable does not have to be provided for each test and just for the tests involving static resources.