### PR TITLE
[QA-778]:Increase steady state duration for lime scripts

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -147,7 +147,7 @@ const profiles: ProfileList = {
       maxVUs: 400,
       stages: [
         { target: 150, duration: '151s' },
-        { target: 150, duration: '120s' }
+        { target: 150, duration: '15m' }
       ],
       exec: 'fraud'
     },
@@ -159,7 +159,7 @@ const profiles: ProfileList = {
       maxVUs: 400,
       stages: [
         { target: 25, duration: '26s' },
-        { target: 25, duration: '120s' }
+        { target: 25, duration: '15m' }
       ],
       exec: 'drivingLicence'
     },
@@ -171,7 +171,7 @@ const profiles: ProfileList = {
       maxVUs: 400,
       stages: [
         { target: 20, duration: '21s' },
-        { target: 20, duration: '120s' }
+        { target: 20, duration: '15m' }
       ],
       exec: 'passport'
     }


### PR DESCRIPTION
## QA-778 <!--Jira Ticket Number-->

### What?
Increase steady state duration for lime scripts

#### Changes:
- Increase steady state duration for lime scripts to 15 minutes

---

### Why?
To run performance test for lime products