### PR TITLE
[QA-970] Adding The Soak Load Profiles for Authentication & Orchestration.

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -189,6 +189,32 @@ const profiles: ProfileList = {
       ],
       exec: 'signIn'
     }
+  },
+  perf006Iteration3SoakTest: {
+    signUp: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 30,
+      maxVUs: 36,
+      stages: [
+        { target: 11, duration: '12s' },
+        { target: 11, duration: '6h' }
+      ],
+      exec: 'signUp'
+    },
+    signIn: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 30,
+      maxVUs: 36,
+      stages: [
+        { target: 2, duration: '1s' },
+        { target: 2, duration: '6h' }
+      ],
+      exec: 'signIn'
+    }
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-970 <!--Jira Ticket Number-->

### What?
Adds the Iteration 3 soak load profile to the auth script for the `signUp` and `signIn` scenarios. 

#### Changes:
- Adds the `perf006Iteration3SoakTest` load profile to `authentication/test.ts ` for the `signUp` and `signIn` scenarios. 

---

### Why?
To run an iteration 3 speak test for auth & orch.

