### PR TITLE
[QA-563] Adding eventIDs to all TxMA Payloads used in TiCF

### DIFF
--- a/deploy/scripts/src/common/requestGenerator/txmaReqFormat.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqFormat.ts
@@ -149,6 +149,7 @@ export interface AuthCodeVerified {
 
 export interface AuthUpdateProfilePhoneNumber {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -171,6 +172,7 @@ export interface AuthUpdateProfilePhoneNumber {
 
 export interface IPVJourneyStart {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -194,6 +196,7 @@ export interface IPVJourneyStart {
 
 export interface IPVSubJourneyStart {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -216,6 +219,7 @@ export interface IPVSubJourneyStart {
 
 export interface IPVDLCRIVCIssued {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -285,6 +289,7 @@ export interface IPVDLCRIVCIssued {
 
 export interface IPVAddressCRIVCIssued {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -319,6 +324,7 @@ export interface IPVAddressCRIVCIssued {
 
 export interface IPVKBVCRIStart {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number
@@ -339,6 +345,7 @@ export interface IPVKBVCRIStart {
 
 export interface IPVKBVCRIEnd {
   client_id: string
+  event_id: string
   component_id: string
   event_name: string
   event_timestamp_ms: number

--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -22,9 +22,9 @@ export function generateAuthCreateAccount(
   userID: string,
   emailID: string,
   pairWiseID: string,
-  journeyID: string
+  journeyID: string,
+  eventID: string
 ): AuthCreateAccount {
-  const eventID = `${testID}_${uuidv4()}`
   return {
     event_id: eventID,
     event_name: 'AUTH_CREATE_ACCOUNT',
@@ -201,10 +201,12 @@ export function generateAuthCodeVerified(
 export function generateAuthUpdatePhone(
   emailID: string,
   journeyID: string,
-  userID: string
+  userID: string,
+  eventID: string
 ): AuthUpdateProfilePhoneNumber {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'AUTH_UPDATE_PROFILE_PHONE_NUMBER',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -226,9 +228,10 @@ export function generateAuthUpdatePhone(
   }
 }
 
-export function generateIPVJourneyStart(journeyID: string, userID: string): IPVJourneyStart {
+export function generateIPVJourneyStart(journeyID: string, userID: string, eventID: string): IPVJourneyStart {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_JOURNEY_START',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -251,9 +254,10 @@ export function generateIPVJourneyStart(journeyID: string, userID: string): IPVJ
   }
 }
 
-export function generateIPVSubJourneyStart(journeyID: string, userID: string): IPVSubJourneyStart {
+export function generateIPVSubJourneyStart(journeyID: string, userID: string, eventID: string): IPVSubJourneyStart {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_SUBJOURNEY_START',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -275,9 +279,10 @@ export function generateIPVSubJourneyStart(journeyID: string, userID: string): I
   }
 }
 
-export function generateIPVDLCRIVCIssued(userID: string, journeyID: string): IPVDLCRIVCIssued {
+export function generateIPVDLCRIVCIssued(userID: string, journeyID: string, eventID: string): IPVDLCRIVCIssued {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_DL_CRI_VC_ISSUED',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -346,9 +351,14 @@ export function generateIPVDLCRIVCIssued(userID: string, journeyID: string): IPV
   }
 }
 
-export function generateIPVAddressCRIVCIssued(journeyID: string, userID: string): IPVAddressCRIVCIssued {
+export function generateIPVAddressCRIVCIssued(
+  journeyID: string,
+  userID: string,
+  eventID: string
+): IPVAddressCRIVCIssued {
   return {
     client_id: 'performanceTestClientId',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_ADDRESS_CRI_VC_ISSUED',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -382,9 +392,10 @@ export function generateIPVAddressCRIVCIssued(journeyID: string, userID: string)
   }
 }
 
-export function generateIPVKBVCRIStart(journeyID: string, userID: string): IPVKBVCRIStart {
+export function generateIPVKBVCRIStart(journeyID: string, userID: string, eventID: string): IPVKBVCRIStart {
   return {
     client_id: 'performanceTestClientID',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_KBV_CRI_START',
     event_timestamp_ms: Math.floor(Date.now()),
@@ -404,9 +415,10 @@ export function generateIPVKBVCRIStart(journeyID: string, userID: string): IPVKB
   }
 }
 
-export function generateIPVKBVCRIEnd(journeyID: string, userID: string): IPVKBVCRIEnd {
+export function generateIPVKBVCRIEnd(journeyID: string, userID: string, eventID: string): IPVKBVCRIEnd {
   return {
     client_id: 'performanceTestClientID',
+    event_id: eventID,
     component_id: 'perfTest',
     event_name: 'IPV_KBV_CRI_END',
     event_timestamp_ms: Math.floor(Date.now()),

--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -112,9 +112,11 @@ export function signUpSuccess(): void {
   const eventID = `perfTestID$_${uuidv4()}`
 
   const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, eventID))
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
+  const authCreateAccPayload = JSON.stringify(
+    generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID, eventID)
+  )
   const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID, eventID))
-  const authUpdatePhonePayload = JSON.stringify(generateAuthUpdatePhone(emailID, journeyID, userID))
+  const authUpdatePhonePayload = JSON.stringify(generateAuthUpdatePhone(emailID, journeyID, userID, eventID))
   iterationsStarted.add(1)
 
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
@@ -148,12 +150,13 @@ export function identityProvingSuccess(): void {
   const groups = groupMap.idProveApiCall
   const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
-  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID))
-  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID))
-  const ipvDLCRIVCIssuedPayload = JSON.stringify(generateIPVDLCRIVCIssued(userID, journeyID))
-  const ipvAddressCRIVCIssuedPayload = JSON.stringify(generateIPVAddressCRIVCIssued(journeyID, userID))
-  const ipvKBVCRIStartPayload = JSON.stringify(generateIPVKBVCRIStart(journeyID, userID))
-  const ipvKBVCRIEndPayload = JSON.stringify(generateIPVKBVCRIEnd(journeyID, userID))
+  const eventID = `perfTestID$_${uuidv4()}`
+  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, eventID))
+  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID, eventID))
+  const ipvDLCRIVCIssuedPayload = JSON.stringify(generateIPVDLCRIVCIssued(userID, journeyID, eventID))
+  const ipvAddressCRIVCIssuedPayload = JSON.stringify(generateIPVAddressCRIVCIssued(journeyID, userID, eventID))
+  const ipvKBVCRIStartPayload = JSON.stringify(generateIPVKBVCRIStart(journeyID, userID, eventID))
+  const ipvKBVCRIEndPayload = JSON.stringify(generateIPVKBVCRIEnd(journeyID, userID, eventID))
 
   iterationsStarted.add(1)
 
@@ -194,8 +197,9 @@ export function identityReuseSuccess(): void {
   const groups = groupMap.idReuseApiCall
   const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
-  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID))
-  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID))
+  const eventID = `perfTestID$_${uuidv4()}`
+  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, eventID))
+  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID, eventID))
   iterationsStarted.add(1)
 
   sqs.sendMessage(env.sqs_queue, ipvJourneyStartPayload)

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -107,7 +107,10 @@ export function setup(): string {
   const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
   const journeyID = 'journeyID'
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
+  const eventID = `${testID}_${uuidv4()}`
+  const authCreateAccPayload = JSON.stringify(
+    generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID, eventID)
+  )
   const authReqParsedPayloadEnrichment = JSON.stringify(generateAuthReqParsedEnrichment(journeyID, testID))
 
   console.log('Sending primer event 1')

--- a/deploy/scripts/src/txma/test.ts
+++ b/deploy/scripts/src/txma/test.ts
@@ -67,7 +67,10 @@ export function setup(): string {
   const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
   const journeyID = uuidv4()
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
+  const eventID = `${testID}_${uuidv4()}`
+  const authCreateAccPayload = JSON.stringify(
+    generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID, eventID)
+  )
 
   console.log('Sending primer event 1')
   sqs.sendMessage(env.sqs_queue, authCreateAccPayload)


### PR DESCRIPTION
## QA-563 <!--Jira Ticket Number-->

### What?
Adds in eventIDs to all the TxMA payloads used in the TiCF CRI script

#### Changes:
- Adds event_id into the TxMA payloads in the `txmaReqGen.ts` and `txmaReqFormat.ts` files.
- Adds eventIDs into the `txma/test.ts`, `txma/clientenrichment.ts`, and `fraud/ticf.ts` scripts where they use the above payloads. 

---

### Why?
To ensure we're sending the correct payloads to TiCF CRI. 

