### PR TITLE
[QA-942] Add CRI-Orange KBV I3 spike profile

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -87,7 +87,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('KBV', 49, 12, 50)
+    ...createI3SpikeSignUpScenario('kbv', 49, 12, 50)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -6,7 +6,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
 import { timeGroup } from '../common/utils/request/timing'
@@ -84,6 +85,9 @@ const profiles: ProfileList = {
       ],
       exec: 'kbv'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('KBV', 49, 12, 50)
   }
 }
 


### PR DESCRIPTION
## QA-942 <!--Jira Ticket Number-->

### What?
PERF006 Iteration3 Spike Test profiles for CRI-Orange` KIWI`

#### Changes:
- Adds the perf006Iteration3SpikeTest profile for CRI-Orange `KIWI`
   KBV Target is 4.9 per sec
   Iteration Duration is 12
   RampupNFR is 50 
---

### Why?
To Perform Perf006 Iteration3 Spike Tests

---

### Related:

