### PR TITLE
[QA-848]: Remove data-vocab dependency to unblock deployment

### DIFF
--- a/deploy/scripts/package-lock.json
+++ b/deploy/scripts/package-lock.json
@@ -8,9 +8,6 @@
       "name": "scripts",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@govuk-one-login/data-vocab": "1.9.3"
-      },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.23.0",
@@ -644,11 +641,6 @@
         "@shikijs/types": "^3.2.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
-    },
-    "node_modules/@govuk-one-login/data-vocab": {
-      "version": "1.9.3",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/1.9.3/fa6de901e9fecc985fca4d91cd9f39e69419bc63",
-      "integrity": "sha512-pOwhj9gYkCEci5qRvlXGFT1e/Li250R9+P4kRP9CliEOxTs1GoAJcDUNs60ZKOgSpL24xOQ4NE09uSn6HL5nPw=="
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/deploy/scripts/package.json
+++ b/deploy/scripts/package.json
@@ -30,8 +30,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT",
-  "dependencies": {
-    "@govuk-one-login/data-vocab": "1.9.3"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
## QA-848 <!--Jira Ticket Number-->

### What?
Remove `data-vocab` dependency to unblock deployment

#### Changes:
- Remove `data-vocab` from `package.json` to unblock deployment

---

### Why?
data-vocab dependency is causing the build and push workflow to fail upon merging. This blocks all deployments in performance testing. Hence this is being removed to unblock perf test deployments.

---

### Related:
- [Failed Github action](https://github.com/govuk-one-login/performance-testing/actions/runs/14220717766)
