### PR TITLE
[QA-740] Fraud - Updated SuddenSpike_L2 profile

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -97,7 +97,7 @@ const profiles: ProfileList = {
     ...createScenario('passport', LoadProfile.spikeNFRSignUp, 22, 8)
   },
   spikeSudden_L2: {
-    ...createScenario('fraud', LoadProfile.spikeSudden, 26, 8),
+    ...createScenario('fraud', LoadProfile.spikeSudden, 27, 8),
     ...createScenario('passport', LoadProfile.spikeSudden, 22, 8)
   }
 }


### PR DESCRIPTION
## QA-740 <!--Jira Ticket Number-->

### What?
Updated the Load profile for the Fraud CRI SpikeSudden_L2 scenario.
#### Changes:
- Changed from 26j/s to 27j/s 
---

### Why?
To accommodate for the 33% ramp up

---


