### PR TITLE
[QA-778]: Add Iteration 1 targets for Lime scripts

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -146,7 +146,7 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 150, duration: '150s' },
+        { target: 150, duration: '151s' },
         { target: 150, duration: '120s' }
       ],
       exec: 'fraud'
@@ -170,7 +170,7 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 20, duration: '20s' },
+        { target: 20, duration: '21s' },
         { target: 20, duration: '120s' }
       ],
       exec: 'passport'

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -137,6 +137,44 @@ const profiles: ProfileList = {
       ],
       exec: 'passport'
     }
+  },
+  perf006Iteration1: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 150, duration: '150s' },
+        { target: 150, duration: '120s' }
+      ],
+      exec: 'fraud'
+    },
+    drivingLicence: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 25, duration: '26s' },
+        { target: 25, duration: '120s' }
+      ],
+      exec: 'drivingLicence'
+    },
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 20, duration: '20s' },
+        { target: 20, duration: '120s' }
+      ],
+      exec: 'passport'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-778 <!--Jira Ticket Number-->

### What?
Add Iteration 1 test targets for Lime scenarios

#### Changes:
- Fraud - 15 journeys per second
- DL - 2.5 journeys per second
- Passport - 2 journeys per second.
---

### Why?
To execute iteration 1 tests for Lime products