### PR TITLE
QA-852 : Load profile update for VC-Storage Perf006 Iter3 Peak test

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -83,6 +83,44 @@ const profiles: ProfileList = {
       ],
       exec: 'summariseVC'
     }
+  },
+  perf006Iteration3PeakTest: {
+    persistVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 48,
+      maxVUs: 96,
+      stages: [
+        { target: 160, duration: '161s' },
+        { target: 160, duration: '30m' }
+      ],
+      exec: 'persistVC'
+    },
+    updateVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 48,
+      maxVUs: 96,
+      stages: [
+        { target: 160, duration: '161s' },
+        { target: 160, duration: '30m' }
+      ],
+      exec: 'updateVC'
+    },
+    summariseVC: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 72,
+      maxVUs: 142,
+      stages: [
+        { target: 24, duration: '12s' },
+        { target: 24, duration: '30m' }
+      ],
+      exec: 'summariseVC'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-852

### What?
EVCS load profile udpate for Perf006 Iter3 Peak test

#### Changes:
Added the `perf006Iteration3PeakTest` load profile for `persistVC, updateVC, summariseVC` scenarios

---

### Why?
Iteration 3 Peak Tests

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
