### PR TITLE
[QA-756]: Add low volume load profiles for Orange CRI

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -65,16 +65,16 @@ const profiles: ProfileList = {
       exec: 'addressAdhocScenario'
     }
   },
-  addressUpdatedConfig: {
+  lowVolumePERF007Test: {
     address: {
       executor: 'ramping-arrival-rate',
-      startRate: 6,
-      timeUnit: '1m',
+      startRate: 1,
+      timeUnit: '10s',
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 120, duration: '200s' },
-        { target: 120, duration: '180s' }
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
       ],
       exec: 'address'
     }

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -24,6 +24,20 @@ const profiles: ProfileList = {
   },
   stress: {
     ...createScenario('kbv', LoadProfile.full, 14)
+  },
+  lowVolumePERF007Test: {
+    kbv: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'kbv'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -22,6 +22,20 @@ const profiles: ProfileList = {
   },
   lowVolume: {
     ...createScenario('ninoCheck', LoadProfile.short, 5)
+  },
+  lowVolumePERF007Test: {
+    ninoCheck: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'ninoCheck'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-756 <!--Jira Ticket Number-->

### What?
Add low volume load profiles for Orange CRI scenarios.

#### Changes:
- Add low volume load profiles for Address, KBV and NiNO Check scenarios.

---

### Why?
To run low volume performance tests for Orange CRIs