### PR TITLE
[QA-876] Adding PEAK Load profile to BAV

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -41,6 +41,20 @@ const profiles: ProfileList = {
       ],
       exec: 'BAV'
     }
+  },
+  perf006Iteration3PeakTest: {
+    BAV: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 10,
+      maxVUs: 100,
+      stages: [
+        { target: 2, duration: '3s' }, //Rounded to 0.2 for the 0.16 target
+        { target: 2, duration: '30m' }
+      ],
+      exec: 'BAV'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-876 <!--Jira Ticket Number-->

### What?
Adding PEAK Load profile to BAV

#### Changes:
* Adds the perf006Iteration3PeakTest  load profiles to cri-kiwi/BAV.ts with volumes of:
* peak test: BAV- 0.16 per sec  (9.6 Journeys/min)
---
### Why?
To Run PERF006-IT3 

---

### Related:
NA
