### PR TITLE
QA-799..DL and DL Attestation PERF 006 Iteration 2 Spike test changes

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -189,6 +189,10 @@ const profiles: ProfileList = {
       ],
       exec: 'passport'
     }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('drivingLicense', LoadProfile.spikeI2HighTraffic, 4, 9),
+    ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 4, 9)
   }
 }
 

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -192,7 +192,7 @@ const profiles: ProfileList = {
   },
   spikeI2HighTraffic: {
     ...createScenario('drivingLicense', LoadProfile.spikeI2HighTraffic, 4, 9),
-    ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 4, 9)
+    ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 7, 9)
   }
 }
 


### PR DESCRIPTION
## QA-799 <!--Jira Ticket Number-->

### What?
SPIKE Test Load test profile changes

#### Changes:
spikeI2HighTraffic: {
    ...createScenario('drivingLicense', LoadProfile.spikeI2HighTraffic, 4, 9),
    ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 7, 9)
  }

---

### Why?
To perform PERF006 Iteration2 SPIKE test

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
