### PR TITLE
[QA-750]: Updated startRate and timeUnit in Address CRI

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -68,13 +68,13 @@ const profiles: ProfileList = {
   addressUpdatedConfig: {
     address: {
       executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '10s',
+      startRate: 6,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '200s' },
-        { target: 20, duration: '180s' }
+        { target: 120, duration: '200s' },
+        { target: 120, duration: '180s' }
       ],
       exec: 'address'
     }


### PR DESCRIPTION
## QA-XXX <!--Jira Ticket Number-->

### What?
Updated startRate and timeUnit in Address CRI

#### Changes:
- Updated startRate to 6 and timeUnit to 1 minute in Address CRI

---

### Why?
To validate that the performance of the Address CRI is similar with the updated test design.