### PR TITLE
[QA 782] OLH landingPage Scenario and load profile updates

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -39,51 +39,63 @@ const profiles: ProfileList = {
   lowVolumePERF007Test: {
     changeEmail: {
       executor: 'ramping-arrival-rate',
-      startRate: 2,
-      timeUnit: '1s',
+      startRate: 12,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 1000,
       stages: [
-        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '5s' },
+        { target: 1, duration: '180s' }
       ],
       exec: 'changeEmail'
     },
     changePassword: {
       executor: 'ramping-arrival-rate',
-      startRate: 2,
-      timeUnit: '1s',
+      startRate: 12,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 1000,
       stages: [
-        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '5s' },
+        { target: 1, duration: '180s' }
       ],
       exec: 'changePassword'
     },
     changePhone: {
       executor: 'ramping-arrival-rate',
-      startRate: 2,
-      timeUnit: '1s',
+      startRate: 12,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 1000,
       stages: [
-        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '5s' },
+        { target: 1, duration: '180s' }
       ],
       exec: 'changePhone'
     },
     deleteAccount: {
       executor: 'ramping-arrival-rate',
-      startRate: 2,
-      timeUnit: '1s',
+      startRate: 12,
+      timeUnit: '1m',
       preAllocatedVUs: 100,
       maxVUs: 1000,
       stages: [
-        { target: 10, duration: '200s' }, // Target to be updated based on the percentage split confirmed by the app team
-        { target: 10, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+        { target: 1, duration: '5s' },
+        { target: 1, duration: '180s' }
       ],
       exec: 'deleteAccount'
+    },
+    landingPage: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 56, duration: '280s' }, // Target to be updated based on the percentage split confirmed by the app team
+        { target: 56, duration: '180s' } // Target to be updated based on the percentage split confirmed by the app team
+      ],
+      exec: 'landingPage'
     }
   }
 }


### PR DESCRIPTION
## QA-782 <!--Jira Ticket Number-->

### What?
This PR adds a scenario for navigating to the landing page, and updates all `lowVolumePERF007Test` profiles with updated volumes. 

#### Changes:
- adds the `landingPage()` function/scenario
- Updated the `lowVolumePERF007Test` load profiles with new target volumes of 56 journeys per minute for `landingPage`, and 1 journey per minute for `changeEmail`, `changePassword`, `deleteAccount`, and `changePhone`. 

---

### Why?
- To run a combined OLH test for all 5 scenarios.

