### PR TITLE
QA-1031: Load Profile update for Lime DL & DLA I4 Peak tests

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -311,7 +311,7 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('passport', 47, 6, 48),
     ...createI4PeakTestSignUpScenario('drivingLicence', 59, 9, 60),
-    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 99, 9, 48),
+    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 99, 9, 100),
     ...createI4PeakTestSignUpScenario('fraud', 470, 6, 471)
   }
 }

--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -311,7 +311,7 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('passport', 47, 6, 48),
     ...createI4PeakTestSignUpScenario('drivingLicence', 59, 9, 60),
-    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 47, 9, 48),
+    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 99, 9, 48),
     ...createI4PeakTestSignUpScenario('fraud', 470, 6, 471)
   }
 }


### PR DESCRIPTION
## QA-1031

### What?
To add Lime DL & DLA I4 peak test profile
DL CRI : `5.9 iters/sec`
DLA CRI : `9.9 iters/sec`(rounded from 9.87) 

#### Changes:
Added DL & DLA I4 Peak test profile `perf006Iteration4PeakTest`

---

### Why?
To test Lime DL & DLA I4 peak scenario

---
