### PR TITLE
QA-988 : Add I4 Peak test Load profiles to Authentication script

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -12,7 +12,9 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignUpScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { getThresholds } from '../common/utils/config/thresholds'
 import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
@@ -261,6 +263,10 @@ const profiles: ProfileList = {
       ],
       exec: 'signIn'
     }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('signUp', 470, 33, 471),
+    ...createI4PeakTestSignInScenario('signIn', 43, 18, 21)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-988

### What?
To add load profile for iteration 4 peak test

#### Changes:
Updated deploy/scripts/src/authentication/test.ts with SignIn & SignUp load profiles for iteration 4 peak test

---

### Why?
To execute iteration 4 peak tests

---
