### PR TITLE
QA-800 corrected loadprofiles for spike and peak

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -191,12 +191,12 @@ const profiles: ProfileList = {
     }
   },
   spikeI2HighTraffic: {
-    ...createScenario('drivingLicense', LoadProfile.spikeI2HighTraffic, 4, 9),
+    ...createScenario('drivingLicence', LoadProfile.spikeI2HighTraffic, 4, 9),
     ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 7, 10),
     ...createScenario('fraud', LoadProfile.spikeI2HighTraffic, 35, 6)
   },
   perf006Iteration2PeakTest: {
-    drivingLicense: {
+    drivingLicence: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
@@ -206,7 +206,7 @@ const profiles: ProfileList = {
         { target: 15, duration: '16s' },
         { target: 15, duration: '30m' }
       ],
-      exec: 'drivingLicense'
+      exec: 'drivingLicence'
     },
     drivingLicenceAttestation: {
       executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-800<!--Jira Ticket Number-->

### What?
QA-800 corrected load profiles for spike and peak

#### Changes:
spikeI2HighTraffic: {
    ...createScenario('drivingLicence', LoadProfile.spikeI2HighTraffic, 4, 9),
    ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 7, 10),
    ...createScenario('fraud', LoadProfile.spikeI2HighTraffic, 35, 6)
  },
  perf006Iteration2PeakTest: {
    drivingLicence: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 9,
      maxVUs: 9,
      stages: [
        { target: 15, duration: '16s' },
        { target: 15, duration: '30m' }
      ],
      exec: 'drivingLicence'
    },
    drivingLicenceAttestation: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 14,
      maxVUs: 14,
      stages: [
        { target: 23, duration: '24s' },
        { target: 23, duration: '30m' }
      ],
      exec: 'drivingLicenceAttestation'
    },
    fraud: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 72,
      maxVUs: 72,
      stages: [
        { target: 120, duration: '121s' },
        { target: 120, duration: '30m' }
      ],
      exec: 'fraud'
    }
  }
}
---

### Why?
Corrected previous req

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
