### PR TITLE
[QA-826] Updating the allEvents PERF006I2 timeunit.

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -48,7 +48,7 @@ const profiles: ProfileList = {
     allEvents: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
-      timeUnit: '10',
+      timeUnit: '10s',
       preAllocatedVUs: 100,
       maxVUs: 1000,
       stages: [


### PR DESCRIPTION
## QA-826 <!--Jira Ticket Number-->

### What?
Updates the timeunit of the `perf006Iteration2PeakTest` `allEvents` scenario.

#### Changes:
Updates the timeunit of the `perf006Iteration2PeakTest` `allEvents` scenario to '10s'

---

### Why?
- Run run an `allEvents` `perf006Iteration2PeakTest` test with a target of 0.3 iterations per second. 

