### PR TITLE
[QA-963]: Remove 'BRP' path from F2F script

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -273,7 +273,7 @@ export function FaceToFace(): void {
   const groups = groupMap.FaceToFace
   let res: Response
   const iteration = execution.scenario.iterationInInstance
-  const paths = ['UKPassport', 'NationalIDEEA', 'EU-DL', 'Non-UKPassport', 'BRP', 'UKDL']
+  const paths = ['UKPassport', 'NationalIDEEA', 'EU-DL', 'Non-UKPassport', 'UKDL']
   const path = paths[iteration % paths.length]
   const expiry = randomDate(new Date(2030, 1, 1), new Date(2030, 12, 31)) // Expiry 5 years from now
   const expiryDay = expiry.getDate().toString()


### PR DESCRIPTION
## QA-963 <!--Jira Ticket Number-->

### What?
Removes the invalid 'BRP' path from the CRI-Kiwi Face to Face performance test script

#### Changes:
- Removed 'BRP' from the `paths` array in the performance test script.

---

### Why?
The script was attempting to process a 'BRP' path which did not have a corresponding case statement, leading to errors and impacting throughput. Removing this invalid path ensures the script only processes valid paths, improving the accuracy and reliability of performance test results.

---
