### PR TITLE
[QA-1058] Adding a 260j/s loadProfile for fraud SSF Inbound

### DIFF
--- a/deploy/scripts/src/fraud/test.ts
+++ b/deploy/scripts/src/fraud/test.ts
@@ -129,6 +129,17 @@ const profiles: ProfileList = {
       stages: [{ target: 250, duration: '6m' }],
       exec: 'fraud'
     }
+  },
+  load260: {
+    fraud: {
+      executor: 'ramping-arrival-rate',
+      startRate: 260,
+      timeUnit: '1s',
+      preAllocatedVUs: 390,
+      maxVUs: 780,
+      stages: [{ target: 260, duration: '6m' }],
+      exec: 'fraud'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1058 <!--Jira Ticket Number-->

### What?
Adds a load profile with a target volume of 260j/s for 6 minutes to the `fraud/test.j`s script. 

#### Changes:
- Adds the `load260` profiles for `fraud` to `fraud/test.js` with a target of 260j/s and a steady-state duration of 6 minutes. 

---

### Why?
To run a test for fraud SSF Inbound with the above load-profile. 

