### PR TITLE
QA-1086 Remove SSM parameters, in favour of CFN Imports.

### DIFF
--- a/dns/acm-certificate.yaml
+++ b/dns/acm-certificate.yaml
@@ -38,7 +38,7 @@ Resources:
             - "${DNSSUFFIX}"
             - DNSSUFFIX:
                 !FindInMap [PlatformConfiguration, !Ref Environment, DNSSUFFIX]
-          HostedZoneId: "{{resolve:ssm:PrimaryZoneID}}"
+          HostedZoneId: !ImportValue PublicHostedZoneId
       ValidationMethod: DNS
       Tags:
         - Key: Name
@@ -52,19 +52,6 @@ Resources:
           Value: "Performance Testing"
         - Key: Environment
           Value: !Sub "${Environment}"
-
-  CertificateARNSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The Certificate ARN
-      Name: PrimaryZoneWildcardCertificateARN
-      Type: String
-      Value: !Ref ExternalCertificate
-      Tags:
-        Name: "PrimaryZoneWildcardCertificateARN"
-        Product: "GOV.UK One Login - Performance Testing"
-        System: "Performance Testing"
-        Environment: !Sub "${Environment}"
 
 Outputs:
   CertificateARN:

--- a/dns/dns.yaml
+++ b/dns/dns.yaml
@@ -16,18 +16,7 @@ Resources:
       Name: !Sub perf.${Environment}.account.gov.uk
     Metadata:
       SamResourceId: PublicHostedZone
-  PublicHostedZoneSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The ARN of hosted zone
-      Name: PrimaryZoneID
-      Type: String
-      Value:
-        Fn::GetAtt:
-          - PublicHostedZone
-          - Id
-    Metadata:
-      SamResourceId: PublicHostedZoneSSM
+
 Outputs:
   PublicHostedZoneNameServers:
     Value:


### PR DESCRIPTION
## QA-1086 

### What?

Switch the base stacks to use CFN Exports & !ImportValue instead of SSM.
SSM triggers Security Alerts, and isn't needed for these stacks; as the core template doesn't depend on the SSM params either.

#### Changes:
- Remove the SSM parameter resource from ACM
- Switch ACM to use the same !ImportValue as the deploy/template.yaml syntax for its dependency on DNS Zone ID.
- Remove the SSM parameter resource from DNS

---

### Why?
The SSM parameters didn't resolve in the correct order to work for the core template; therefore in reverting to CFN Export / !ImportValue - it keeps the pattern consistent across the repo.
---
