### PR TITLE
[QA-814] Adding PERF006 I2 Load Profiles for TxMA

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -22,9 +22,24 @@ const profiles: ProfileList = {
     ...createScenario('sendRegularEventWithEnrichment', LoadProfile.smoke)
   },
   load: {
-    ...createScenario('sendRegularEvent', LoadProfile.full, 2000, 2),
-    ...createScenario('sendSingleEvent', LoadProfile.full, 750, 2),
     ...createScenario('sendRegularEventWithEnrichment', LoadProfile.full, 100, 3)
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('sendRegularEventWithEnrichment', LoadProfile.spikeI2HighTraffic, 1804, 3)
+  },
+  perf006Iteration2PeakTest: {
+    sendRegularEventWithEnrichment: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1857,
+      stages: [
+        { target: 619, duration: '283s' },
+        { target: 619, duration: '30m' }
+      ],
+      exec: 'sendRegularEventWithEnrichment'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-814 <!--Jira Ticket Number-->

### What?
Adds the peak and spike PERf006 Iteration 1 load profiles for the TxMA `sendRegaularEventWithEnrichment` scenario.

#### Changes:
- Adds the `perf006Iteration2PeakTest` and `spikeI2HighTraffic` profiles for the TxMA `sendRegaularEventWithEnrichment` scenario.
- Removes the `sendSingleEvent` and `sendRegularEvent` Load profiles as they're no longer relevant to this script.  

---

### Why?
To run PERF006 Iteration 2 spike and peak tests for the TxMA Event-Streaming-Platform. 

