### PR TITLE
[QA-933]: Add Address Manual Entry scenario

### DIFF
--- a/deploy/scripts/src/cri-orange/data/addressMEData.csv
+++ b/deploy/scripts/src/cri-orange/data/addressMEData.csv
@@ -1,0 +1,2 @@
+postCode
+E11 3BW


### PR DESCRIPTION
## QA-933 <!--Jira Ticket Number-->

### What?
Add Address Manual Entry scenario

#### Changes:
- Added a separate `addressME` scenario to mimic the manual address entry scenario.
- Added a separate test data file `addressMEData.csv` with the test data to be used for manual entry scenario.

---

### Why?
To test the manual entry scenario alongside the happy path scenario.