### PR TITLE
[QA-746] Mobile FE - Added load profile to run test with 95 Iteration per second

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -34,6 +34,9 @@ const profiles: ProfileList = {
   load: {
     ...createScenario('mamIphonePassport', LoadProfile.full, 40, 40)
   },
+  nfrload: {
+    ...createScenario('mamIphonePassport', LoadProfile.full, 95, 40)
+  },
   deploy: {
     ...createScenario('mamIphonePassport', LoadProfile.deployment, 1, 40)
   },


### PR DESCRIPTION
## QA-746 <!--Jira Ticket Number-->

### What?
Load profile addition to run the test with NFR target

#### Changes:
- Added load profile `nfrload` to execute the load test with a target throughput of 95 iteration per second

---

### Why?
To conduct the load test for Mobile FE against NFR target throughput.

---
