### PR TITLE
[QA-956] Adding CIC & F2F I3 Spike Test Load Profiles

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -7,7 +7,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import execution from 'k6/execution'
 import { b64encode } from 'k6/encoding'
@@ -83,6 +84,10 @@ const profiles: ProfileList = {
       ],
       exec: 'CIC'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('FaceToFace', 12, 42, 13),
+    ...createI3SpikeSignUpScenario('CIC', 12, 21, 13)
   }
 }
 


### PR DESCRIPTION
## QA-956 <!--Jira Ticket Number-->

### What?
Adds the `FaceToFace` and CIC Iteration 3 spike test load profiles 

#### Changes:
- Adds the `perf006Iteration3SpikeTest` load profile to `cri-kiwi/f2f-cic.ts` for the `FaceToFace` and `CIC` scenarios.

---

### Why?
To run Iteration 3 Spike tests for CIC and F2F.

