### PR TITLE
[QA-962]: Add spike test profile for IPVR BE

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -5,7 +5,9 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3SpikeSignUpScenario,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import {
@@ -87,6 +89,10 @@ const profiles: ProfileList = {
       ],
       exec: 'allEvents'
     }
+  },
+  perf006Iteration3SpikeTest: {
+    ...createI3SpikeSignUpScenario('allEvents', 12, 20, 13),
+    ...createI3SpikeSignInScenario('authEvent', 71, 5, 7)
   }
 }
 


### PR DESCRIPTION
## QA-962 <!--Jira Ticket Number-->

### What?
Add spike test profile for IPVR BE

#### Changes:
- Auth Event (Target - 71/s, Ramp Up - 7 seconds)
- All Events (Target - 1.2/s, Ramp Up - 13 seconds)

---

### Why?
To run a spike test for IPVR BE scenario.
