### PR TITLE
[QA-818] Adding load profiles to the fraud SSF script

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -47,7 +47,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 50,
       timeUnit: '1s',
-      preAllocatedVUs: 100,
+      preAllocatedVUs: 150,
       maxVUs: 150,
       stages: [{ target: 50, duration: '6m' }],
       exec: 'fraud'
@@ -58,7 +58,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 100,
       timeUnit: '1s',
-      preAllocatedVUs: 100,
+      preAllocatedVUs: 300,
       maxVUs: 300,
       stages: [{ target: 100, duration: '6m' }],
       exec: 'fraud'
@@ -69,7 +69,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 380,
       timeUnit: '1s',
-      preAllocatedVUs: 100,
+      preAllocatedVUs: 1140,
       maxVUs: 1140,
       stages: [{ target: 380, duration: '6m' }],
       exec: 'fraud'

--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -28,7 +28,7 @@ const profiles: ProfileList = {
   steadyStateOnly: {
     ...createScenario('fraud', LoadProfile.steadyStateOnly, 250, 3)
   },
-  PeakTest: {
+  peakTest: {
     fraud: {
       executor: 'ramping-arrival-rate',
       startRate: 50,
@@ -39,6 +39,39 @@ const profiles: ProfileList = {
         { target: 250, duration: '4s' },
         { target: 250, duration: '6m' }
       ],
+      exec: 'fraud'
+    }
+  },
+  load50: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 50,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 150,
+      stages: [{ target: 50, duration: '6m' }],
+      exec: 'fraud'
+    }
+  },
+  load100: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 100,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 300,
+      stages: [{ target: 100, duration: '6m' }],
+      exec: 'fraud'
+    }
+  },
+  load380: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 380,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1140,
+      stages: [{ target: 380, duration: '6m' }],
       exec: 'fraud'
     }
   }


### PR DESCRIPTION
## QA-818 <!--Jira Ticket Number-->

### What?
Adds 3 new load profiles to the `fraud/test.ts` script

#### Changes:
Adds 3 load profiles of the below to the `fraud/test.ts` script:
1. maintain 50j/s for 6 minutes
2. maintain 100j/s for 6 minutes
3. maintain 380j/s for 6 minutes

---

### Why?
To run the 3 above tests
