### PR TITLE
[QA-1032]: mobile V2 STS PEAK load profile for I4

### DIFF
--- a/deploy/scripts/src/mobile/v2-sts-get-service-access-token.ts
+++ b/deploy/scripts/src/mobile/v2-sts-get-service-access-token.ts
@@ -1,4 +1,5 @@
 import {
+  createI4PeakTestSignUpScenario,
   createScenario,
   describeProfile,
   LoadProfile,
@@ -37,6 +38,9 @@ const profiles: ProfileList = {
       ],
       exec: 'getServiceAccessToken'
     }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('getServiceAccessToken', 450, 30, 451)
   }
 }
 


### PR DESCRIPTION
## QA-1032 <!--Jira Ticket Number-->

### What?
mobile V2 STS Peak load profile for I4

#### Changes:
- Target Load 45 J/Sec
- Rampup time 451 sec
- Peak Test Duration - 30 min

---

### Why?
to Perform PERF006-Iteration4 testing

---

### Related:

