### PR TITLE
[QA-744]: Add a separate profile for Address scenario

### DIFF
--- a/deploy/scripts/src/common/utils/request/timing.ts
+++ b/deploy/scripts/src/common/utils/request/timing.ts
@@ -41,7 +41,7 @@ export function timeRequest<T>(fn: () => T, checks: Checkers<T> = {}): T {
   if (check(res, checks)) {
     durations.add(duration)
   } else {
-    fail('Response validation failed')
+    fail(res.status + res.body)
   }
   return res
 }

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -64,6 +64,21 @@ const profiles: ProfileList = {
       ],
       exec: 'addressAdhocScenario'
     }
+  },
+  addressUpdatedConfig: {
+    address: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 130, duration: '129s' },
+        { target: 130, duration: '900s' },
+        { target: 0, duration: '300s' }
+      ],
+      exec: 'address'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -73,7 +73,7 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 130, duration: '129s' },
+        { target: 130, duration: '120s' },
         { target: 130, duration: '900s' },
         { target: 0, duration: '120s' }
       ],

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -1,5 +1,5 @@
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
-import { fail } from 'k6'
+import { fail, sleep } from 'k6'
 import { type Options } from 'k6/options'
 import http, { type Response } from 'k6/http'
 import { SharedArray } from 'k6/data'
@@ -73,9 +73,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 130, duration: '120s' },
-        { target: 130, duration: '900s' },
-        { target: 0, duration: '120s' }
+        { target: 20, duration: '200s' },
+        { target: 20, duration: '180s' }
       ],
       exec: 'address'
     }
@@ -186,7 +185,7 @@ export function address(): void {
     )
   })
 
-  sleepBetween(1, 3)
+  sleep(1)
 
   // B02_Address_02_SearchPostCode
   res = timeGroup(
@@ -212,7 +211,7 @@ export function address(): void {
     { isStatusCode200, ...pageContentCheck('Enter your address') }
   )
 
-  sleepBetween(1, 3)
+  sleep(1)
 
   // B02_Address_04_VerifyAddress
   res = timeGroup(
@@ -225,7 +224,7 @@ export function address(): void {
     { isStatusCode200, ...pageContentCheck('Confirm your details') }
   )
 
-  sleepBetween(1, 3)
+  sleep(1)
 
   // B02_Address_05_ConfirmDetails
   timeGroup(groups[6], () => {

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -75,7 +75,7 @@ const profiles: ProfileList = {
       stages: [
         { target: 130, duration: '129s' },
         { target: 130, duration: '900s' },
-        { target: 0, duration: '300s' }
+        { target: 0, duration: '120s' }
       ],
       exec: 'address'
     }

--- a/deploy/scripts/src/cri-orange/utils/config.ts
+++ b/deploy/scripts/src/cri-orange/utils/config.ts
@@ -6,7 +6,7 @@ export const env = {
   kbvEndPoint: getEnv('IDENTITY_KBV_URL'),
   addressEndPoint: getEnv('IDENTITY_ADDRESS_URL'),
   envName: getEnv('ENVIRONMENT'),
-  staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true'
+  staticResources: __ENV.K6_NO_STATIC_RESOURCES == 'true'
 }
 
 export const stubCreds = {


### PR DESCRIPTION
## QA-744 <!--Jira Ticket Number-->

### What?
Add a separate profile for Address scenario

#### Changes:
- Added a separate load profile for Address scenario with the `ramping-arrival-rate` executor with the `timeUnit` as **10 seconds**. Adjusted the `target` load accordingly and updated the `preAllocatedVU` and `maxVUs` count to match baseline.
- Updated the `timeRequest` function to return the HTTP error status and body if an assertion fails.

---

### Why?
To conduct a performance test for Address scenario with the updated config.