### PR TITLE
QA-816: Updated EVCS load profile for Perf006 Iteration 2 tests

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -43,8 +43,8 @@ const profiles: ProfileList = {
   },
   spikeI2HighTraffic: {
     ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 15),
-    ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 35, 15),
-    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 32, 15)
+    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 35, 15),
+    ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 32, 15)
   },
   perf006Iteration2PeakTest: {
     persistVC: {
@@ -59,9 +59,9 @@ const profiles: ProfileList = {
       ],
       exec: 'persistVC'
     },
-    summariseVC: {
+    updateVC: {
       executor: 'ramping-arrival-rate',
-      startRate: 2,
+      startRate: 1,
       timeUnit: '10s',
       preAllocatedVUs: 100,
       maxVUs: 264,
@@ -69,11 +69,11 @@ const profiles: ProfileList = {
         { target: 120, duration: '121s' },
         { target: 120, duration: '30m' }
       ],
-      exec: 'summariseVC'
+      exec: 'updateVC'
     },
-    updateVC: {
+    summariseVC: {
       executor: 'ramping-arrival-rate',
-      startRate: 1,
+      startRate: 2,
       timeUnit: '1s',
       preAllocatedVUs: 100,
       maxVUs: 264,
@@ -81,7 +81,7 @@ const profiles: ProfileList = {
         { target: 11, duration: '6s' },
         { target: 11, duration: '30m' }
       ],
-      exec: 'updateVC'
+      exec: 'summariseVC'
     }
   }
 }

--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -40,6 +40,49 @@ const profiles: ProfileList = {
       maxDuration: '120m',
       exec: 'persistVC'
     }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 15),
+    ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 35, 15),
+    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 32, 15)
+  },
+  perf006Iteration2PeakTest: {
+    persistVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 576,
+      stages: [
+        { target: 120, duration: '121s' },
+        { target: 120, duration: '30m' }
+      ],
+      exec: 'persistVC'
+    },
+    summariseVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 264,
+      stages: [
+        { target: 120, duration: '121s' },
+        { target: 120, duration: '30m' }
+      ],
+      exec: 'summariseVC'
+    },
+    updateVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 264,
+      stages: [
+        { target: 11, duration: '6s' },
+        { target: 11, duration: '30m' }
+      ],
+      exec: 'updateVC'
+    }
   }
 }
 

--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -51,8 +51,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 100,
-      maxVUs: 576,
+      preAllocatedVUs: 30,
+      maxVUs: 36,
       stages: [
         { target: 120, duration: '121s' },
         { target: 120, duration: '30m' }
@@ -63,8 +63,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 100,
-      maxVUs: 264,
+      preAllocatedVUs: 30,
+      maxVUs: 36,
       stages: [
         { target: 120, duration: '121s' },
         { target: 120, duration: '30m' }
@@ -75,8 +75,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 100,
-      maxVUs: 264,
+      preAllocatedVUs: 50,
+      maxVUs: 66,
       stages: [
         { target: 11, duration: '6s' },
         { target: 11, duration: '30m' }


### PR DESCRIPTION
## QA-816

### What?
The EVCS load profile(vc-storage.ts) has been updated to test spike and peak, 
refer the below 

![image](https://github.com/user-attachments/assets/19a0f6db-6f1b-48e4-9a8d-14f5bc869461)


#### Changes:
```
 spikeI2HighTraffic: {
    ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 15),
    ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 35, 15),
    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 32, 15)
  },
  perf006Iteration2PeakTest: {
    persistVC: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 576,
      stages: [
        { target: 120, duration: '121s' },
        { target: 120, duration: '30m' }
      ],
      exec: 'persistVC'
    },
    summariseVC: {
      executor: 'ramping-arrival-rate',
      startRate: 2,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 264,
      stages: [
        { target: 120, duration: '121s' },
        { target: 120, duration: '30m' }
      ],
      exec: 'summariseVC'
    },
    updateVC: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '1s',
      preAllocatedVUs: 100,
      maxVUs: 264,
      stages: [
        { target: 11, duration: '6s' },
        { target: 11, duration: '30m' }
      ],
      exec: 'updateVC'
    }
  }

```
---

### Why?
To test EVCS scenarios as part of the perf006 iteration 2 tests


