### PR TITLE
[QA-1067]: Address CRI - Experian KBV I4 Peak load profile

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -7,7 +7,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
 import { timeGroup } from '../common/utils/request/timing'
@@ -88,6 +89,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('kbv', 49, 12, 50)
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignInScenario('kbv', 47, 12, 48)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -8,7 +8,7 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI4PeakTestSignInScenario
+  createI4PeakTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { env, encodedCredentials } from './utils/config'
 import { timeGroup } from '../common/utils/request/timing'
@@ -91,7 +91,7 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('kbv', 49, 12, 50)
   },
   perf006Iteration4PeakTest: {
-    ...createI4PeakTestSignInScenario('kbv', 47, 12, 48)
+    ...createI4PeakTestSignUpScenario('kbv', 47, 12, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1067 <!--Jira Ticket Number-->

### What?
Experian KBV I4 Peak load profile

#### Changes:
- Target Peak Load - 4.7 J/sec
- Ramp up duration 48 sec

---

### Why?
to perform PERF006 Iteration4 testing

---

### Related:

