### PR TITLE
[QA-872] Adding I3 peak load proflies for OLH.

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -228,6 +228,68 @@ const profiles: ProfileList = {
       ],
       exec: 'landingPage'
     }
+  },
+  perf006Iteration3PeakTest: {
+    changeEmail: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 2, duration: '1s' },
+        { target: 2, duration: '30m' }
+      ],
+      exec: 'changeEmail'
+    },
+    changePassword: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 2, duration: '1s' },
+        { target: 2, duration: '30m' }
+      ],
+      exec: 'changePassword'
+    },
+    changePhone: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 2, duration: '1s' },
+        { target: 2, duration: '30m' }
+      ],
+      exec: 'changePhone'
+    },
+    deleteAccount: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 2, duration: '1s' },
+        { target: 2, duration: '30m' }
+      ],
+      exec: 'deleteAccount'
+    },
+    landingPage: {
+      executor: 'ramping-arrival-rate',
+      startRate: 12,
+      timeUnit: '1m',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 138, duration: '13s' },
+        { target: 138, duration: '30m' }
+      ],
+      exec: 'landingPage'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-872 <!--Jira Ticket Number-->

### What?
Adds the Iteration 3 peak load profiles for the OLH scenarios.  

#### Changes:
- Adds the `perf006Iteration3PeakTest` load profiles to the `olh/test.ts` script with target volumes of 138j/min for `landingPage`, and 2j/s for `changeEmail`, `changePhone`, `changePassword`, and `deleteAccount`. 

---

### Why?
To run Iteration 3 peak tests for OLH.
