### PR TITLE
[QA-913] Adding the Iteration 3 peak load profile for IPVR.

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -61,6 +61,32 @@ const profiles: ProfileList = {
   spikeI2HighTraffic: {
     ...createScenario('authEvent', LoadProfile.spikeI2HighTraffic, 32),
     ...createScenario('allEvents', LoadProfile.spikeI2HighTraffic, 1)
+  },
+  perf006Iteration3PeakTest: {
+    authEvent: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 24, duration: '12s' },
+        { target: 24, duration: '30m' }
+      ],
+      exec: 'authEvent'
+    },
+    allEvents: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 1000,
+      stages: [
+        { target: 4, duration: '5s' },
+        { target: 4, duration: '30m' }
+      ],
+      exec: 'allEvents'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-913 <!--Jira Ticket Number-->

### What?
Adds the Iteration 3 peak load profile for IPVR. 

#### Changes:
- Adds the `perf006Iteration3PeakTest` load profile to `cri-kiwi/ipvr.ts ` with target volumes of 24j/s and 0.4j/s for `authEvent` and `allEvents` respectively. 

---

### Why?
to run an Iteration 3 peak test for IPVR.

