### PR TITLE
QA-795 Load profile for PEAK test-IPV core

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -156,7 +156,7 @@ const profiles: ProfileList = {
       maxVUs: 432,
       stages: [
         { target: 120, duration: '121s' },
-        { target: 120, duration: '15m' }
+        { target: 120, duration: '30m' }
       ],
       exec: 'identity'
     },
@@ -168,7 +168,7 @@ const profiles: ProfileList = {
       maxVUs: 66,
       stages: [
         { target: 11, duration: '6s' },
-        { target: 11, duration: '15m' }
+        { target: 11, duration: '30m' }
       ],
       exec: 'idReuse'
     }


### PR DESCRIPTION
## QA-795 Load profile for PEAK test-IPV core

### What?
Load profile for PEAK test-IPV core

#### Changes:
perf006Iteration2PeakTest: {
    identity: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 432,
      stages: [
        { target: 120, duration: '121s' },
        { target: 120, duration: '30m' }
      ],
      exec: 'identity'
    },
    idReuse: {
      executor: 'ramping-arrival-rate',
      startRate: 2,
      timeUnit: '1s',
      preAllocatedVUs: 15,
      maxVUs: 66,
      stages: [
        { target: 11, duration: '6s' },
        { target: 11, duration: '30m' }
      ],
      exec: 'idReuse'
    }
  },

---

### Why?
IPV core peak test

---

### Related:
