### PR TITLE
[QA-818] Adding the load250 profile for fraud SSF inbound

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -118,6 +118,17 @@ const profiles: ProfileList = {
       stages: [{ target: 200, duration: '3m' }],
       exec: 'fraud'
     }
+  },
+  load250: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 250,
+      timeUnit: '1s',
+      preAllocatedVUs: 750,
+      maxVUs: 750,
+      stages: [{ target: 250, duration: '6m' }],
+      exec: 'fraud'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-818 <!--Jira Ticket Number-->

### What?
Adds the `load250` load profile to the `fraud/test.ts` script

#### Changes:
- Adds the `load250` load profile to the `fraud/test.ts` script which runs at a target volume of 250 iterations per second for a 6 minute steady-state duration. 

---

### Why?
To run a test for Fraud SSF Inbound at a target volume of 250j/s for 6 minutes. 

