### PR TITLE
[QA-1028]: Add Perf006 Iteration 4 Peak Test Profiles for CRI Lime

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -9,7 +9,8 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI3RegressionScenario
+  createI3RegressionScenario,
+  createI4PeakTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import exec from 'k6/execution'
@@ -306,6 +307,12 @@ const profiles: ProfileList = {
   },
   perf006RegressionTest: {
     ...createI3RegressionScenario('fraud', 5, 6, 6)
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('passport', 47, 6, 48),
+    ...createI4PeakTestSignUpScenario('drivingLicence', 59, 9, 60),
+    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 47, 9, 48),
+    ...createI4PeakTestSignUpScenario('fraud', 470, 6, 471)
   }
 }
 


### PR DESCRIPTION
## QA-1028 <!--Jira Ticket Number-->

### What?
This adds peak test load profiles for CRI Lime (Passport, DL CRI, DL Attestation, and Fraud) for Perf006 Iteration 4.

#### Changes:
Passport: 4.7 requests/second, 48s ramp-up
DL CRI: 5.9 requests/second, 60s ramp-up
DL Attestation: 4.7 requests/second, 48s ramp-up
Fraud: 47 requests/second, 471s ramp-up

---

### Why?
These profiles are needed to execute the Iteration 4 peak performance tests.
---
