### PR TITLE
Added Low Volume Profiles

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -94,6 +94,32 @@ const profiles: ProfileList = {
       ],
       exec: 'passport'
     }
+  },
+  lowVolPerf007Test: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' },
+        { target: 20, duration: '180s' }
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' },
+        { target: 10, duration: '180s' }
+      ],
+      exec: 'idReuse'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-753 <!--Jira Ticket Number-->

### What?
Added load profiles to the IPV Core script for low volume tests.

#### Changes:
- Added a low volume Perf test for the identity scenario
- Added a low volume Perf test for the IDRe-use scenario

---

### Why?
In order to run low volume performance tests as part of the Performance testing initiative.

---

