### PR TITLE
[QA-970] Updating the soak test volumes for Auth & Orch.

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -195,7 +195,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 30,
+      preAllocatedVUs: 33,
       maxVUs: 66,
       stages: [
         { target: 20, duration: '21s' },
@@ -207,7 +207,7 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 30,
+      preAllocatedVUs: 27,
       maxVUs: 54,
       stages: [
         { target: 3, duration: '3s' },

--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -196,10 +196,10 @@ const profiles: ProfileList = {
       startRate: 1,
       timeUnit: '10s',
       preAllocatedVUs: 30,
-      maxVUs: 36,
+      maxVUs: 66,
       stages: [
-        { target: 11, duration: '12s' },
-        { target: 11, duration: '6h' }
+        { target: 20, duration: '21s' },
+        { target: 20, duration: '6h' }
       ],
       exec: 'signUp'
     },
@@ -208,10 +208,10 @@ const profiles: ProfileList = {
       startRate: 2,
       timeUnit: '1s',
       preAllocatedVUs: 30,
-      maxVUs: 36,
+      maxVUs: 54,
       stages: [
-        { target: 2, duration: '1s' },
-        { target: 2, duration: '6h' }
+        { target: 3, duration: '3s' },
+        { target: 3, duration: '6h' }
       ],
       exec: 'signIn'
     }


### PR DESCRIPTION
## QA-970 <!--Jira Ticket Number-->

### What?
Updates the soak test volumes for auth & orch `signIn` and `signUp` to 3 and 2 iterations per second respectively. 

#### Changes:
Updates the `perf006Iteration3SoakTest` volumes for `authentication/test.ts` `signIn` and `signUp` to 3 and 2 iterations per second respectively. 

---

### Why?
To run an auth & orch soak test at the above target volumes. 

