### PR TITLE
[QA-1055]: Add Perf006 I4 PeakTestProfile for DCMAW -Mobile (FE+BE)

### DIFF
--- a/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
+++ b/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
@@ -5,7 +5,8 @@ import {
   type ProfileList,
   selectProfile,
   createScenario,
-  LoadProfile
+  LoadProfile,
+  createI4PeakTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import {
   postSelectDevice,
@@ -80,6 +81,9 @@ const profiles: ProfileList = {
       ],
       exec: 'mamIphonePassport'
     }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('mamIphonePassport', 450, 48, 451)
   }
 }
 


### PR DESCRIPTION
## QA-1055 <!--Jira Ticket Number-->

### What?
This adds peak test load profiles for DCMAW -Mobile (FE+BE) for Perf006 Iteration 4.

#### Changes:
- Mobile(FE=BE): 45 requests/second, 451s ramp-up

---

### Why?
This profile is needed to execute the Iteration 4 peak performance tests.

