### PR TITLE
[QA-748] Increasing TxMA sendRegularEvent target volume

### DIFF
--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -31,7 +31,7 @@ const profiles: ProfileList = {
     ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.short, 30, 4)
   },
   load: {
-    ...createScenario('sendRegularEvent', LoadProfile.full, 500, 2),
+    ...createScenario('sendRegularEvent', LoadProfile.full, 2000, 2),
     ...createScenario('sendSingleEvent', LoadProfile.full, 750, 2),
     ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.full, 100, 4)
   },


### PR DESCRIPTION
## QA-748 <!--Jira Ticket Number-->

### What?
Increases the TxMA `sendRegularEvent` target volume to 2000j/s
#### Changes:
- Increases the target volume for the `sendRegularEvent` load profile in the TxMA script to 2000j/s.

---

### Why?
To run a load test for TxMA at 2000j/s

