### PR TITLE
[QA-920] Updating TiCF permissions in the CF Template.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -48,6 +48,11 @@ Mappings:
   IPVR:
     AWS:
       AccountID: "073717171046"
+  TiCF:
+    Build:
+      AccountID: "769837561067"
+    Dev:
+      AccountID: "105566562881"
 
 Resources:
   CodeBuildServiceRole:
@@ -219,6 +224,16 @@ Resources:
                   - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
                     - !FindInMap [TxMA, Staging, AccountID]
                     - "key/*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
+                    - !FindInMap [TiCF, Build, AccountID]
+                    - "key/*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}"
+                    - !FindInMap [TiCF, Dev, AccountID]
+                    - "key/*"
           - Effect: "Allow"
             Action:
               - "execute-api:*"
@@ -255,8 +270,13 @@ Resources:
               - Fn::Join:
                   - ":"
                   - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
-                    - !FindInMap [TxMA, Staging, AccountID]
-                    - "self-staging-*"
+                    - !FindInMap [TiCF, Build, AccountID]
+                    - "di-ticf-*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
+                    - !FindInMap [TiCF, Dev, AccountID]
+                    - "di-ticf-*"
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"
@@ -275,6 +295,16 @@ Resources:
                   - ":"
                   - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
                     - !FindInMap [TxMA, Staging, AccountID]
+                    - "function:*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
+                    - !FindInMap [TiCF, Build, AccountID]
+                    - "function:*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}"
+                    - !FindInMap [TiCF, Dev, AccountID]
                     - "function:*"
 
   VPCTestPolicy:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -270,6 +270,11 @@ Resources:
               - Fn::Join:
                   - ":"
                   - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
+                    - !FindInMap [TxMA, Staging, AccountID]
+                    - "self-staging-*"
+              - Fn::Join:
+                  - ":"
+                  - - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}"
                     - !FindInMap [TiCF, Build, AccountID]
                     - "di-ticf-*"
               - Fn::Join:


### PR DESCRIPTION
## QA-920 <!--Jira Ticket Number-->

### What?
Updates the Cloud Formation Template with permissions for the TiCF Build and Dev AWS Accounts. 

#### Changes:
- Adds the TiCF Build and Dev account details to the TiCF mappings, and `PerformanceTesterPolicy`. 

---

### Why?
To allow us to send SQS messages to the TiCF Build and Dev accounts during a performance test.

