### PR TITLE
[QA-793] Adding a new load profile for Fraud.

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -103,7 +103,8 @@ export enum LoadProfile {
   spikeNFRSignUpL2,
   spikeNFRSignInL2,
   spikeI2LowTraffic,
-  spikeI2HighTraffic
+  spikeI2HighTraffic,
+  steadyStateOnly
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -227,6 +228,12 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target, duration: '1s' }, // Ramp up to 100% target throughput over 1 second
         { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
         { target: 0, duration: '1s' } // Ramp down over 1 second
+      ]
+    }
+    case LoadProfile.steadyStateOnly: {
+      return [
+        { target, duration: '1s' }, // Ramp-up to 100% volume in 1 second
+        { target, duration: '6m' } // Maintain 100% volume for 6 minutes
       ]
     }
   }

--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -24,6 +24,9 @@ const profiles: ProfileList = {
   },
   stress: {
     ...createScenario('fraud', LoadProfile.full, 2500, 3)
+  },
+  steadyStateOnly: {
+    ...createScenario('fraud', LoadProfile.steadyStateOnly, 250, 3)
   }
 }
 


### PR DESCRIPTION
## QA-793 <!--Jira Ticket Number-->

### What?
Adds in a new steady-state only load profile for the `fraud/test.ts` script

#### Changes:
- Adds in the `steadyStateOnly` profile to `load-profiles.ts `, which ramps up to 100% volume in 1 second and maintains it for 6 minutes. 

---

### Why?
To run a test for Fraud at 250 messages per second for only a 6 minute steady state period. 

