### PR TITLE
QA-828 updated SPIKE and PEAK loadprofiles

### DIFF
--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -22,6 +22,23 @@ const profiles: ProfileList = {
   },
   stress: {
     ...createScenario('otg', LoadProfile.full, 44)
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('otg', LoadProfile.spikeI2HighTraffic, 2, 4)
+  },
+  perf006Iteration2PeakTest: {
+    ninoCheck: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { target: 13, duration: '14s' },
+        { target: 13, duration: '30m' }
+      ],
+      exec: 'otg'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-828 <!--Jira Ticket Number-->

### What?
SKIPE and Peak Load profile for OTG

#### Changes:


spikeI2HighTraffic: {
    ...createScenario('otg', LoadProfile.spikeI2HighTraffic, 2, 4)
  },
  

 perf006Iteration2PeakTest: {
    ninoCheck: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 100,
      maxVUs: 400,
      stages: [
        { target: 13, duration: '14s' },
        { target: 13, duration: '30m' }
      ],
      exec: 'otg'
    }
  }

---

### Why?
Why are these changes being made?

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
