### PR TITLE
[QA-1079]:Add Load Profile for I4 PeakTest

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -8,7 +8,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createI4PeakTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import execution from 'k6/execution'
 import { b64encode } from 'k6/encoding'
@@ -88,6 +89,10 @@ const profiles: ProfileList = {
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('FaceToFace', 12, 42, 13),
     ...createI3SpikeSignUpScenario('CIC', 12, 21, 13)
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('FaceToFace', 12, 42, 13),
+    ...createI4PeakTestSignUpScenario('CIC', 12, 21, 13)
   }
 }
 


### PR DESCRIPTION
## QA-1079 <!--Jira Ticket Number-->

### What?
Adds the peak test load profile for CRI-KIWI-CIC and F2F in Perf006 Iteration 4.


#### Changes:
- CIC: 1.2 requests/second, 13s ramp-up
- F2F: 1.2 requests/second, 13s ramp-up

---

### Why?
To execute the Iteration 4 peak performance test

---
