### PR TITLE
[QA-846] Adding the I3 peak load profile for TxMA ESP & Audit-Service

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -40,6 +40,20 @@ const profiles: ProfileList = {
       ],
       exec: 'sendRegularEventWithEnrichment'
     }
+  },
+  perf006I3PeakTest: {
+    sendRegularEventWithEnrichment: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 3408,
+      stages: [
+        { target: 1136, duration: '518s' },
+        { target: 1136, duration: '30m' }
+      ],
+      exec: 'sendRegularEventWithEnrichment'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-846 <!--Jira Ticket Number-->

### What?
Adds the PERF006 Iteration 3 peak load profile to the `txma/clientEnrichment.ts` script, for Iteration 3 peak testing of TxMA ESP & Audit-Service

#### Changes:
- Adds in a new `perf006I3PeakTest` load profile with a target of 1,136 and a ramp-up duration of 518s. 

---

### Why?
To run an Iteration 3 peak test for TxMA ESP & Audit-Service

