### PR TITLE
[QA-826] Adding Iteration 2 load profiles to IPVR

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -30,6 +30,36 @@ const profiles: ProfileList = {
   stress: {
     ...createScenario('authEvent', LoadProfile.full, 2000, 2),
     ...createScenario('allEvents', LoadProfile.full, 12, 2)
+  },
+  perf006Iteration2PeakTest: {
+    authEvent: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 11, duration: '6s' },
+        { target: 11, duration: '30m' }
+      ],
+      exec: 'authEvent'
+    },
+    allEvents: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 3, duration: '4s' },
+        { target: 3, duration: '30m' }
+      ],
+      exec: 'allEvents'
+    }
+  },
+  spikeI2HighTraffic: {
+    ...createScenario('authEvent', LoadProfile.spikeI2HighTraffic, 32),
+    ...createScenario('allEvents', LoadProfile.spikeI2HighTraffic, 1)
   }
 }
 


### PR DESCRIPTION
## QA-826 <!--Jira Ticket Number-->

### What?
Adds Iteration 2 peak and spike load profiles for IPVR.

#### Changes:
- Adds the `perf006Iteration2PeakTest` and `spikeI2HighTraffic` load profiles to `cri-kiwi/ipvr.ts` with volumes of:
- peak test: `authEvent` - 11j/s, `allEvents` - 0.3j/s
- spike test: `authEvent` - 32j/s, `allEvents` - 1j/s

---

### Why?
To run iteration 2 peak and spike tests for IPVR 
