### PR TITLE
[QA-951] Perf006 I3 load profiles for HMRC-check and OTG 

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -85,7 +85,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('ninoCheck', 5, 6, 61)
+    ...createI3SpikeSignUpScenario('ninoCheck', 5, 6, 6)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -85,7 +85,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('ninoCheck', 49, 6, 61)
+    ...createI3SpikeSignUpScenario('ninoCheck', 5, 6, 61) //0.49 j/sec rounding to 5  ( 5/10 in profile)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -8,7 +8,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
@@ -82,6 +83,9 @@ const profiles: ProfileList = {
       ],
       exec: 'ninoCheck'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('ninoCheck', 49, 6, 61)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -85,7 +85,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('ninoCheck', 5, 6, 61) //0.49 j/sec rounding to 5  ( 5/10 in profile)
+    ...createI3SpikeSignUpScenario('ninoCheck', 5, 6, 61)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -6,7 +6,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, pageContentCheck } from '../common/utils/checks/assertions'
@@ -56,6 +57,9 @@ const profiles: ProfileList = {
       ],
       exec: 'otg'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('otg', 49, 3, 31)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -59,7 +59,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('otg', 49, 3, 31)
+    ...createI3SpikeSignUpScenario('otg', 5, 3, 31) //0.49 j/sec rounding to 5  ( 5/10 in profile)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -59,7 +59,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('otg', 5, 3, 31) //0.49 j/sec rounding to 5  ( 5/10 in profile)
+    ...createI3SpikeSignUpScenario('otg', 5, 3, 31)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/otg.ts
+++ b/deploy/scripts/src/cri-orange/otg.ts
@@ -59,7 +59,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('otg', 5, 3, 31)
+    ...createI3SpikeSignUpScenario('otg', 5, 3, 6)
   }
 }
 


### PR DESCRIPTION
## QA-951 <!--Jira Ticket Number-->

### What?
PERF006 I3 Spike Test Load profiles for NINO_CHECK and OTG

#### Changes: 
-  For NinoCheck
    target : 5/10 (0.49 Iterations/Sec)
    iterationDuration : 6 Sec
    rampUpNFR: 6
-  For OTG
    target : 5/10 (0.49 Iterations/Sec)
    iterationDuration : 3 Sec
    rampUpNFR: 6

---

### Why?
To perform PERF006 I3 Spike Tests

---

### Related:

