### PR TITLE
QA-813 PERF006-IT2 profile for passport-limeCRI

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -193,7 +193,8 @@ const profiles: ProfileList = {
   spikeI2HighTraffic: {
     ...createScenario('drivingLicence', LoadProfile.spikeI2HighTraffic, 4, 9),
     ...createScenario('drivingLicenceAttestation', LoadProfile.spikeI2HighTraffic, 7, 10),
-    ...createScenario('fraud', LoadProfile.spikeI2HighTraffic, 35, 6)
+    ...createScenario('fraud', LoadProfile.spikeI2HighTraffic, 35, 6),
+    ...createScenario('passport', LoadProfile.spikeI2HighTraffic, 4, 6)
   },
   perf006Iteration2PeakTest: {
     drivingLicence: {
@@ -231,6 +232,18 @@ const profiles: ProfileList = {
         { target: 120, duration: '30m' }
       ],
       exec: 'fraud'
+    },
+    passport: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 20,
+      maxVUs: 72,
+      stages: [
+        { target: 12, duration: '13s' },
+        { target: 12, duration: '30m' }
+      ],
+      exec: 'passport'
     }
   }
 }


### PR DESCRIPTION
## QA-813  <!--Jira Ticket Number-->

### What?
Add an overview of what this pull request changes

#### Changes:
- spikeI2HighTraffic: {
    ...createScenario('passport', LoadProfile.spikeI2HighTraffic, 4, 6)
  }

- perf006Iteration2PeakTest: {
  passport: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 20,
      maxVUs: 72,
      stages: [
        { target: 12, duration: '13s' },
        { target: 12, duration: '30m' }
      ],
      exec: 'passport'
    }
  }

---

### Why?
to perform PERF006-Iteration2

---


