### PR TITLE
[Qa-961] Adding Iteration 3 spike load profiles to TxMA ESP & Audit-service

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -5,7 +5,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -54,6 +55,9 @@ const profiles: ProfileList = {
       ],
       exec: 'sendRegularEventWithEnrichment'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 3389, 3, 1542)
   }
 }
 


### PR DESCRIPTION
## QA-961 <!--Jira Ticket Number-->

### What?
Adds Iteration 3 spike load profiles for the `sendRegularEventWithEnrichment` scenario to test TxMA ESP & Audit-service

#### Changes:
- Adds the `createI3SpikeSignInScenario` load profiles to `txma/clientEnrichment.ts` for the `sendRegularEventWithEnrichment` scenario

---

### Why?
To run an iteration 3 spike test for TxMA ESP & Audit-Service
