### PR TITLE
[QA-777] PERF006Iteration1 load profile target corrected

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -45,8 +45,8 @@ const profiles: ProfileList = {
       preAllocatedVUs: 100,
       maxVUs: 400,
       stages: [
-        { target: 5, duration: '51s' },
-        { target: 5, duration: '15m' }
+        { target: 50, duration: '51s' },
+        { target: 50, duration: '15m' }
       ],
       exec: 'ninoCheck'
     }


### PR DESCRIPTION
## QA-777 <!--Jira Ticket Number-->

### What?
For NiNO check ppdated target in  PERF006 iteration 1 load profile

#### Changes:
- Target value updated from 5 to 50 in perf006Iteration1 load profile.

---

### Why?
To achieve the target throughput of 5 journey per second, since time unit is 10s hence to target value will be translated to 5 as a target throughput for ramp-up and steady state.

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
