### PR TITLE
Update pageContentCheck in AIS script

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -129,7 +129,7 @@ export function retrieveIV(): void {
   // B02_RetrieveIV_01_GetInterventionData
   timeGroup(groups[0], () => http.get(env.aisEnvURL + `/v1/ais/${retrieveData.userID}?history=true`), {
     isStatusCode200,
-    ...pageContentCheck('Perf Testing')
+    ...pageContentCheck('intervention')
   })
   iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-824 <!--Jira Ticket Number-->

### What?
Update the pageContentCheck for the retrieveIV scenario.
#### Changes:
- pageContentCheck changed from 'Perf Testing' to 'intervention'

---

### Why?
The previous string used was incorrect and causing the Test being run for AIS to fail.

---
