### PR TITLE
QA-968: I3 Regression load profile update to Auth & Orch scripts

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -163,6 +163,32 @@ const profiles: ProfileList = {
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('signUp', 490, 33, 491),
     ...createI3SpikeSignInScenario('signIn', 71, 18, 33)
+  },
+  perf006Iteration3RegressionTest: {
+    signUp: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 33,
+      maxVUs: 66,
+      stages: [
+        { target: 20, duration: '21s' },
+        { target: 20, duration: '5m' }
+      ],
+      exec: 'signUp'
+    },
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 45,
+      maxVUs: 90,
+      stages: [
+        { target: 5, duration: '3s' },
+        { target: 5, duration: '5m' }
+      ],
+      exec: 'signIn'
+    }
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-968

### What?
Add regression load profile to Auth & Orch script

#### Changes:
- Update Auth & Orch script with regression load profile of 5X production volume during march

---

### Why?
To conduct Perf006 Iteration 3 regression tests

---
