### PR TITLE
[QA-1060]: Update I4 PeakTest SignUp and Sign In Load Profile to adjust the VU counts

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -351,8 +351,8 @@ export function createI4PeakTestSignUpScenario(
   rampUpDuration: number
 ): ScenarioList {
   const list: ScenarioList = {}
-  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
-  const maxVUs = target * iterationDuration * 2
+  const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
+  const maxVUs = Math.round((target / 10) * iterationDuration)
 
   list[exec] = {
     executor: 'ramping-arrival-rate',

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -378,7 +378,7 @@ export function createI4PeakTestSignInScenario(
 ): ScenarioList {
   const list: ScenarioList = {}
   const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
-  const maxVUs = target * iterationDuration * 2
+  const maxVUs = target * iterationDuration
 
   list[exec] = {
     executor: 'ramping-arrival-rate',


### PR DESCRIPTION
## QA-1060 <!--Jira Ticket Number-->

### What?
Update I4 PeakTest SignUp Load Profile to adjust the VU counts

#### Changes:
- Target for pre Allocated VUs should not be 10x hence the change is `const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)`
- Target for Max VUs should not be 10x hence the change is `const maxVUs = Math.round((target / 10) * iterationDuration)`

---

### Why?
To initiate the right number of pre-allocated and max virtual users during the peak test for iteration 4.

