### PR TITLE
[QA-1026] Adding a 2000j/s load profiles for TxMA

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -59,7 +59,7 @@ const profiles: ProfileList = {
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 3389, 3, 1542)
   },
-  PeakTest2000: {
+  peakTest2000: {
     sendRegularEventWithEnrichment: {
       executor: 'ramping-arrival-rate',
       startRate: 2,

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -58,6 +58,20 @@ const profiles: ProfileList = {
   },
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 3389, 3, 1542)
+  },
+  PeakTest2000: {
+    sendRegularEventWithEnrichment: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 3000,
+      maxVUs: 6000,
+      stages: [
+        { target: 2000, duration: '911s' },
+        { target: 2000, duration: '30m' }
+      ],
+      exec: 'sendRegularEventWithEnrichment'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1026 <!--Jira Ticket Number-->

### What?
Adds a load profile with a target of 2000j/s for TxMA `sendRegularEventWithEnrichment`
`
#### Changes:
- Adds in the `PeakTest2000` load profile with a target of 2000j/s and growth-rate of 2.2j/s/s for the `sendRegularEventWithEnrichment` scenario.

---

### Why?
To run a test for TxMA SS at 2000j/s

