### PR TITLE
[QA-773] - Parameterise Load Profile for Pipeline Execution to eliminate Hardcoded Profiles

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -18,6 +18,19 @@ import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { getEnv } from '../common/utils/config/environment-variables'
 import { getThresholds } from '../common/utils/config/thresholds'
 
+const dprofile = {
+  // scenarioName: getEnv('K6_SCENARIO_NAME'),
+  // executor: getEnv('K6_EXECUTOR'),
+  startRate: parseInt(getEnv('K6_START_RATE') || '1', 10),
+  timeUnit: getEnv('K6_TIME_UNIT'),
+  preAllocatedVUs: parseInt(getEnv('K6_PRE_ALLOCATED_VUS') || '100', 10),
+  maxVUs: parseInt(getEnv('K6_MAXVUS') || '400', 10),
+  rutarget: parseInt(getEnv('K6_RU_TARGET') || '20', 10),
+  ruduration: getEnv('K6_RU_DURATION'),
+  sstarget: parseInt(getEnv('K6_SS_TARGET') || '20', 10),
+  ssduration: getEnv('K6_SS_DURATION')
+}
+
 const profiles: ProfileList = {
   smoke: {
     ...createScenario('changeEmail', LoadProfile.smoke),
@@ -83,6 +96,22 @@ const profiles: ProfileList = {
         { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
       ],
       exec: 'deleteAccount'
+    }
+  },
+  dynamicProfile: {
+    changeEmail: {
+      //executor: dprofile.executor,
+      executor: 'ramping-arrival-rate',
+      startRate: dprofile.startRate,
+      timeUnit: dprofile.timeUnit,
+      preAllocatedVUs: dprofile.preAllocatedVUs,
+      maxVUs: dprofile.maxVUs,
+      stages: [
+        { target: dprofile.rutarget, duration: dprofile.ruduration },
+        { target: dprofile.sstarget, duration: dprofile.ssduration }
+      ],
+      //exec: dprofile.scenarioName
+      exec: 'changeEmail'
     }
   }
 }


### PR DESCRIPTION
## QA-773 <!--Jira Ticket Number-->

### What?
This Pull Request introduces parameterisation to our k6 performance test scripts, enabling us to dynamically configure load profiles without code modifications.

#### Changes:

- Environment Variable based Load Profile: The k6 script now reads key load profile settings from environment variables:
- K6_START_RATE: Initial arrival rate of virtual users.
- K6_TIME_UNIT: Time unit for arrival rate calculations
- K6_PRE_ALLOCATED_VUS: Number of pre-allocated virtual users.
- K6_MAXVUS: Maximum concurrent virtual users.
- K6_RU_TARGET: Target arrival rate for the ramp-up phase.
- K6_RU_DURATION: Duration of the ramp-up phase (in seconds).
- K6_SS_TARGET: Target arrival rate for the steady-state phase.
- K6_SS_DURATION: Duration of the steady-state phase (in seconds).

---

### Why?
We can now quickly adjust load test parameters without modifying the script, speeding up testing cycles
---

