### PR TITLE
QA-837 Spike and Peak load profiles for CRI KIWI

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -24,6 +24,23 @@ const profiles: ProfileList = {
   },
   load: {
     ...createScenario('BAV', LoadProfile.full, 5)
+  },
+  spikeI2LowTraffic: {
+    ...createScenario('BAV', LoadProfile.spikeI2LowTraffic, 1) //rounded to 1 from 0.4 based on the iteration 2 plan
+  },
+  perf006Iteration2PeakTest: {
+    BAV: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 10,
+      maxVUs: 100,
+      stages: [
+        { target: 1, duration: '1s' },
+        { target: 1, duration: '30m' }
+      ],
+      exec: 'BAV'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -27,6 +27,36 @@ const profiles: ProfileList = {
   load: {
     ...createScenario('FaceToFace', LoadProfile.short, 3),
     ...createScenario('CIC', LoadProfile.short, 3)
+  },
+  spikeI2LowTraffic: {
+    ...createScenario('FaceToFace', LoadProfile.spikeI2LowTraffic, 1), //rounded to 1 from 0.4 based on the iteration 2 plan
+    ...createScenario('CIC', LoadProfile.spikeI2LowTraffic, 1)
+  },
+  perf006Iteration2PeakTest: {
+    FaceToFace: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 10,
+      maxVUs: 100,
+      stages: [
+        { target: 3, duration: '4s' },
+        { target: 3, duration: '30m' }
+      ],
+      exec: 'FaceToFace'
+    },
+    CIC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 10,
+      maxVUs: 100,
+      stages: [
+        { target: 3, duration: '4s' },
+        { target: 3, duration: '30m' }
+      ],
+      exec: 'CIC'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-837 <!--Jira Ticket Number-->

### What?
Add an overview of what this pull request changes

#### Changes:
- spikeI2LowTraffic: {
    ...createScenario('FaceToFace', LoadProfile.spikeI2LowTraffic, 1), //rounded to 1 from 0.4 based on the iteration 2 plan
    ...createScenario('CIC', LoadProfile.spikeI2LowTraffic, 1)
  },
spikeI2LowTraffic: {
    ...createScenario('BAV', LoadProfile.spikeI2LowTraffic, 1) //rounded to 1 from 0.4 based on the iteration 2 plan
  },

PEAK Tests
 perf006Iteration2PeakTest: {
    BAV: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 10,
      maxVUs: 100,
      stages: [
        { target: 1, duration: '1s' },
        { target: 1, duration: '30m' }
      ],
      exec: 'BAV'
    }
  }
perf006Iteration2PeakTest: {
    FaceToFace: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 10,
      maxVUs: 100,
      stages: [
        { target: 3, duration: '4s' },
        { target: 3, duration: '30m' }
      ],
      exec: 'FaceToFace'
    },
    CIC: {
      executor: 'ramping-arrival-rate',
      startRate: 1,
      timeUnit: '10s',
      preAllocatedVUs: 10,
      maxVUs: 100,
      stages: [
        { target: 3, duration: '4s' },
        { target: 3, duration: '30m' }
      ],
      exec: 'CIC'
    }
  }
---

### Why?
PERF006 Iteration 2

---

