### PR TITLE
[QA-755]: Add Lime CRI low volume load profiles

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -108,32 +108,32 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 20, duration: '180s' } // // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '200s' },
+        { target: 20, duration: '180s' }
       ],
       exec: 'fraud'
     },
     drivingLicence: {
       executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '10s',
+      startRate: 2,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 40, duration: '400s' },
+        { target: 40, duration: '180s' }
       ],
       exec: 'drivingLicence'
     },
     passport: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
-      timeUnit: '10s',
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 12, duration: '120s' },
+        { target: 12, duration: '180s' }
       ],
       exec: 'passport'
     }

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -99,6 +99,44 @@ const profiles: ProfileList = {
   spikeSudden_L2: {
     ...createScenario('fraud', LoadProfile.spikeSudden, 27, 8),
     ...createScenario('passport', LoadProfile.spikeSudden, 22, 8)
+  },
+  lowVolPerf007Test: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'fraud'
+    },
+    drivingLicence: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'drivingLicence'
+    },
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'passport'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-755 <!--Jira Ticket Number-->

### What?
Add low volume load profiles for Lime CRI scenarios

#### Changes:
- Add low volume load profiles for Fraud, Driving Licence and Passport CRI scenarios.

---

### Why?
To run low volume performance tests for Lime CRIs