### PR TITLE
[QA-955]: PERF006-I3 Spike Test Profile for BAV(CRI KIWI)

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -6,7 +6,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { b64encode } from 'k6/encoding'
 import { timeGroup } from '../common/utils/request/timing'
@@ -55,6 +56,9 @@ const profiles: ProfileList = {
       ],
       exec: 'BAV'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('ninoCheck', 5, 21, 6)
   }
 }
 

--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -58,7 +58,7 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('ninoCheck', 5, 21, 6)
+    ...createI3SpikeSignUpScenario('BAV', 5, 21, 6)
   }
 }
 


### PR DESCRIPTION
## QA-955 <!--Jira Ticket Number-->

### What?
Spike Test Profile for BAV(CRI KIWI)

#### Changes:
-   SPIKE Test Load profile for I3 changes as below
    target : 5/10 (0.49 Iterations/Sec rounded to 0.5)
    iterationDuration : 21 Sec ( 7 Steps in a Iteration)
    rampUpNFR: 6 ( RampupNFR time for 0.5 J/sec)

---

### Why?
To perform PERF006-I3 Spike testing

---

### Related:

