### PR TITLE
[QA-1080]: Add Load Profile for I4 PeakTest

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -7,7 +7,9 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignUpScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import {
@@ -93,6 +95,10 @@ const profiles: ProfileList = {
   perf006Iteration3SpikeTest: {
     ...createI3SpikeSignUpScenario('allEvents', 12, 20, 13),
     ...createI3SpikeSignInScenario('authEvent', 71, 5, 7)
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignUpScenario('allEvents', 12, 20, 13),
+    ...createI4PeakTestSignInScenario('authEvent', 43, 5, 21)
   }
 }
 


### PR DESCRIPTION
## QA-1080 <!--Jira Ticket Number-->

### What?
Adds the peak test load profile for CRI-KIWI-IPRV BE in Perf006 Iteration 4.

#### Changes:
- All Events: 1.2 requests/second, 13s ramp-up
- Auth Event: 43 requests/second, 21s ramp-up

---

### Why?
To execute the Iteration 4 peak performance test

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
