### PR TITLE
[QA-1070]: Add Load Profile for I4 PeakTest

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -7,7 +7,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createI4PeakTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { b64encode } from 'k6/encoding'
 import { timeGroup } from '../common/utils/request/timing'
@@ -59,6 +60,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('BAV', 5, 21, 6)
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('BAV', 5, 21, 6)
   }
 }
 


### PR DESCRIPTION
## QA-1070 <!--Jira Ticket Number-->

### What?
Adds the peak test load profile for CRI-KIWI-BAV in Perf006 Iteration 4.

#### Changes:
- BAV: 0.5 requests/second, 6s ramp-up

---

### Why?
To execute the Iteration 4 peak performance test
---

