### PR TITLE
[QA-849]: Update working directory in Docker build and push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: ./deploy
+    working-directory: ./deploy/scripts
 
 jobs:
   dockerBuildAndPush:


### PR DESCRIPTION
## QA-849 <!--Jira Ticket Number-->

### What?
Update working directory in Docker build and push

#### Changes:
- Update working directory to `./deploy/scripts` in Docker build and push workflow

---

### Why?
Correcting the path of the working directly to fix the workflow failures.