### PR TITLE
Update Orange KBV scenario with PERF006 profiles

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -38,6 +38,20 @@ const profiles: ProfileList = {
       ],
       exec: 'kbv'
     }
+  },
+  perf006Iteration1: {
+    kbv: {
+      executor: 'ramping-arrival-rate',
+      startRate: 6,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 156, duration: '27s' },
+        { target: 156, duration: '15m' }
+      ],
+      exec: 'kbv'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-783 <!--Jira Ticket Number-->

### What?
Add a profile for Experian KBV PERF006 iteration 1


#### Changes:
- Added a profile to the Experian KBV scenario named PERF006 iteration 1.

---

### Why?
To conduct a performance test for Experian KBV at the PERF 006 Targets.
