### PR TITLE
[QA-1065]: Updated Profile-for I4PeakTest

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -6,7 +6,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
@@ -48,6 +49,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignInScenario('spot', 120, 3, 55)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI4PeakTestSignInScenario('spot', 90, 3, 21)
   }
 }
 


### PR DESCRIPTION
## QA-1065 <!--Jira Ticket Number-->

### What?
Adds the peak test load profile for SPOT in Perf006 Iteration 4.


#### Changes:
- SPOT: 90 requests/second, 21s ramp-up

---

### Why?
To execute the Iteration 4 peak performance tests.
---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
