### PR TITLE
[QA-949]: Add I3 spike test profile for EVCS scenarios

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -7,7 +7,9 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import { uuidv4 } from '../common/utils/jslib'
@@ -121,6 +123,11 @@ const profiles: ProfileList = {
       ],
       exec: 'summariseVC'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('persistVC', 490, 5, 491),
+    ...createI3SpikeSignUpScenario('updateVC', 490, 7, 491),
+    ...createI3SpikeSignInScenario('summariseVC', 71, 6, 33)
   }
 }
 


### PR DESCRIPTION
## QA-949 <!--Jira Ticket Number-->

### What?
Add Iteration 3 spike test profile for EVCS scenarios

#### Changes:
- Add a spike test profile for `persistVC` scenario
- Add a spike test profile for `updateVC` scenario
- Add a spike test profile for `summariseVC` scenario

---

### Why?
To conduct spike tests for EVCS scenarios.