### PR TITLE
Changed the target for AIS peak test

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -57,11 +57,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 20,
-      maxVUs: 99,
+      preAllocatedVUs: 200,
+      maxVUs: 909,
       stages: [
-        { target: 33, duration: '16s' },
-        { target: 33, duration: '30m' }
+        { target: 303, duration: '139s' },
+        { target: 303, duration: '30m' }
       ],
       exec: 'retrieveIV'
     }


### PR DESCRIPTION
## QA-820 <!--Jira Ticket Number-->

### What?
Changed the target for the retrieveIV peak test.
#### Changes:
- The target of the retrieveIV scenario was increased from 33rps to 303rps.
- the MaxVU was increased to 909.
- the ramp up time was increased to 139 seconds.
---

### Why?
AIS has been able to handle large amounts of traffic (5700rps). 33rps is too low and would be a waste of time and resources.

---