### PR TITLE
[QA-779] Reducing the Fraud SSF Inbound target volume

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -20,7 +20,7 @@ const profiles: ProfileList = {
     ...createScenario('fraud', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('fraud', LoadProfile.full, 250, 3)
+    ...createScenario('fraud', LoadProfile.full, 3, 3)
   },
   stress: {
     ...createScenario('fraud', LoadProfile.full, 2500, 3)

--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -20,7 +20,7 @@ const profiles: ProfileList = {
     ...createScenario('fraud', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('fraud', LoadProfile.full, 3, 3)
+    ...createScenario('fraud', LoadProfile.short, 3, 3)
   },
   stress: {
     ...createScenario('fraud', LoadProfile.full, 2500, 3)


### PR DESCRIPTION
## QA-779 <!--Jira Ticket Number-->

### What?
Reduces the Fraud SSF Inbound target volume to 3 messages per second

#### Changes:
Reduces the Fraud SSF Inbound target volume to 3 messages per second

---

### Why?
To run a performance test for Fraud SSF Inbound at 3 messages per second. 
