### PR TITLE
[QA-563] Adding eventIDs to TiCF payloads

### DIFF
--- a/deploy/scripts/src/common/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqFormat.ts
@@ -105,6 +105,7 @@ export interface DcmawAbortWeb {
 
 export interface AuthAuthorisationInitiated {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -123,6 +124,7 @@ export interface AuthAuthorisationInitiated {
 
 export interface AuthCodeVerified {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number

--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -145,9 +145,10 @@ export function generateDcmawAbortWeb(userID: string, journeyID: string, emailID
   }
 }
 
-export function generateAuthAuthorisationInitiated(journeyID: string): AuthAuthorisationInitiated {
+export function generateAuthAuthorisationInitiated(journeyID: string, eventID: string): AuthAuthorisationInitiated {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'AUTH_AUTHORISATION_INITIATED',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -165,9 +166,15 @@ export function generateAuthAuthorisationInitiated(journeyID: string): AuthAutho
   }
 }
 
-export function generateAuthCodeVerified(emailID: string, journeyID: string, userID: string): AuthCodeVerified {
+export function generateAuthCodeVerified(
+  emailID: string,
+  journeyID: string,
+  userID: string,
+  eventID: string
+): AuthCodeVerified {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'AUTH_CODE_VERIFIED',
     event_timestamp_ms: Math.floor(Date.now()),

--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -74,9 +74,9 @@ export function signInSuccess(): void {
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
   const journeyID = `perfJourney${uuidv4()}`
   const eventID = `perfTestID$_${uuidv4()}`
-  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, eventID))
   const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(eventID, userID, emailID, journeyID))
-  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID))
+  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID, eventID))
   iterationsStarted.add(1)
 
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
@@ -109,10 +109,11 @@ export function signUpSuccess(): void {
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
   const pairWiseID = `performanceTestRpPairwiseId${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
+  const eventID = `perfTestID$_${uuidv4()}`
 
-  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, eventID))
   const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
-  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID))
+  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID, eventID))
   const authUpdatePhonePayload = JSON.stringify(generateAuthUpdatePhone(emailID, journeyID, userID))
   iterationsStarted.add(1)
 


### PR DESCRIPTION
## QA-563 <!--Jira Ticket Number-->

### What?
Adds in and eventID to the `signInSuccess` TiCF payloads

#### Changes:
- Adds in an `event_id` to the `AUTH_CODE_VERIFIED` and `AUTH_AUTHORISATION_INITIATED` TxMA payloads

---

### Why?
To send complete payloads with eventIDs in the TiCF `signInSuccess` scenario

