### PR TITLE
[QA-700] Adding a max duration for the maxVUs calculation to March 2025 tests

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -59,36 +59,36 @@ const profiles: ProfileList = {
     }
   },
   loadMar2025_L1: {
-    ...createScenario('signUp', LoadProfile.short, 45),
-    ...createScenario('signIn', LoadProfile.short, 60)
+    ...createScenario('signUp', LoadProfile.short, 45, 48),
+    ...createScenario('signIn', LoadProfile.short, 60, 8)
   },
   soakMar2025_L1: {
-    ...createScenario('signUp', LoadProfile.soak, 45),
-    ...createScenario('signIn', LoadProfile.soak, 60)
+    ...createScenario('signUp', LoadProfile.soak, 45, 48),
+    ...createScenario('signIn', LoadProfile.soak, 60, 8)
   },
   spikeNFR_L1: {
-    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 45),
-    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 60)
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 45, 48),
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 60, 8)
   },
   spikeSudden_L1: {
-    ...createScenario('signUp', LoadProfile.spikeSudden, 45),
-    ...createScenario('signIn', LoadProfile.spikeSudden, 60)
+    ...createScenario('signUp', LoadProfile.spikeSudden, 45, 48),
+    ...createScenario('signIn', LoadProfile.spikeSudden, 60, 8)
   },
   loadMar2025_L2: {
-    ...createScenario('signUp', LoadProfile.short, 90),
-    ...createScenario('signIn', LoadProfile.short, 120)
+    ...createScenario('signUp', LoadProfile.short, 90, 48),
+    ...createScenario('signIn', LoadProfile.short, 120, 8)
   },
   soakMar2025_L2: {
-    ...createScenario('signUp', LoadProfile.soak, 90),
-    ...createScenario('signIn', LoadProfile.soak, 120)
+    ...createScenario('signUp', LoadProfile.soak, 90, 48),
+    ...createScenario('signIn', LoadProfile.soak, 120, 8)
   },
   spikeNFR_L2: {
-    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 90),
-    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 120)
+    ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 90, 48),
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 120, 8)
   },
   spikeSudden_L2: {
-    ...createScenario('signUp', LoadProfile.spikeSudden, 90),
-    ...createScenario('signIn', LoadProfile.spikeSudden, 120)
+    ...createScenario('signUp', LoadProfile.spikeSudden, 90, 48),
+    ...createScenario('signIn', LoadProfile.spikeSudden, 120, 8)
   }
 }
 const loadProfile = selectProfile(profiles)

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -60,35 +60,35 @@ const profiles: ProfileList = {
   },
   loadMar2025_L1: {
     ...createScenario('signUp', LoadProfile.short, 45, 48),
-    ...createScenario('signIn', LoadProfile.short, 60, 8)
+    ...createScenario('signIn', LoadProfile.short, 60, 24)
   },
   soakMar2025_L1: {
     ...createScenario('signUp', LoadProfile.soak, 45, 48),
-    ...createScenario('signIn', LoadProfile.soak, 60, 8)
+    ...createScenario('signIn', LoadProfile.soak, 60, 24)
   },
   spikeNFR_L1: {
     ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 45, 48),
-    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 60, 8)
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 60, 24)
   },
   spikeSudden_L1: {
     ...createScenario('signUp', LoadProfile.spikeSudden, 45, 48),
-    ...createScenario('signIn', LoadProfile.spikeSudden, 60, 8)
+    ...createScenario('signIn', LoadProfile.spikeSudden, 60, 24)
   },
   loadMar2025_L2: {
     ...createScenario('signUp', LoadProfile.short, 90, 48),
-    ...createScenario('signIn', LoadProfile.short, 120, 8)
+    ...createScenario('signIn', LoadProfile.short, 120, 24)
   },
   soakMar2025_L2: {
     ...createScenario('signUp', LoadProfile.soak, 90, 48),
-    ...createScenario('signIn', LoadProfile.soak, 120, 8)
+    ...createScenario('signIn', LoadProfile.soak, 120, 24)
   },
   spikeNFR_L2: {
     ...createScenario('signUp', LoadProfile.spikeNFRSignUp, 90, 48),
-    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 120, 8)
+    ...createScenario('signIn', LoadProfile.spikeNFRSignIn, 120, 24)
   },
   spikeSudden_L2: {
     ...createScenario('signUp', LoadProfile.spikeSudden, 90, 48),
-    ...createScenario('signIn', LoadProfile.spikeSudden, 120, 8)
+    ...createScenario('signIn', LoadProfile.spikeSudden, 120, 24)
   }
 }
 const loadProfile = selectProfile(profiles)

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -69,20 +69,20 @@ const profiles: ProfileList = {
     ...createScenario('passport', LoadProfile.rampOnly, 30)
   },
   loadMar2025: {
-    ...createScenario('fraud', LoadProfile.short, 13),
-    ...createScenario('passport', LoadProfile.short, 11)
+    ...createScenario('fraud', LoadProfile.short, 13, 8),
+    ...createScenario('passport', LoadProfile.short, 11, 8)
   },
   soakMar2025: {
-    ...createScenario('fraud', LoadProfile.soak, 13),
-    ...createScenario('passport', LoadProfile.soak, 11)
+    ...createScenario('fraud', LoadProfile.soak, 13, 8),
+    ...createScenario('passport', LoadProfile.soak, 11, 8)
   },
   spikeNFR: {
-    ...createScenario('fraud', LoadProfile.spikeNFRSignUp, 13),
-    ...createScenario('passport', LoadProfile.spikeNFRSignUp, 11)
+    ...createScenario('fraud', LoadProfile.spikeNFRSignUp, 13, 8),
+    ...createScenario('passport', LoadProfile.spikeNFRSignUp, 11, 8)
   },
   spikeSudden: {
-    ...createScenario('fraud', LoadProfile.spikeSudden, 13),
-    ...createScenario('passport', LoadProfile.spikeSudden, 11)
+    ...createScenario('fraud', LoadProfile.spikeSudden, 13, 8),
+    ...createScenario('passport', LoadProfile.spikeSudden, 11, 8)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -28,16 +28,16 @@ const profiles: ProfileList = {
     ...createScenario('address', LoadProfile.full, 65)
   },
   loadMar2025: {
-    ...createScenario('address', LoadProfile.short, 13)
+    ...createScenario('address', LoadProfile.short, 13, 20)
   },
   soakMar2025: {
-    ...createScenario('address', LoadProfile.soak, 13)
+    ...createScenario('address', LoadProfile.soak, 13, 20)
   },
   spikeNFR: {
-    ...createScenario('address', LoadProfile.spikeNFRSignUp, 13)
+    ...createScenario('address', LoadProfile.spikeNFRSignUp, 13, 20)
   },
   spikeSudden: {
-    ...createScenario('address', LoadProfile.spikeSudden, 13)
+    ...createScenario('address', LoadProfile.spikeSudden, 13, 20)
   }
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -41,19 +41,19 @@ const profiles: ProfileList = {
   },
   loadMar2025: {
     ...createScenario('identity', LoadProfile.short, 20, 44),
-    ...createScenario('idReuse', LoadProfile.short, 40, 28)
+    ...createScenario('idReuse', LoadProfile.short, 40, 8)
   },
   soakMar2025: {
     ...createScenario('identity', LoadProfile.soak, 20, 44),
-    ...createScenario('idReuse', LoadProfile.soak, 40, 28)
+    ...createScenario('idReuse', LoadProfile.soak, 40, 8)
   },
   spikeNFR: {
     ...createScenario('identity', LoadProfile.spikeNFRSignUp, 20, 44),
-    ...createScenario('idReuse', LoadProfile.spikeNFRSignIn, 40, 28)
+    ...createScenario('idReuse', LoadProfile.spikeNFRSignIn, 40, 8)
   },
   spikeSudden: {
     ...createScenario('identity', LoadProfile.spikeSudden, 20, 44),
-    ...createScenario('idReuse', LoadProfile.spikeSudden, 40, 28)
+    ...createScenario('idReuse', LoadProfile.spikeSudden, 40, 8)
   },
   dataCreationForIDReuse: {
     identity: {

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -40,20 +40,20 @@ const profiles: ProfileList = {
     ...createScenario('orchStubIsolatedTest', LoadProfile.full, 100)
   },
   loadMar2025: {
-    ...createScenario('identity', LoadProfile.short, 20),
-    ...createScenario('idReuse', LoadProfile.short, 40)
+    ...createScenario('identity', LoadProfile.short, 20, 44),
+    ...createScenario('idReuse', LoadProfile.short, 40, 28)
   },
   soakMar2025: {
-    ...createScenario('identity', LoadProfile.soak, 20),
-    ...createScenario('idReuse', LoadProfile.soak, 40)
+    ...createScenario('identity', LoadProfile.soak, 20, 44),
+    ...createScenario('idReuse', LoadProfile.soak, 40, 28)
   },
   spikeNFR: {
-    ...createScenario('identity', LoadProfile.spikeNFRSignUp, 20),
-    ...createScenario('idReuse', LoadProfile.spikeNFRSignIn, 40)
+    ...createScenario('identity', LoadProfile.spikeNFRSignUp, 20, 44),
+    ...createScenario('idReuse', LoadProfile.spikeNFRSignIn, 40, 28)
   },
   spikeSudden: {
-    ...createScenario('identity', LoadProfile.spikeSudden, 20),
-    ...createScenario('idReuse', LoadProfile.spikeSudden, 40)
+    ...createScenario('identity', LoadProfile.spikeSudden, 20, 44),
+    ...createScenario('idReuse', LoadProfile.spikeSudden, 40, 28)
   },
   dataCreationForIDReuse: {
     identity: {


### PR DESCRIPTION
## QA-700 <!--Jira Ticket Number-->

### What?
Adds a maximum duration to the March 2025 volume load profiles for all scenarios

#### Changes:
- Adds a maximum duration value (of 4 * no. of steps) to each March 2025 volume loadProfiles for Auth, IPV Core, Address CRI, Passport CRI, and Fraud CRI. 

---

### Why?
To correct the number of maxVUs allocated during a test

