### PR TITLE
[QA-805] Adding a new clientEnrichment, SSF Outbound scenario for TxMA

### DIFF
--- a/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqFormat.ts
@@ -34,7 +34,6 @@ export interface AuthCreateAccount {
 export interface AuthLogInSuccess {
   event_id: string
   event_name: string
-  client_id: string
   component_id: string
   timestamp: number
   event_timestamp_ms: number
@@ -70,11 +69,6 @@ export interface AuthAuthorisationReqParsed {
   event_name: string
   event_timestamp_ms: number
   event_timestamp_ms_formatted: string
-  extensions: {
-    identityRequested: boolean
-    reauthRequested: boolean
-    rpSid: string
-  }
   timestamp: number
   timestamp_formatted: string
   user: {
@@ -82,6 +76,9 @@ export interface AuthAuthorisationReqParsed {
     ip_address: string
     persistent_session_id: string
     session_id: string
+  }
+  txma: {
+    obfuscated: boolean
   }
 }
 

--- a/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/txma/requestGenerator/txmaReqGen.ts
@@ -5,7 +5,8 @@ export function generateAuthCreateAccount(
   testID: string,
   userID: string,
   emailID: string,
-  pairWiseID: string
+  pairWiseID: string,
+  journeyID: string
 ): AuthCreateAccount {
   const eventID = `${testID}_${uuidv4()}`
   return {
@@ -17,7 +18,7 @@ export function generateAuthCreateAccount(
     event_timestamp_ms: Math.floor(Date.now()),
     user: {
       user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`
-      govuk_signin_journey_id: uuidv4(),
+      govuk_signin_journey_id: journeyID,
       ip_address: '1.2.3.4',
       email: emailID,
       session_id: uuidv4(),
@@ -42,17 +43,21 @@ export function generateAuthCreateAccount(
   }
 }
 
-export function generateAuthLogInSuccess(eventID: string, userID: string, emailID: string): AuthLogInSuccess {
+export function generateAuthLogInSuccess(
+  eventID: string,
+  userID: string,
+  emailID: string,
+  journeyID: string
+): AuthLogInSuccess {
   return {
     event_id: eventID,
     event_name: 'AUTH_LOG_IN_SUCCESS',
-    client_id: 'performanceTestClientId',
     component_id: 'SharedSignalPerfTest',
     timestamp: Math.floor(Date.now() / 1000),
     event_timestamp_ms: Math.floor(Date.now()),
     user: {
       user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`,
-      govuk_signin_journey_id: uuidv4(),
+      govuk_signin_journey_id: journeyID,
       ip_address: '1.2.3.4',
       session_id: uuidv4(),
       email: emailID,
@@ -76,28 +81,26 @@ export function generateAuthLogInSuccess(eventID: string, userID: string, emailI
   }
 }
 
-export function generateAuthReqParsed(journeyID: string): AuthAuthorisationReqParsed {
-  const eventID = `perfAuthReqParsed${uuidv4()}`
+export function generateAuthReqParsed(journeyID: string, testID: string): AuthAuthorisationReqParsed {
   const eventTime = new Date().toISOString()
+  const eventID = `${testID}_${uuidv4()}`
   return {
-    client_id: 'e2eTestClientId',
+    client_id: 'performanceTestClientId',
     component_id: 'https://oidc.account.gov.uk/',
     event_id: eventID,
     event_name: 'AUTH_AUTHORISATION_REQUEST_PARSED',
     event_timestamp_ms: Math.floor(Date.now()),
     event_timestamp_ms_formatted: eventTime,
-    extensions: {
-      identityRequested: true,
-      reauthRequested: false,
-      rpSid: 'test123'
-    },
     timestamp: Math.floor(Date.now() / 1000),
     timestamp_formatted: eventTime,
     user: {
       govuk_signin_journey_id: journeyID,
       ip_address: '01.01.01.001',
-      persistent_session_id: uuidv4(),
+      persistent_session_id: 'vJNUUY3s3pa95VcIXmytYF65ogE--1738669313306',
       session_id: uuidv4()
+    },
+    txma: {
+      obfuscated: true
     }
   }
 }

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -14,30 +14,26 @@ import { getEnv } from '../common/utils/config/environment-variables'
 import {
   generateAuthLogInSuccess,
   generateAuthCreateAccount,
-  generateAuthReqParsed,
-  generateDcmawAbortWeb
+  generateAuthReqParsed
 } from './requestGenerator/txmaReqGen'
-import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 
 const profiles: ProfileList = {
   smoke: {
     ...createScenario('sendSingleEvent', LoadProfile.smoke),
     ...createScenario('sendRegularEvent', LoadProfile.smoke),
-    ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.smoke)
+    ...createScenario('sendRegularEventWithEnrichment', LoadProfile.smoke)
   },
   lowVolume: {
     ...createScenario('sendSingleEvent', LoadProfile.short, 30, 2),
-    ...createScenario('sendRegularEvent', LoadProfile.short, 30, 2),
-    ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.short, 30, 4)
+    ...createScenario('sendRegularEvent', LoadProfile.short, 30, 2)
   },
   load: {
     ...createScenario('sendRegularEvent', LoadProfile.full, 2000, 2),
     ...createScenario('sendSingleEvent', LoadProfile.full, 750, 2),
-    ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.full, 100, 4)
+    ...createScenario('sendRegularEventWithEnrichment', LoadProfile.full, 100, 3)
   },
   stress: {
-    ...createScenario('sendSingleEvent', LoadProfile.full, 7500, 2),
-    ...createScenario('pairwiseMappingClientEnrichment', LoadProfile.full, 7500, 4)
+    ...createScenario('sendSingleEvent', LoadProfile.full, 7500, 2)
   }
 }
 
@@ -72,10 +68,17 @@ export function setup(): string {
   const userID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestCommonSubjectId`
   const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID))
-  console.log('Sending primer event')
+  const journeyID = 'journeyID'
+  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
+  const authReqParsedPayload = JSON.stringify(generateAuthReqParsed(journeyID, testID))
+
+  console.log('Sending primer event 1')
   sqs.sendMessage(env.sqs_queue, authCreateAccPayload)
-  console.log('Primer event sent')
+  console.log('Primer event 1 sent')
+
+  console.log('Sending primer event 2')
+  sqs.sendMessage(env.sqs_queue, authReqParsedPayload)
+  console.log('Primer event 2 sent')
   return authCreateAccPayload
 }
 
@@ -84,40 +87,33 @@ export function sendRegularEvent(authCreateAccPayload: string): void {
   const authCreatePayload = JSON.parse(authCreateAccPayload)
   const testID = JSON.stringify(authCreatePayload.event_id).substring(1, 26)
   const eventID = `${testID}_${uuidv4()}`
+  const journeyID = 'journeyID'
   const authLogInSuccessPayload = JSON.stringify(
-    generateAuthLogInSuccess(eventID, `${authCreatePayload.user.user_id}`, `${authCreatePayload.user.email}`)
+    generateAuthLogInSuccess(eventID, `${authCreatePayload.user.user_id}`, `${authCreatePayload.user.email}`, journeyID)
+  )
+  sqs.sendMessage(env.sqs_queue, authLogInSuccessPayload)
+  iterationsCompleted.add(1)
+}
+
+export function sendRegularEventWithEnrichment(authCreateAccPayload: string): void {
+  iterationsStarted.add(1)
+  const authCreatePayload = JSON.parse(authCreateAccPayload)
+  const testID = JSON.stringify(authCreatePayload.event_id).substring(1, 26)
+  const eventID = `${testID}_${uuidv4()}`
+  const journeyID = 'journeyID'
+  const authLogInSuccessPayload = JSON.stringify(
+    generateAuthLogInSuccess(eventID, `${authCreatePayload.user.user_id}`, `${authCreatePayload.user.email}`, journeyID)
   )
   sqs.sendMessage(env.sqs_queue, authLogInSuccessPayload)
   iterationsCompleted.add(1)
 }
 
 export function sendSingleEvent(): void {
-  const journeyID = `perfJourney${uuidv4()}`
-  iterationsStarted.add(1)
-  const authReqParsedPayload = JSON.stringify(generateAuthReqParsed(journeyID))
-  sqs.sendMessage(env.sqs_queue, authReqParsedPayload)
-  iterationsCompleted.add(1)
-}
-
-export function pairwiseMappingClientEnrichment(): void {
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '') // YYMMDDTHHmmss
-  const testID = `perfTestID${timestamp}`
-  const userID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestCommonSubjectId`
-  const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
-  const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
-  const eventID = `${testID}_${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
+  const testID = `perfTestID${timestamp}`
   iterationsStarted.add(1)
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID))
-  const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(eventID, userID, emailID))
-  const authInitiatedPayload = JSON.stringify(generateAuthReqParsed(journeyID))
-  const dcmawAbortPayload = JSON.stringify(generateDcmawAbortWeb(userID, journeyID, emailID))
-  sqs.sendMessage(env.sqs_queue, authCreateAccPayload)
-  sleepBetween(0.5, 1)
-  sqs.sendMessage(env.sqs_queue, authLogInSuccessPayload)
-  sleepBetween(0.5, 1)
-  sqs.sendMessage(env.sqs_queue, authInitiatedPayload)
-  sleepBetween(0.5, 1)
-  sqs.sendMessage(env.sqs_queue, dcmawAbortPayload)
+  const authReqParsedPayload = JSON.stringify(generateAuthReqParsed(journeyID, testID))
+  sqs.sendMessage(env.sqs_queue, authReqParsedPayload)
   iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-805 <!--Jira Ticket Number-->

### What?
- Removes the outdated `pairwiseMappingClientEnrichment` scenario and replaces it with the new `sendRegularEventWithEnrichment` scenario. 
- alters the `AUTH_AUTHORISATION_REQUEST_PARSED` and `AUTH_LOGIN_SUCCESS` payload to contain new correct values for this scenario. 

#### Changes:
- Removes the `pairwiseMappingClientEnrichment` scenario
- Creates a new `sendRegularEventWithEnrichment` scenario which send the `AUTH_LOGIN_SUCCESS` event with no clientID.
- Alters the setup() function to send 2 primer events for the `sendRegularEventWithEnrichment` scenario.
- Changes all journeyIDs to a static value of "journeyID"
- Alters the `AUTH_LOGIN_SUCCESS` payload to remove the clientID value
- Alters the `AUTH_AUTHORISATION_REQUEST_PARSED` to contain only necessary details

---

### Why?
To enable testing of clientEnrichment in TxMA SSF Outbound

