### PR TITLE
[QA-818] Adding more load profiles to the fraud script

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -49,7 +49,18 @@ const profiles: ProfileList = {
       timeUnit: '1s',
       preAllocatedVUs: 150,
       maxVUs: 150,
-      stages: [{ target: 50, duration: '6m' }],
+      stages: [{ target: 50, duration: '3m' }],
+      exec: 'fraud'
+    }
+  },
+  load75: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 75,
+      timeUnit: '1s',
+      preAllocatedVUs: 225,
+      maxVUs: 225,
+      stages: [{ target: 75, duration: '3m' }],
       exec: 'fraud'
     }
   },


### PR DESCRIPTION
## QA-818 <!--Jira Ticket Number-->

### What?
Adds a `load75` profile to the `fraud/test.ts` script
#### Changes:
- reduces the `load50` duration from 6m to 3m
- adds a `load75` which has a target volume of 75j/s for 3 minutes. 

---

### Why?
To run tests with the above load profiles. 
