### PR TITLE
[QA-785] Updating the IPV Core PERF006 volumes

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -127,10 +127,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '10s',
       preAllocatedVUs: 100,
-      maxVUs: 1476,
+      maxVUs: 504,
       stages: [
-        { target: 410, duration: '410s' },
-        { target: 410, duration: '15m' }
+        { target: 140, duration: '141s' },
+        { target: 140, duration: '15m' }
       ],
       exec: 'identity'
     },
@@ -138,11 +138,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 20,
-      maxVUs: 54,
+      preAllocatedVUs: 15,
+      maxVUs: 18,
       stages: [
-        { target: 9, duration: '5s' },
-        { target: 9, duration: '15m' }
+        { target: 3, duration: '3s' },
+        { target: 3, duration: '15m' }
       ],
       exec: 'idReuse'
     }


### PR DESCRIPTION
## QA-785 <!--Jira Ticket Number-->

### What?
Lowers the IPV Core PERF0006 volumes 

#### Changes:
- Lowers the `identity` PERF006 target volume to 14 j/s, and therefore changing the ramp-up duration to 410s and `maxVU` count to 504 (12 * 3 * 14)
- Lowers the `idReuse` PERF006 target volume to 3j/s, and therefore changing the ramp-up duration to 3s, `maxVU` Count to 18 (2 * 3 * 4), and `preAllocatedVUs` to 15. 

---

### Why?
to run a PERF006 volume test at lower volumes 

