### PR TITLE
[QA-774] Adding load profiles and script fixes to IPV Core.

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -120,6 +120,32 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
+  },
+  perf006Iteration1: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the historical peak calculation.
+        { target: 20, duration: '15m' } // Target to be updated based on the historical peak calculation.
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' }, // Target to be updated based on the historical peak calculation.
+        { target: 20, duration: '15m' } // Target to be updated based on the historical peak calculation.
+      ],
+      exec: 'idReuse'
+    }
   }
 }
 
@@ -130,37 +156,38 @@ const groupMap = {
     'B01_Identity_02_GoToFullJourneyRoute',
     'B01_Identity_02_GoToFullJourneyRoute::01_OrchStubCall',
     'B01_Identity_02_GoToFullJourneyRoute::02_CoreCall',
-    'B01_Identity_03_ClickContinueStartPage',
-    'B01_Identity_03_ClickContinueStartPage::01_CoreCall',
-    'B01_Identity_03_ClickContinueStartPage::02_DCMAWStub',
-    'B01_Identity_04_DCMAWContinue',
-    'B01_Identity_04_DCMAWContinue::01_DCMAWStub',
-    'B01_Identity_04_DCMAWContinue::02_CoreCall',
-    'B01_Identity_05_ContinueOnPYIStartPage',
-    'B01_Identity_05_ContinueOnPYIStartPage::01_CoreCall',
-    'B01_Identity_05_ContinueOnPYIStartPage::02_PassStub',
-    'B01_Identity_05_ContinueOnPYIStartPage::02_DLStub',
-    'B01_Identity_06_DocumentDataContinue',
-    'B01_Identity_06_DocumentDataContinue::01_PassStub',
-    'B01_Identity_06_DocumentDataContinue::01_DLStub',
-    'B01_Identity_06_DocumentDataContinue::02_CoreCall',
-    'B01_Identity_06_DocumentDataContinue::03_AddStub',
-    'B01_Identity_07_AddrDataContinue',
-    'B01_Identity_07_AddrDataContinue::01_AddStub',
-    'B01_Identity_07_AddrDataContinue::02_CoreCall',
-    'B01_Identity_07_AddrDataContinue::03_FraudStub',
-    'B01_Identity_08_FraudDataContinue',
-    'B01_Identity_08_FraudDataContinue::01_FraudStub',
-    'B01_Identity_08_FraudDataContinue::02_CoreCall',
-    'B01_Identity_09_PreKBVTransition',
-    'B01_Identity_09_PreKBVTransition::01_CoreCall',
-    'B01_Identity_09_PreKBVTransition::02_KBVStub',
-    'B01_Identity_10_KBVDataContinue',
-    'B01_Identity_10_KBVDataContinue::01_KBVStub',
-    'B01_Identity_10_KBVDataContinue::02_CoreCall',
-    'B01_Identity_11_ContinueSuccessPage',
-    'B01_Identity_11_ContinueSuccessPage::01_CoreCall',
-    'B01_Identity_11_ContinueSuccessPage::02_OrchStub'
+    'B01_Identity_03_LiveInTheUK',
+    'B01_Identity_04_ClickContinueStartPage',
+    'B01_Identity_04_ClickContinueStartPage::01_CoreCall',
+    'B01_Identity_04_ClickContinueStartPage::02_DCMAWStub',
+    'B01_Identity_05_DCMAWContinue',
+    'B01_Identity_05_DCMAWContinue::01_DCMAWStub',
+    'B01_Identity_05_DCMAWContinue::02_CoreCall',
+    'B01_Identity_06_ContinueOnPYIStartPage',
+    'B01_Identity_06_ContinueOnPYIStartPage::01_CoreCall',
+    'B01_Identity_06_ContinueOnPYIStartPage::02_PassStub',
+    'B01_Identity_06_ContinueOnPYIStartPage::02_DLStub',
+    'B01_Identity_07_DocumentDataContinue',
+    'B01_Identity_07_DocumentDataContinue::01_PassStub',
+    'B01_Identity_07_DocumentDataContinue::01_DLStub',
+    'B01_Identity_07_DocumentDataContinue::02_CoreCall',
+    'B01_Identity_07_DocumentDataContinue::03_AddStub',
+    'B01_Identity_08_AddrDataContinue',
+    'B01_Identity_08_AddrDataContinue::01_AddStub',
+    'B01_Identity_08_AddrDataContinue::02_CoreCall',
+    'B01_Identity_08_AddrDataContinue::03_FraudStub',
+    'B01_Identity_09_FraudDataContinue',
+    'B01_Identity_09_FraudDataContinue::01_FraudStub',
+    'B01_Identity_09_FraudDataContinue::02_CoreCall',
+    'B01_Identity_10_PreKBVTransition',
+    'B01_Identity_10_PreKBVTransition::01_CoreCall',
+    'B01_Identity_10_PreKBVTransition::02_KBVStub',
+    'B01_Identity_11_KBVDataContinue',
+    'B01_Identity_11_KBVDataContinue::01_KBVStub',
+    'B01_Identity_11_KBVDataContinue::02_CoreCall',
+    'B01_Identity_12_ContinueSuccessPage',
+    'B01_Identity_12_ContinueSuccessPage::01_CoreCall',
+    'B01_Identity_12_ContinueSuccessPage::02_OrchStub'
   ],
   idReuse: [
     'B02_IDReuse_01_LoginToCore',
@@ -265,7 +292,7 @@ export function identity(stubOnly: boolean = false): void {
     // 02_CoreCall
     res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('Tell us if you have one of the following types of photo ID') // Do you live in the UK, the Channel Islands or the Isle of Man
+      ...pageContentCheck('Do you live in the UK, the Channel Islands or the Isle of Man') // Do you live in the UK, the Channel Islands or the Isle of Man
     })
   })
   if (stubOnly) {
@@ -275,7 +302,6 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  /*
   // B01_Identity_03_LiveInTheUK
   res = timeGroup(
     groups[4],
@@ -285,13 +311,12 @@ export function identity(stubOnly: boolean = false): void {
       }),
     { isStatusCode200, ...pageContentCheck('Tell us if you have one of the following types of photo ID') }
   )
-    */
 
-  // B01_Identity_03_ClickContinueStartPage
-  timeGroup(groups[4], () => {
+  // B01_Identity_04_ClickContinueStartPage
+  timeGroup(groups[5], () => {
     // 01_CoreCall
     res = timeGroup(
-      groups[5].split('::')[1],
+      groups[6].split('::')[1],
       () =>
         res.submitForm({
           fields: { journey: 'appTriage' },
@@ -300,7 +325,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_DCMAWStub
-    res = timeGroup(groups[6].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[7].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('DOC Checking App (Stub)')
     })
@@ -308,11 +333,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_04_DCMAWContinue
-  timeGroup(groups[7], () => {
+  // B01_Identity_05_DCMAWContinue
+  timeGroup(groups[8], () => {
     // 01_DCMAWStub
     res = timeGroup(
-      groups[8].split('::')[1],
+      groups[9].split('::')[1],
       () =>
         res.submitForm({
           fields: {
@@ -324,7 +349,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_CoreCall
-    res = timeGroup(groups[9].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+    res = timeGroup(groups[10].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Enter your UK passport details')
     })
@@ -332,11 +357,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_05_ContinueOnPYIStartPage
-  timeGroup(groups[10], () => {
+  // B01_Identity_06_ContinueOnPYIStartPage
+  timeGroup(groups[11], () => {
     // 01_CoreCall
     res = timeGroup(
-      groups[11].split('::')[1],
+      groups[12].split('::')[1],
       () =>
         res.submitForm({
           fields: { journey: passport ? 'ukPassport' : 'drivingLicence' },
@@ -345,7 +370,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_XXXStub
-    const name = (passport ? groups[12] : groups[13]).split('::')[1]
+    const name = (passport ? groups[13] : groups[14]).split('::')[1]
     const content = passport ? 'UK Passport (Stub)' : 'Driving Licence (Stub)'
     res = timeGroup(name, () => http.get(res.headers.Location), {
       isStatusCode200,
@@ -355,10 +380,10 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_06_DocumentDataContinue
-  timeGroup(groups[14], () => {
+  // B01_Identity_07_DocumentDataContinue
+  timeGroup(groups[15], () => {
     // 01_XXXStub
-    const name = (passport ? groups[15] : groups[16]).split('::')[1]
+    const name = (passport ? groups[16] : groups[17]).split('::')[1]
     res = timeGroup(
       name,
       () =>
@@ -381,11 +406,11 @@ export function identity(stubOnly: boolean = false): void {
     )
 
     // 02_CoreCall
-    res = timeGroup(groups[17].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+    res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
       isStatusCode302
     })
     // 03_AddStub
-    res = timeGroup(groups[18].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[19].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Address (Stub)')
     })
@@ -393,11 +418,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_07_AddrDataContinue
-  timeGroup(groups[19], () => {
+  // B01_Identity_08_AddrDataContinue
+  timeGroup(groups[20], () => {
     // 01_AddStub
     res = timeGroup(
-      groups[20].split('::')[1],
+      groups[21].split('::')[1],
       () =>
         res.submitForm({
           fields: { jsonPayload: passport ? addressPayloadP : addressPayloadDL },
@@ -406,11 +431,11 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_CoreCall
-    res = timeGroup(groups[21].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
+    res = timeGroup(groups[22].split('::')[1], () => http.get(res.headers.Location, { redirects: 0 }), {
       isStatusCode302
     })
     // 03_FraudStub
-    res = timeGroup(groups[22].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[23].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Fraud Check (Stub)')
     })
@@ -418,11 +443,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_08_FraudDataContinue
-  timeGroup(groups[23], () => {
+  // B01_Identity_09_FraudDataContinue
+  timeGroup(groups[24], () => {
     // 01_FraudStub
     res = timeGroup(
-      groups[24].split('::')[1],
+      groups[25].split('::')[1],
       () =>
         res.submitForm({
           fields: passport
@@ -440,7 +465,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_CoreCall
-    res = timeGroup(groups[25].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[26].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Answer security questions')
     })
@@ -448,11 +473,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_09_PreKBVTransition
-  timeGroup(groups[26], () => {
+  // B01_Identity_10_PreKBVTransition
+  timeGroup(groups[27], () => {
     // 01_CoreCall
     res = timeGroup(
-      groups[27].split('::')[1],
+      groups[28].split('::')[1],
       () =>
         res.submitForm({
           params: { redirects: 0 }
@@ -460,7 +485,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_KBVStub
-    res = timeGroup(groups[28].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[29].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Knowledge Based Verification (Stub)')
     })
@@ -468,11 +493,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_10_KBVDataContinue
-  timeGroup(groups[29], () => {
+  // B01_Identity_11_KBVDataContinue
+  timeGroup(groups[30], () => {
     // 01_KBVStub
     res = timeGroup(
-      groups[30].split('::')[1],
+      groups[31].split('::')[1],
       () =>
         res.submitForm({
           fields: {
@@ -484,7 +509,7 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_CoreCall
-    res = timeGroup(groups[31].split('::')[1], () => http.get(res.headers.Location), {
+    res = timeGroup(groups[32].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Continue to the service you need to use')
     })
@@ -492,11 +517,11 @@ export function identity(stubOnly: boolean = false): void {
 
   sleepBetween(0.5, 1)
 
-  // B01_Identity_11_ContinueSuccessPage
-  timeGroup(groups[32], () => {
+  // B01_Identity_12_ContinueSuccessPage
+  timeGroup(groups[33], () => {
     // 01_CoreCall
     res = timeGroup(
-      groups[33].split('::')[1],
+      groups[34].split('::')[1],
       () =>
         res.submitForm({
           params: { redirects: 0 }
@@ -505,7 +530,7 @@ export function identity(stubOnly: boolean = false): void {
     )
     // 02_OrchStub
     res = timeGroup(
-      groups[34].split('::')[1],
+      groups[35].split('::')[1],
       () =>
         http.get(res.headers.Location, {
           headers: { Authorization: `Basic ${encodedCredentials}` }


### PR DESCRIPTION
## QA-774 <!--Jira Ticket Number-->

### What?
Adds the PERF006 Iteration 1 load profiles and includes some script changes to the `identity` journey.

#### Changes:
- Adds the `perf006Iteration1` load profile for the identity and idReuse journeys. 
- Adds the `B01_Identity_03_LiveInTheUK` back into the identity scenario script

---

### Why?
To run a combined IPV Core `identity` and `idReuse` test at PERF006 Iteration 1 volumes.
