### PR TITLE
[QA-741] updating target volumes for address CRI

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -23,7 +23,7 @@ const profiles: ProfileList = {
     ...createScenario('internationalAddress', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('address', LoadProfile.short, 5),
+    ...createScenario('address', LoadProfile.short, 10),
     ...createScenario('internationalAddress', LoadProfile.short, 5)
   },
   stress: {

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -23,8 +23,8 @@ const profiles: ProfileList = {
     ...createScenario('internationalAddress', LoadProfile.smoke)
   },
   lowVolume: {
-    ...createScenario('address', LoadProfile.short, 10),
-    ...createScenario('internationalAddress', LoadProfile.short, 3)
+    ...createScenario('address', LoadProfile.short, 10, 20),
+    ...createScenario('internationalAddress', LoadProfile.short, 3, 16)
   },
   stress: {
     ...createScenario('address', LoadProfile.full, 65)

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -24,7 +24,7 @@ const profiles: ProfileList = {
   },
   lowVolume: {
     ...createScenario('address', LoadProfile.short, 10),
-    ...createScenario('internationalAddress', LoadProfile.short, 5)
+    ...createScenario('internationalAddress', LoadProfile.short, 3)
   },
   stress: {
     ...createScenario('address', LoadProfile.full, 65)


### PR DESCRIPTION
## QA-741 <!--Jira Ticket Number-->

### What?
Updates the low volume target volume for the `address` and `internationalAddress` scenarios to 10j/s and 5j/s respectively

#### Changes:
- Updates the low-volume load profile target volume for the `address` and `internationalAddress` scenarios to 10j/s and 5j/s respectively.

---

### Why?
To run a combined low volume test for `address` and `internationalAddress`.

