### PR TITLE
QA-714 Update Lime for L2 Spike tests

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -93,8 +93,8 @@ const profiles: ProfileList = {
     ...createScenario('passport', LoadProfile.soak, 22, 8)
   },
   spikeNFR_L2: {
-    ...createScenario('fraud', LoadProfile.spikeNFRSignUp, 26, 8),
-    ...createScenario('passport', LoadProfile.spikeNFRSignUp, 22, 8)
+    ...createScenario('fraud', LoadProfile.spikeNFRSignUpL2, 26, 8),
+    ...createScenario('passport', LoadProfile.spikeNFRSignUpL2, 22, 8)
   },
   spikeSudden_L2: {
     ...createScenario('fraud', LoadProfile.spikeSudden, 27, 8),


### PR DESCRIPTION
## QA-714

### What?
Update Lime for L2 Spike tests

#### Changes:
- Update Lime script for L2 Spike tests to use the spikeNFRSignUpL2 load profile

---

### Why?
To match the test approach for L2 tests

---
