### PR TITLE
QA-989 Update Iter 4 IPVCore load prof

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -9,7 +9,9 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignUpScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
@@ -268,6 +270,10 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('identity', 470, 36, 471),
+    ...createI4PeakTestSignInScenario('idReuse', 43, 6, 21)
   }
 }
 


### PR DESCRIPTION
## QA-989
### What?
Update Iteration 4 IPVCore load profiles

#### Changes:
- Update Iteration 4 IPVCore load profiles

---

### Why?
to enable Iteration 4 peak test on IPV Core
---
