### PR TITLE
[QA-939] Adding CRI-Lime I3 Spike profiles

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -7,7 +7,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
@@ -295,6 +296,12 @@ const profiles: ProfileList = {
       ],
       exec: 'passport'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('passport', 47, 6, 48),
+    ...createI3SpikeSignUpScenario('drivingLicence', 61, 9, 62),
+    ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 103, 9, 104),
+    ...createI3SpikeSignUpScenario('fraud', 490, 6, 491)
   }
 }
 


### PR DESCRIPTION
## QA-939 <!--Jira Ticket Number-->

### What?
Adds the PERF006 Iteration3 Spike Test profiles for CRI-Lime `passport`, `fraud`, `drivingLicence`, and `drivingLicenceAttestation`. 

#### Changes:
- Adds the `perf006Iteration3SpikeTest` profile for CRI-Lime `passport`, `fraud`, `drivingLicence`, and `drivingLicenceAttestation`. 

---

### Why?
To run Iteration 3 spike tests 

