### PR TITLE
QA-788 Load profile changes for IPV core

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -146,6 +146,10 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('identity', LoadProfile.spikeI2HighTraffic, 35, 44),
+    ...createScenario('idReuse', LoadProfile.spikeI2HighTraffic, 32, 8)
   }
 }
 


### PR DESCRIPTION
## QA-788 Load profile changes for IPV core for PERF006 Iteration2 targets 

### What?
Changing Load profile to the PERF006 Iteration2 targets which accommodate Spike tests

#### Changes:
 spikeI2HighTraffic: {
    ...createScenario('identity', LoadProfile.spikeI2HighTraffic, 35, 44),
    ...createScenario('idReuse', LoadProfile.spikeI2HighTraffic, 32, 8)
  }

---

### Why?
As part of PERF006 Iteration2 targets which accommodate Spike tests

---

