### PR TITLE
QA-960 : Address CRI Iteration3 Spike Test - Load profile update

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -141,8 +141,8 @@ const profiles: ProfileList = {
   },
 
   perf006Iteration3SpikeTest: {
-    ...createI3SpikeSignUpScenario('address', 100, 15, 491),
-    ...createI3SpikeSignUpScenario('addressME', 390, 15, 491)
+    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
+    ...createI3SpikeSignUpScenario('addressME', 390, 15, 391)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -9,7 +9,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
 import { timeGroup } from '../common/utils/request/timing'
@@ -137,6 +138,11 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
+  },
+
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('address', 100, 15, 491),
+    ...createI3SpikeSignUpScenario('addressME', 390, 15, 491)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -142,7 +142,25 @@ const profiles: ProfileList = {
 
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('address', 100, 15, 101),
-    ...createI3SpikeSignUpScenario('addressME', 390, 15, 391)
+    addressME: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 45,
+      maxVUs: 90,
+      stages: [
+        { target: 0, duration: '101s' }, // Wait until the happy path scenario ramps up to target load
+        { target: 130, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
+        { target: 130, duration: '5m' }, // // Maintain steady state at 33% target throughput for 5 minutes
+        { target: 390, duration: '78s' }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
+        { target: 390, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+        { target: 130, duration: '1s' }, // Ramp down to 33% over 1 second
+        { target: 130, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+        { target: 390, duration: '391' }, // Ramp up to 100% target throughput at the rate defined in PERF008
+        { target: 390, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+      ],
+      exec: 'addressME'
+    }
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -142,25 +142,7 @@ const profiles: ProfileList = {
 
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('address', 100, 15, 101),
-    addressME: {
-      executor: 'ramping-arrival-rate',
-      startRate: 1,
-      timeUnit: '10s',
-      preAllocatedVUs: 45,
-      maxVUs: 90,
-      stages: [
-        { target: 0, duration: '101s' }, // Wait until the happy path scenario ramps up to target load
-        { target: 130, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
-        { target: 130, duration: '5m' }, // // Maintain steady state at 33% target throughput for 5 minutes
-        { target: 390, duration: '78s' }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
-        { target: 390, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
-        { target: 130, duration: '1s' }, // Ramp down to 33% over 1 second
-        { target: 130, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-        { target: 390, duration: '391' }, // Ramp up to 100% target throughput at the rate defined in PERF008
-        { target: 390, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
-      ],
-      exec: 'addressME'
-    }
+    ...createI3SpikeSignUpScenario('addressME', 390, 15, 391)
   }
 }
 


### PR DESCRIPTION
## QA-960

### What?
This pull-request is to add Iteration 3 spike load profile for Orange Address CRI

---

### Changes:
Adds `perf006Iteration3SpikeTest` load profile to cri-orange/address.js. The load profile has two scenarios - address & addressME

Spike steady state volumes
address : 10 iters/sec
addressME : 39 iters/sec

---

### Why?
To run an iteration 3 spike test for Orange Address CRI

---

