### PR TITLE
[QA-937]: Added load profiles for iteration 3 spike tests

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -10,7 +10,9 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { getThresholds } from '../common/utils/config/thresholds'
 import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
@@ -157,6 +159,10 @@ const profiles: ProfileList = {
       ],
       exec: 'signIn'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('signUp', 490, 33, 491),
+    ...createI3SpikeSignInScenario('signIn', 71, 18, 33)
   }
 }
 const loadProfile = selectProfile(profiles)

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -279,3 +279,67 @@ export function createScenario(
   }
   return list
 }
+
+export function createI3SpikeSignUpScenario(
+  exec: string,
+  target: number = 1,
+  iterationDuration: number = 30,
+  rampUpNFR: number
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
+  const maxVUs = Math.round((target / 10) * iterationDuration)
+  const step = Math.round(target / 10 / 3)
+  const spikeRamp = Math.round(rampUpNFR / 5)
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: 1,
+    timeUnit: '10s',
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
+      { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+      { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
+      { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+    ],
+    exec
+  }
+  return list
+}
+
+export function createI3SpikeSignInScenario(
+  exec: string,
+  target: number = 1,
+  iterationDuration: number = 30,
+  rampUpNFR: number
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
+  const maxVUs = target * iterationDuration
+  const step = Math.round(target / 3)
+  const spikeRamp = Math.round(rampUpNFR / 5)
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: 2,
+    timeUnit: '1s',
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
+      { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+      { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
+      { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+    ],
+    exec
+  }
+  return list
+}


### PR DESCRIPTION
## QA-937 <!--Jira Ticket Number-->

### What?
Added load profiles for iteration 3 spike test

#### Changes:
- Added a common load profile for signUp,ID proving, CRIs etc. called `createI3SpikeSignUpScenario`
- Added a common load profile for ID reuse, Sign in scenarios called `createI3SpikeSignInScenario`
- Updated Authentication script to include these load profiles at Iteration 3 target.

---

### Why?
To conduct Iteration 3 spike tests