### PR TITLE
[QA-779] Changing duration for preAllocatedVU calculation in Fraud SSF Script

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -20,7 +20,7 @@ const profiles: ProfileList = {
     ...createScenario('fraud', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('fraud', LoadProfile.short, 3, 3)
+    ...createScenario('fraud', LoadProfile.short, 3, 4)
   },
   stress: {
     ...createScenario('fraud', LoadProfile.full, 2500, 3)


### PR DESCRIPTION
## QA-779 <!--Jira Ticket Number-->

### What?
Changes the duration from 3 to 4 so the `preAllocatedVUs` is an integer n the Fraud SSF Inbound script.  

#### Changes:
Changes the duration from 3 to 4 so the `preAllocatedVUs` number is calculated is an integer in the Fraud SSF Inbound script.  

---

### Why?
To successfully run a performance test for Fraud SSF Inbound. 


