### PR TITLE
[QA-983]: Added load profiles for iteration 3 peak tests

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -344,6 +344,60 @@ export function createI3SpikeSignInScenario(
   return list
 }
 
+export function createI4PeakTestSignUpScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number,
+  peakDuration: number = 1800 // 30 minutes in seconds
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
+  const maxVUs = target * iterationDuration * 2
+
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: 1,
+    timeUnit: '10s',
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target, duration: `${rampUpDuration}s` },
+      { target, duration: `${peakDuration}s` }
+    ],
+    exec
+  }
+
+  return list
+}
+
+export function createI4PeakTestSignInScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number,
+  peakDuration: number = 1800 // 30 minutes in seconds
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
+  const maxVUs = target * iterationDuration * 2
+
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: 1,
+    timeUnit: '1s',
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target, duration: `${rampUpDuration}s` },
+      { target, duration: `${peakDuration}s` }
+    ],
+    exec
+  }
+
+  return list
+}
+
 export function createI3SpikeOLHScenario(
   exec: string,
   target: number = 1,


### PR DESCRIPTION
## QA-983 <!--Jira Ticket Number-->

### What?
Added load profiles for iteration 4 peak test


#### Changes:
Added a common load profile for signUp,ID proving, CRIs etc. called createI4PeakTestSignUpScenario
Added a common load profile for ID reuse, Sign in scenarios called createI4PeakTestSignInScenario

---

### Why?
To execute iteration 4 peak tests
---


