### PR TITLE
Added Perf006 load profile for auth

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -115,6 +115,32 @@ const profiles: ProfileList = {
       ],
       exec: 'signIn'
     }
+  },
+  perf006Iteration1: {
+    signUp: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 297,
+      stages: [
+        { target: 90, duration: '90s' },
+        { target: 90, duration: '15m' }
+      ],
+      exec: 'signUp'
+    },
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 306,
+      stages: [
+        { target: 17, duration: '9s' },
+        { target: 17, duration: '15m' }
+      ],
+      exec: 'signIn'
+    }
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-776 <!--Jira Ticket Number-->

### What?
Added a perf-006 load profile to the auth script.
#### Changes:
- Adds the perf006Iteration1 load profile for the sign-up & sign-in journeys.
---
### Why?
To run a combined Auth test in the pipeline at PERF-006 volumes.

