### PR TITLE
QA-794 : CRI Address & KBV profile updates for Perf006 Iteration 2

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -92,6 +92,23 @@ const profiles: ProfileList = {
       ],
       exec: 'address'
     }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('address', LoadProfile.spikeI2HighTraffic, 35, 20)
+  },
+  perf006Iteration2PeakTest: {
+    address: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 120, duration: '121s' },
+        { target: 120, duration: '30m' }
+      ],
+      exec: 'address'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -52,6 +52,24 @@ const profiles: ProfileList = {
       ],
       exec: 'kbv'
     }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('kbv', LoadProfile.spikeI2HighTraffic, 4)
+  },
+
+  perf006Iteration2PeakTest: {
+    kbv: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 12, duration: '13s' },
+        { target: 12, duration: '30m' }
+      ],
+      exec: 'kbv'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -53,8 +53,8 @@ const profiles: ProfileList = {
       exec: 'kbv'
     }
   },
-  spikeI2HighTraffic: {
-    ...createScenario('kbv', LoadProfile.spikeI2HighTraffic, 4)
+  spikeI2LowTraffic: {
+    ...createScenario('kbv', LoadProfile.spikeI2LowTraffic, 4) //rounded to 4 from 3.5
   },
 
   perf006Iteration2PeakTest: {


### PR DESCRIPTION
[QA-794](https://govukverify.atlassian.net/browse/QA-794)

What?
CRI Address & KBV scenarios will be tested for spike and peak load profiles

Changes:

Added the below profiles

Address

spikeI2HighTraffic: {
    ...createScenario('address', LoadProfile.spikeI2HighTraffic, 35, 20)
  },
  perf006Iteration2PeakTest: {
    address: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 400,
      stages: [
        { target: 120, duration: '121s' },
        { target: 120, duration: '30m' }
      ],
      exec: 'address'
    }
  }
KBV

  spikeI2LowTraffic: {
    ...createScenario('kbv', LoadProfile.spikeI2LowTraffic, 4) //rounded to 4 from 3.5
  },

  perf006Iteration2PeakTest: {
    kbv: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 400,
      stages: [
        { target: 12, duration: '13s' },
        { target: 12, duration: '30m' }
      ],
      exec: 'kbv'
    }
  }
Why?
To facilitate Perf006 iteration 2 tests of Address & KBV

[QA-794]: https://govukverify.atlassian.net/browse/QA-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ