### PR TITLE
[QA-761]: Updated load profile for lowVolPERF007Test

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -31,8 +31,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 1, duration: '60s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 1, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '60s' },
+        { target: 1, duration: '180s' }
       ],
       exec: 'ninoCheck'
     }

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -27,12 +27,12 @@ const profiles: ProfileList = {
     ninoCheck: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
-      timeUnit: '10s',
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 20, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '60s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
       ],
       exec: 'ninoCheck'
     }


### PR DESCRIPTION
## QA-761 <!--Jira Ticket Number-->

### What?
Update the load profile to execute NiNo test with 1 Journey per minute throughput target
#### Changes:

- Start rate is 1 user per 1m 
- Ramp-up is 1 journey in 60 seconds and steady state target is 1 journey per minute.

---

### Why?
To run the test with flat volume.

---

