### PR TITLE
QA-827 : Load Profile updates -  EVCS for PERF006 Iteration2- Spike Test

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -42,8 +42,8 @@ const profiles: ProfileList = {
     }
   },
   spikeI2HighTraffic: {
-    ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 15),
-    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 35, 15),
+    ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 16),
+    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 35, 16),
     ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 32, 15)
   },
   perf006Iteration2PeakTest: {


### PR DESCRIPTION
## QA-827

### What?
Load profile changes for Perf006 Iter2 Spike Test

#### Changes:
 spikeI2HighTraffic: {
    ...createScenario('persistVC', LoadProfile.spikeI2HighTraffic, 35, 16),
    ...createScenario('updateVC', LoadProfile.spikeI2HighTraffic, 35, 16),
    ...createScenario('summariseVC', LoadProfile.spikeI2HighTraffic, 32, 15)
  },


### Why?
To update the spikeI2HighTraffic load profile

