### PR TITLE
[QA-941]: Update IPV core script with Iteration 3 spike test profiles

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -7,7 +7,9 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
@@ -236,6 +238,10 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('identity', 490, 36, 491),
+    ...createI3SpikeSignInScenario('idReuse', 71, 6, 33)
   }
 }
 


### PR DESCRIPTION
## QA-941 <!--Jira Ticket Number-->

### What?
Update IPV core script with Iteration 3 spike test profiles

#### Changes:
- Add `createI3SpikeSignUpScenario` for `identity` scenario.
- Add `createI3SpikeSignInScenario` for `idReuse` scenario. 

---

### Why?
To conduct spike tests for IPV core scenarios based on Iteration 3 plan.