### PR TITLE
[QA-818] Reducing the duration for the 100j/s fraud load profile.

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -60,7 +60,7 @@ const profiles: ProfileList = {
       timeUnit: '1s',
       preAllocatedVUs: 300,
       maxVUs: 300,
-      stages: [{ target: 100, duration: '6m' }],
+      stages: [{ target: 100, duration: '3m' }],
       exec: 'fraud'
     }
   },


### PR DESCRIPTION
## QA-818 <!--Jira Ticket Number-->

### What?
Reduces the duration of the `load100` profile for the fraud script. 

#### Changes:
- Reduces the duration to 3 minutes for the `load100` load profile in the `fraud/test.ts` script. 

---

### Why?
To run a test at a target volume of 100 messages per second for 3 minutes 
