### PR TITLE
Changed OLH profile for PERF006 i2 tests

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -160,12 +160,12 @@ const profiles: ProfileList = {
       exec: 'landingPage'
     }
   },
-  spikeI2LowTraffic: {
-    ...createScenario('changeEmail', LoadProfile.spikeI2LowTraffic, 1, 32),
-    ...createScenario('changePassword', LoadProfile.spikeI2LowTraffic, 1, 28),
-    ...createScenario('changePhone', LoadProfile.spikeI2LowTraffic, 1, 32),
-    ...createScenario('deleteAccount', LoadProfile.spikeI2LowTraffic, 1, 24),
-    ...createScenario('landingPage', LoadProfile.spikeI2LowTraffic, 3, 4)
+  spikeI2HighTraffic: {
+    ...createScenario('changeEmail', LoadProfile.spikeI2HighTraffic, 1, 32),
+    ...createScenario('changePassword', LoadProfile.spikeI2HighTraffic, 1, 28),
+    ...createScenario('changePhone', LoadProfile.spikeI2HighTraffic, 1, 32),
+    ...createScenario('deleteAccount', LoadProfile.spikeI2HighTraffic, 1, 24),
+    ...createScenario('landingPage', LoadProfile.spikeI2HighTraffic, 3, 4)
   },
   perf006Iteration2PeakTest: {
     changeEmail: {


### PR DESCRIPTION
## QA-801 <!--Jira Ticket Number-->

### What?
changed the spike test load profile for OLH
#### Changes:
- The previous 'spikeI2LowTraffic' profile was changed to 'spikeI2HighTraffic'

---

### Why?
To run Tests against PERF006 iteration 2 for OLH.

---