### PR TITLE
[QA-850] Adding Iteration 3 peak profiles for IPV Core

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -176,6 +176,32 @@ const profiles: ProfileList = {
   spikeI2HighTraffic: {
     ...createScenario('identity', LoadProfile.spikeI2HighTraffic, 35, 44),
     ...createScenario('idReuse', LoadProfile.spikeI2HighTraffic, 32, 8)
+  },
+  perf006Iteration3PeakTest: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 576,
+      stages: [
+        { target: 160, duration: '161s' },
+        { target: 160, duration: '30m' }
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 144,
+      stages: [
+        { target: 24, duration: '12s' },
+        { target: 24, duration: '30m' }
+      ],
+      exec: 'idReuse'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-850 <!--Jira Ticket Number-->

### What?
Adds in the Iteration 3 peak load profiles for IPV Core `identity` and `idReuse`

#### Changes:
- Adds the `perf006Iteration3PeakTest` load profile for the `identity` and `idReuse` scenarios with target volumes of 16 and 24 respectively. 

---

### Why?
To run Iteration 3 peak tests for IPV Core. 

