### PR TITLE
[QA-978]: Update k6 version to build the output-statsd extension

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,7 +19,7 @@ FROM golang:1.24-alpine AS k6-build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@v0.13.0 \
-  && xk6 build v0.54.0 --with github.com/LeonAdato/xk6-output-statsd@v0.2.0 --output /k6
+  && xk6 build v0.58.0 --with github.com/LeonAdato/xk6-output-statsd@v0.2.1 --output /k6
 
 # -----------------------
 # OpenTelemetry Collector


### PR DESCRIPTION
## QA-978 <!--Jira Ticket Number-->

### What?
Update k6 version in the Dockerfile

#### Changes:
- Update k6 version in xk6 build using the output-statsd extension to create the k6 binary

---

### Why?
To fix compatibility issues with the latest crypto module used in the repo.