### PR TITLE
[QA-849]: Add data vocab dependency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'deploy/**'
-      - '.github/workflows/publish.yaml'
+      - "deploy/**"
+      - ".github/workflows/publish.yaml"
 
 defaults:
   run:
@@ -21,7 +21,32 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: "0"
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: "deploy/scripts/package-lock.json"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+
+      - name: Run linting checks
+        run: npm run lint
+
+      - name: Transpile TypeScript test scripts
+        run: npm start
+
       - name: Deploy SAM app to ECR
         uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # 1.3.0
         with:

--- a/deploy/scripts/package-lock.json
+++ b/deploy/scripts/package-lock.json
@@ -8,6 +8,9 @@
       "name": "scripts",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@govuk-one-login/data-vocab": "1.9.3"
+      },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.23.0",
@@ -641,6 +644,11 @@
         "@shikijs/types": "^3.2.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
+    },
+    "node_modules/@govuk-one-login/data-vocab": {
+      "version": "1.9.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/1.9.3/fa6de901e9fecc985fca4d91cd9f39e69419bc63",
+      "integrity": "sha512-pOwhj9gYkCEci5qRvlXGFT1e/Li250R9+P4kRP9CliEOxTs1GoAJcDUNs60ZKOgSpL24xOQ4NE09uSn6HL5nPw=="
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/deploy/scripts/package.json
+++ b/deploy/scripts/package.json
@@ -30,5 +30,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@govuk-one-login/data-vocab": "1.9.3"
+  }
 }


### PR DESCRIPTION
## QA-849 <!--Jira Ticket Number-->

### What?
Add data vocab dependency

#### Changes:
- Added the `data-vocab` package dependency.
- Update the `Docker Build and Push` github workflow to allow permissions to access the package

---

### Why?
To use `data-vocab` package in the `performance-testing` scripts

---

### Related:
- Guidance in the [https://github.com/govuk-one-login/performance-testing/blob/main/.github/workflows/publish.yaml](url) repo to allow permissions
