### PR TITLE
QA-1064: I4 Peak Load profile update to Orange Address script

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -146,6 +146,33 @@ const profiles: ProfileList = {
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('address', 100, 15, 101),
     ...createI3SpikeSignUpScenario('addressME', 390, 15, 391)
+  },
+  perf006Iteration4PeakTest: {
+    address: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 75,
+      maxVUs: 150,
+      stages: [
+        { target: 100, duration: '101s' },
+        { target: 100, duration: '30m' }
+      ],
+      exec: 'address'
+    },
+    addressME: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 278,
+      maxVUs: 555,
+      stages: [
+        { target: 0, duration: '101s' }, // Wait until the happy path scenario ramps up to target load
+        { target: 370, duration: '371s' }, // Ramp up to target load
+        { target: 370, duration: '30m' } // Maintain a steady state at the target load for 30 minutes.
+      ],
+      exec: 'addressME'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1064

### What?
To add peak load profile to Orange Address script

#### Changes:
Added `perf006Iteration4PeakTest` profile for address & addressME scenarios to achieve the below peak targets
`address: 10 iters/sec`
`addressME: 37 iters/sec` - the rampup starts after the initial 101 seconds wait

---

### Why?
To test Perf006 Iters4 peak test

---

