### PR TITLE
[QA-972]: Adding regression Load profiles for Address and Fraud

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -104,7 +104,8 @@ export enum LoadProfile {
   spikeNFRSignInL2,
   spikeI2LowTraffic,
   spikeI2HighTraffic,
-  steadyStateOnly
+  steadyStateOnly,
+  regression
 }
 function createStages(type: LoadProfile, target: number): Stage[] {
   switch (type) {
@@ -236,6 +237,11 @@ function createStages(type: LoadProfile, target: number): Stage[] {
         { target, duration: '6m' } // Maintain 100% volume for 6 minutes
       ]
     }
+    case LoadProfile.regression:
+      return [
+        { target, duration: '2m' }, // Ramps up to target volume(5x of prod) in 2 minutes
+        { target, duration: '3m' } // Maintain steady state at target throughput for 3 minutes
+      ]
   }
 }
 

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -388,7 +388,7 @@ export function createI3RegressionScenario(
   list[exec] = {
     executor: 'ramping-arrival-rate',
     startRate: 1,
-    timeUnit: '1s',
+    timeUnit: '10s',
     preAllocatedVUs,
     maxVUs,
     stages: [

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -8,7 +8,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createI3RegressionScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
@@ -302,6 +303,9 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('drivingLicence', 61, 9, 62),
     ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 103, 9, 104),
     ...createI3SpikeSignUpScenario('fraud', 490, 6, 491)
+  },
+  perf006RegressionTest: {
+    ...createI3RegressionScenario('fraud', 5, 6, 6)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -10,7 +10,7 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3RegressionScenario
+  createI3RegressionScenario,
   createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -9,7 +9,8 @@ import {
   type ProfileList,
   describeProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI3RegressionScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
 import { timeGroup } from '../common/utils/request/timing'
@@ -137,6 +138,9 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
+  },
+  perf006RegressionTest: {
+    ...createI3RegressionScenario('address', 5, 15, 6)
   }
 }
 


### PR DESCRIPTION
## QA-972 <!--Jira Ticket Number-->

### What?
Load profile for PERF006 - regression testing

#### Changes:
-  created  a load profile function for createI3RegressionScenario
       Ramp up  to rampupNFR and Steady State 5 minutes
  

---

### Why?
To Perform PERF006-Regression tests

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
