### PR TITLE
QA-886 Add M1C peak test load profile for IPVCore

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -210,6 +210,20 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
+  },
+  identityM1CPeakTest: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 576,
+      stages: [
+        { target: 160, duration: '161s' },
+        { target: 160, duration: '30m' }
+      ],
+      exec: 'identityM1C'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-886 

### What?
Add M1C peak test load profile for IPVCore

#### Changes:
- Add identityM1C peak test load profile for IPVCore using PERF006 Iteration 3 peak test volumes
---

### Why?
To test Fraud Resilience M1C changes on IPV Core at PERF006 Iteration 3 peak test volumes
---