### PR TITLE
QA-917:Address(Orange CRI):Perf006-I3 Peak test load profile update

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -115,11 +115,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 120,
-      maxVUs: 240,
+      preAllocatedVUs: 75,
+      maxVUs: 150,
       stages: [
-        { target: 160, duration: '161s' },
-        { target: 160, duration: '30m' }
+        { target: 100, duration: '101s' },
+        { target: 100, duration: '30m' }
       ],
       exec: 'address'
     }

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -115,8 +115,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 100,
-      maxVUs: 400,
+      preAllocatedVUs: 120,
+      maxVUs: 240,
       stages: [
         { target: 160, duration: '161s' },
         { target: 160, duration: '30m' }


### PR DESCRIPTION
## QA-917

### What?
Address CRI load profile changes for Perf006 I3 

---

#### Changes:
Address CRI load profile will be updated to simulate 16 iters/sec. The test will run for 30 mins, after the rampup in 161s

---

### Why?
To peak test Address CRI against I3 volume

---


