### PR TITLE
[QA-818] Adding a load profile for Fraud SSF Inbound

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -27,6 +27,20 @@ const profiles: ProfileList = {
   },
   steadyStateOnly: {
     ...createScenario('fraud', LoadProfile.steadyStateOnly, 250, 3)
+  },
+  PeakTest: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 50,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 750,
+      stages: [
+        { target: 250, duration: '4s' },
+        { target: 250, duration: '6m' }
+      ],
+      exec: 'fraud'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-818 <!--Jira Ticket Number-->

### What?
Adds the `peakTest` load profile to the fraud script, which starts at 50j/s and ramps up to 250j/s in 4s, which is then maintained for 6 minutes. 

#### Changes:
- adds the `PeakTest` load profile for the `fraud/test.ts` script

---

### Why?
to run a test for Fraud SSF Inbound ramping from 50j/s to 250j/s in 4 seconds, and maintaining that load for 6 minutes. 

