### PR TITLE
QA-886 Correct typo in load profile

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -212,7 +212,7 @@ const profiles: ProfileList = {
     }
   },
   identityM1CPeakTest: {
-    identity: {
+    identityM1C: {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',


### PR DESCRIPTION
## QA-886

### What?
Correct typo in IPVCore load profile for identityM1C

#### Changes:
- Correct typo in IPVCore load profile for identityM1C

---

### Why?
Typo exists
---
