### PR TITLE
QA-908 : Lime(Fraud) load profile updates/correction with right Pre & Max vusers

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -275,8 +275,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 16,
-      maxVUs: 32,
+      preAllocatedVUs: 48,
+      maxVUs: 96,
       stages: [
         { target: 160, duration: '161s' },
         { target: 160, duration: '30m' }


### PR DESCRIPTION
## QA-908

### What?
Lime(Fraud) load profile updates/correction with right Pre & Max vusers

#### Changes:
The PreAllocated & Max vusers were incorrectly mentioned during the last test and hence couldnt achieve the targeted TPH. This PR is raised to update the preAllocatedVUs to 48 & maxVUs to 96

### Why?
Pre & Max vusers were incorrect to reach the throughput of 16 iterations per second


