### PR TITLE
[QA-948] Adding OLH iteration 3 spike profiles

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -343,3 +343,35 @@ export function createI3SpikeSignInScenario(
   }
   return list
 }
+
+export function createI3SpikeOLHScenario(
+  exec: string,
+  target: number = 1,
+  iterationDuration: number = 30,
+  rampUpNFR: number
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
+  const maxVUs = target * iterationDuration
+  const step = Math.round(target / 3)
+  const spikeRamp = Math.round(rampUpNFR / 5)
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: 120,
+    timeUnit: '1m',
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
+      { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+      { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
+      { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+    ],
+    exec
+  }
+  return list
+}

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -10,6 +10,7 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
+  createI3SpikeOLHScenario,
   createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
@@ -293,10 +294,10 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignInScenario('changeEmail', 1, 24, 1),
-    ...createI3SpikeSignInScenario('changePassword', 1, 21, 1),
-    ...createI3SpikeSignInScenario('changePhone', 1, 24, 1),
-    ...createI3SpikeSignInScenario('deleteAccount', 1, 18, 1),
+    ...createI3SpikeOLHScenario('changeEmail', 4, 24, 1),
+    ...createI3SpikeOLHScenario('changePassword', 4, 21, 1),
+    ...createI3SpikeOLHScenario('changePhone', 4, 24, 1),
+    ...createI3SpikeOLHScenario('deleteAccount', 4, 18, 1),
     ...createI3SpikeSignInScenario('landingPage', 7, 6, 5)
   }
 }

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -9,7 +9,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import { timeGroup } from '../common/utils/request/timing'
@@ -290,6 +291,13 @@ const profiles: ProfileList = {
       ],
       exec: 'landingPage'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignInScenario('changeEmail', 1, 24, 1),
+    ...createI3SpikeSignInScenario('changePassword', 1, 21, 1),
+    ...createI3SpikeSignInScenario('changePhone', 1, 24, 1),
+    ...createI3SpikeSignInScenario('deleteAccount', 1, 18, 1),
+    ...createI3SpikeSignInScenario('landingPage', 7, 6, 5)
   }
 }
 


### PR DESCRIPTION
## QA-948 <!--Jira Ticket Number-->

### What?
Creates an iteration 3 spike load profile specific for OLH.

#### Changes:
- creates the `createI3SpikeOLHScenario` function in `load-profiles.ts` to enable OLH scenarios to ramp at 2t/s/s while still maintaining load during 33% volume steady-states.
- imports the `createI3SpikeOLHScenario` into `olh.ts` with relevant target volumes, iteration durations, and ramp-up durations. 

---

### Why?
