### PR TITLE
Update AIS script to include PERF006 I2 tests

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -39,6 +39,32 @@ const profiles: ProfileList = {
       maxDuration: '60m',
       exec: 'dataCreationForRetrieve'
     }
+  },
+  perf006Iteration2PeakTest: {
+    persistIV: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 20,
+      maxVUs: 90,
+      stages: [
+        { target: 30, duration: '15s' },
+        { target: 30, duration: '30m' }
+      ],
+      exec: 'persistIV'
+    },
+    retrieveIV: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 20,
+      maxVUs: 99,
+      stages: [
+        { target: 33, duration: '16s' },
+        { target: 33, duration: '30m' }
+      ],
+      exec: 'retrieveIV'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-817 <!--Jira Ticket Number-->

### What?
Added the load profiles for the PERF006 Iteration2 Peak test for PersistIV & RetrieveIV scenarios.
#### Changes:
- Peak Test Iteration2 profile was added for the PersistIV & RetrieveIV scenarios.

---

### Why?
To run PERF006 iteration 2 peak tests for AIS

---
