### PR TITLE
[QA-774] Decreasing preAllocatedVU Count for idReuse.

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -138,7 +138,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 100,
+      preAllocatedVUs: 20,
       maxVUs: 54,
       stages: [
         { target: 9, duration: '5s' },


### PR DESCRIPTION
## QA-774 <!--Jira Ticket Number-->

### What?
Decreased the preAllocatedVU Count for the `idReuse` scanerio.

#### Changes:
- decreases the preAllocatedVUs for the `idReuse` scenario to 20 (below the maxVU Count)

---

### Why?
To successfully run a `perf006Iteration1` test for IPV Core

