### PR TITLE
[QA-937]: Fix sign up spike load profile

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -289,7 +289,7 @@ export function createI3SpikeSignUpScenario(
   const list: ScenarioList = {}
   const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
   const maxVUs = Math.round((target / 10) * iterationDuration)
-  const step = Math.round(target / 10 / 3)
+  const step = Math.round(target / 3)
   const spikeRamp = Math.round(rampUpNFR / 5)
   list[exec] = {
     executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-937 <!--Jira Ticket Number-->

### What?
Fix createI3SpikeSignUpScenario load prrofile.

#### Changes:
- The 33% load step is incorrectly divided by 10 which reduces it further.

---

### Why?
To conduct load test at correct load profiles.