### PR TITLE
[QA-775] - Added lowVolumePerf007Test load profile in MobileFE

### DIFF
--- a/deploy/scripts/src/mobile/frontend-e2e.test.ts
+++ b/deploy/scripts/src/mobile/frontend-e2e.test.ts
@@ -45,6 +45,20 @@ const profiles: ProfileList = {
   },
   incrementalLoad: {
     ...createScenario('mamIphonePassport', LoadProfile.incremental, 100)
+  },
+  lowVolumePERF007Test: {
+    mamIphonePassport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '200s' },
+        { target: 20, duration: '180s' }
+      ],
+      exec: 'mamIphonePassport'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-775 <!--Jira Ticket Number-->

### What?
Updates the MobileFE scenario with the new lowVolPerf007Test profile.

#### Changes:
- Adds the lowVolPerf007Test load profile to MobileFE scenario at a target volume of 2j/s.

---

### Why?
To run flat load profile test for MobileFE
---

