### PR TITLE
DCMAW-12496: Mobile Backend performance tests

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend/testSteps/backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend/testSteps/backend.ts
@@ -1,0 +1,57 @@
+import { timeGroup } from '../../../common/utils/request/timing'
+import http from 'k6/http'
+import { isStatusCode200 } from '../../../common/utils/checks/assertions'
+import { config } from '../utils/config'
+import { groupMap } from '../../v2-mobile-backend-get-client-attestation'
+
+export function getAppInfo(): void {
+  timeGroup(
+    groupMap.getClientAttestation[0],
+    () => {
+      return http.get(`${config.mobileBackendBaseUrl}/appInfo`)
+    },
+    {
+      isStatusCode200
+    }
+  )
+}
+
+export function postClientAttestation(publicKeyJwk: JsonWebKey, appCheckToken: string): string {
+  const requestBody = {
+    jwk: {
+      kty: publicKeyJwk.kty,
+      use: 'sig',
+      crv: publicKeyJwk.crv,
+      x: publicKeyJwk.x,
+      y: publicKeyJwk.y
+    }
+  }
+
+  const res = timeGroup(
+    groupMap.getClientAttestation[2],
+    () => {
+      return http.post(`${config.mobileBackendBaseUrl}/client-attestation`, JSON.stringify(requestBody), {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Firebase-AppCheck': appCheckToken
+        }
+      })
+    },
+    {
+      isStatusCode200
+    }
+  )
+  return res.json('client_attestation') as string
+}
+
+export function simulateCallToMobileBackendJwks(): void {
+  timeGroup(
+    groupMap.getClientAttestation[3],
+    () => {
+      return http.get(`${config.mobileBackendBaseUrl}/.well-known/jwks.json`)
+    },
+    {
+      isStatusCode200
+    }
+  )
+}

--- a/deploy/scripts/src/mobile/mobile-backend/utils/appCheckToken.ts
+++ b/deploy/scripts/src/mobile/mobile-backend/utils/appCheckToken.ts
@@ -1,0 +1,33 @@
+import { getEnv } from '../../../common/utils/config/environment-variables'
+import { AssumeRoleOutput } from '../../../common/utils/aws/types'
+import { timeGroup } from '../../../common/utils/request/timing'
+import http from 'k6/http'
+import { isStatusCode200 } from '../../../common/utils/checks/assertions'
+import { signRequest } from '../../utils/signatureV4'
+import { config } from './config'
+import { groupMap } from '../../v2-mobile-backend-get-client-attestation'
+
+const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
+
+export function getAppCheckToken(): string {
+  const signedRequest = signRequest(
+    getEnv('AWS_REGION'),
+    credentials,
+    'GET',
+    config.appCheckStubBaseUrl.split('https://')[1],
+    '/app-check-token',
+    {},
+    ''
+  )
+
+  const res = timeGroup(
+    groupMap.getClientAttestation[1],
+    () => {
+      return http.get(signedRequest.url, { headers: signedRequest.headers })
+    },
+    {
+      isStatusCode200
+    }
+  )
+  return res.json('token') as string
+}

--- a/deploy/scripts/src/mobile/mobile-backend/utils/config.ts
+++ b/deploy/scripts/src/mobile/mobile-backend/utils/config.ts
@@ -1,0 +1,12 @@
+import { getEnv } from '../../../common/utils/config/environment-variables'
+
+// Refer to deploy/scripts/README.md for guidance on how to set environment variables
+export const environment = getEnv('ENVIRONMENT').toLocaleUpperCase()
+const validEnvironments = ['BUILD', 'DEV']
+if (!validEnvironments.includes(environment))
+  throw new Error(`Environment '${environment}' not in [${validEnvironments.toString()}]`)
+
+export const config = {
+  mobileBackendBaseUrl: getEnv(`MOBILE_BACKEND_${environment}_MOBILE_BACKEND_BASE_URL`),
+  appCheckStubBaseUrl: getEnv(`MOBILE_BACKEND_${environment}_APP_CHECK_STUB_BASE_URL`)
+}

--- a/deploy/scripts/src/mobile/utils/crypto.ts
+++ b/deploy/scripts/src/mobile/utils/crypto.ts
@@ -1,0 +1,35 @@
+import { algParamMap, JwtAlgorithm } from '../../common/utils/authentication/jwt'
+import { b64encode } from 'k6/encoding'
+
+export async function signJwt(
+  type: JwtAlgorithm,
+  key: CryptoKey,
+  payload: object,
+  additionalHeaderParameters: object
+): Promise<string> {
+  const encodedHeader = b64encode(JSON.stringify({ alg: type, typ: 'JWT', ...additionalHeaderParameters }), 'rawurl')
+  const encodedPayload = b64encode(JSON.stringify(payload), 'rawurl')
+  const buf = strToBuf(`${encodedHeader}.${encodedPayload}`)
+  const sigBuf = await crypto.subtle.sign(algParamMap[type], key, buf)
+  const signature = b64encode(sigBuf, 'rawurl')
+  return `${encodedHeader}.${encodedPayload}.${signature}`
+}
+
+export async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  const data = strToBuf(codeVerifier)
+  const buf = await crypto.subtle.digest('SHA-256', data)
+  return b64encode(buf, 'rawurl')
+}
+
+export async function generateKey() {
+  return await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign'])
+}
+
+export function strToBuf(str: string): ArrayBuffer {
+  const buf = new ArrayBuffer(str.length)
+  const bufView = new Uint8Array(buf)
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i)
+  }
+  return buf
+}

--- a/deploy/scripts/src/mobile/utils/signatureV4.ts
+++ b/deploy/scripts/src/mobile/utils/signatureV4.ts
@@ -1,0 +1,41 @@
+import { SignatureV4 } from '../../common/utils/jslib/aws-signature'
+
+type Credentials = {
+  AccessKeyId: string
+  SecretAccessKey: string
+  SessionToken: string
+}
+
+export function signRequest(
+  region: string,
+  credentials: Credentials,
+  method: string,
+  hostname: string,
+  path: string,
+  headers: Record<string, string>,
+  requestBody: string
+): {
+  headers: Record<string, string>
+  url: string
+} {
+  const apiGatewaySigner = new SignatureV4({
+    service: 'execute-api',
+    region: region,
+    credentials: {
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken
+    },
+    uriEscapePath: false,
+    applyChecksum: false
+  })
+
+  return apiGatewaySigner.sign({
+    method,
+    protocol: 'https',
+    hostname,
+    path,
+    headers,
+    body: requestBody
+  })
+}

--- a/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
+++ b/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
@@ -16,6 +16,20 @@ import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 const profiles: ProfileList = {
   smoke: {
     ...createScenario('getClientAttestation', LoadProfile.smoke)
+  },
+  perf006Iteration3PeakTest: {
+    getClientAttestation: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 100,
+      maxVUs: 528,
+      stages: [
+        { target: 150, duration: '151s' },
+        { target: 150, duration: '30m' }
+      ],
+      exec: 'getClientAttestation'
+    }
   }
 }
 

--- a/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
+++ b/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
@@ -11,6 +11,7 @@ import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_m
 import { generateKey } from './utils/crypto'
 import { getAppInfo, postClientAttestation, simulateCallToMobileBackendJwks } from './mobile-backend/testSteps/backend'
 import { getAppCheckToken } from './mobile-backend/utils/appCheckToken'
+import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 
 const profiles: ProfileList = {
   smoke: {
@@ -44,6 +45,7 @@ export async function getClientAttestation(): Promise<void> {
 
   iterationsStarted.add(1)
   getAppInfo()
+  sleepBetween(1, 2)
   const appCheckToken = getAppCheckToken()
   postClientAttestation(publicKeyJwk, appCheckToken)
   simulateCallToMobileBackendJwks()

--- a/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
+++ b/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
@@ -22,10 +22,10 @@ const profiles: ProfileList = {
 const loadProfile = selectProfile(profiles)
 export const groupMap = {
   getClientAttestation: [
-    '01 GET /appInfo',
-    '02 GET /app-check-token',
-    '03 POST /client-attestation',
-    '04 GET /.well-known/jwks.json'
+    '01_GET_/appInfo',
+    '02_GET_/app-check-token',
+    '03_POST_/client-attestation',
+    '04_GET_/.well-known/jwks.json'
   ]
 } as const
 

--- a/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
+++ b/deploy/scripts/src/mobile/v2-mobile-backend-get-client-attestation.ts
@@ -1,0 +1,51 @@
+import {
+  createScenario,
+  describeProfile,
+  LoadProfile,
+  ProfileList,
+  selectProfile
+} from '../common/utils/config/load-profiles'
+import { Options } from 'k6/options'
+import { getThresholds } from '../common/utils/config/thresholds'
+import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
+import { generateKey } from './utils/crypto'
+import { getAppInfo, postClientAttestation, simulateCallToMobileBackendJwks } from './mobile-backend/testSteps/backend'
+import { getAppCheckToken } from './mobile-backend/utils/appCheckToken'
+
+const profiles: ProfileList = {
+  smoke: {
+    ...createScenario('getClientAttestation', LoadProfile.smoke)
+  }
+}
+
+const loadProfile = selectProfile(profiles)
+export const groupMap = {
+  getClientAttestation: [
+    '01 GET /appInfo',
+    '02 GET /app-check-token',
+    '03 POST /client-attestation',
+    '04 GET /.well-known/jwks.json'
+  ]
+} as const
+
+export const options: Options = {
+  scenarios: loadProfile.scenarios,
+  thresholds: getThresholds(groupMap),
+  tags: { name: '' }
+}
+
+export function setup(): void {
+  describeProfile(loadProfile)
+}
+
+export async function getClientAttestation(): Promise<void> {
+  const keyPair = await generateKey()
+  const publicKeyJwk = await crypto.subtle.exportKey('jwk', keyPair.publicKey)
+
+  iterationsStarted.add(1)
+  getAppInfo()
+  const appCheckToken = getAppCheckToken()
+  postClientAttestation(publicKeyJwk, appCheckToken)
+  simulateCallToMobileBackendJwks()
+  iterationsCompleted.add(1)
+}


### PR DESCRIPTION
## DCMAW-12496 <!--Jira Ticket Number-->

### What?

- Adds `getClientAttestation.ts` script for getting a client attestation from the Mobile Backend. This simulates a user logging in to the 'V2 app' and client attestation that is needed to get tokens from STS.

#### Changes:

##### `get-client-attestation.ts`

- Script for getting a client attestation from the Mobile Backend. This includes only the calls to the Mobile Backend as part of a login journey and does not make any calls to STS.

---

### Why?

Adds scripts for STS performance tests.

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
