### PR TITLE
[QA-762] Updating OLH and Auth Load Profiles

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -89,6 +89,32 @@ const profiles: ProfileList = {
   spikeSudden_L2: {
     ...createScenario('signUp', LoadProfile.spikeSudden, 90, 48),
     ...createScenario('signIn', LoadProfile.spikeSudden, 120, 24)
+  },
+  lowVolPerf007Test: {
+    signUp: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' },
+        { target: 20, duration: '180s' }
+      ],
+      exec: 'signUp'
+    },
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' },
+        { target: 10, duration: '180s' }
+      ],
+      exec: 'signIn'
+    }
   }
 }
 const loadProfile = selectProfile(profiles)

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -34,6 +34,56 @@ const profiles: ProfileList = {
     ...createScenario('deleteAccount', LoadProfile.full, 30, 24),
     ...createScenario('validateUser', LoadProfile.full, 10, 40),
     ...createScenario('contactsPage', LoadProfile.full, 10, 4)
+  },
+  lowVolumePERF007Test: {
+    changeEmail: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'changeEmail'
+    },
+    changePassword: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'changePassword'
+    },
+    changePhone: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'changePhone'
+    },
+    deleteAccount: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'deleteAccount'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-762 <!--Jira Ticket Number-->

### What?
Updates the OLH and Auth scenarios with the new `lowVolPerf007Test` profile.

#### Changes:
- Adds the `lowVolPerf007Test` load profile to OLH `changeEmail`, `changePassword`, `changePhone`, and `deleteAccount` scenarios at a target volume of 2j/s, and to the Auth `signIn` and `signUp` at 10j/s and 2j/s respectively. 

---

### Why?
To run flat load profile tests for OLH and Auth

