### PR TITLE
QA-722 Add L2 load profs, Include in IPV test

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -180,6 +180,26 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target: 0, duration: '5m' } // Ramp down over 5 minutes
       ]
     }
+    case LoadProfile.spikeNFRSignUpL2: {
+      const step = Math.round(target / 2)
+      return [
+        { target: step, duration: '8m' }, // Ramp up to 50% target throughput over 8 minutes
+        { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 2, duration: '8m' }, // Ramp up to 100% target throughput over 8 minutes
+        { target: step * 2, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    }
+    case LoadProfile.spikeNFRSignInL2: {
+      const step = Math.round(target / 2)
+      return [
+        { target: step, duration: '30s' }, // Ramp up to 50% target throughput over 30 seconds
+        { target: step, duration: '10m' }, // Maintain steady state at 50% target throughput for 10 minutes
+        { target: step * 2, duration: '30s' }, // Ramp up to 100% target throughput over 30 seconds
+        { target: step * 2, duration: '10m' }, // Maintain steady state at 100% target throughput for 10 minutes
+        { target: 0, duration: '5m' } // Ramp down over 5 minutes
+      ]
+    }
   }
 }
 

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -99,7 +99,9 @@ export enum LoadProfile {
   soak,
   spikeNFRSignUp,
   spikeNFRSignIn,
-  spikeSudden
+  spikeSudden,
+  spikeNFRSignUpL2,
+  spikeNFRSignInL2
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -55,6 +55,22 @@ const profiles: ProfileList = {
     ...createScenario('identity', LoadProfile.spikeSudden, 20, 44),
     ...createScenario('idReuse', LoadProfile.spikeSudden, 40, 8)
   },
+  loadMar2025L2: {
+    ...createScenario('identity', LoadProfile.short, 40, 44),
+    ...createScenario('idReuse', LoadProfile.short, 80, 8)
+  },
+  soakMar2025L2: {
+    ...createScenario('identity', LoadProfile.soak, 40, 44),
+    ...createScenario('idReuse', LoadProfile.soak, 80, 8)
+  },
+  spikeNFRL2: {
+    ...createScenario('identity', LoadProfile.spikeNFRSignUpL2, 40, 44),
+    ...createScenario('idReuse', LoadProfile.spikeNFRSignInL2, 80, 8)
+  },
+  spikeSuddenL2: {
+    ...createScenario('identity', LoadProfile.spikeSudden, 40, 44),
+    ...createScenario('idReuse', LoadProfile.spikeSudden, 80, 8)
+  },
   dataCreationForIDReuse: {
     identity: {
       executor: 'per-vu-iterations',


### PR DESCRIPTION
## QA-722

### What?
Add Level 2 load profiles into configuration, Include level 2 load profiles in IPV test script

#### Changes:
- Add 2 Level 2 load profiles into load profile configuration, 
- Include 4 level 2 load profiles in IPV test script

---

### Why?
To enable load, soak, spike, sudden spike tests against Level 2 targets for IPV core

---

