### PR TITLE
[QA-1091]:Adding the I4 peak test load profile for TxMA ESP & Audit-Service

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -6,7 +6,8 @@ import {
   describeProfile,
   createScenario,
   LoadProfile,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -72,6 +73,9 @@ const profiles: ProfileList = {
       ],
       exec: 'sendRegularEventWithEnrichment'
     }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2423, 3, 66)
   }
 }
 


### PR DESCRIPTION
## QA-1091 <!--Jira Ticket Number-->

### What?
This pull request adds the Iteration 4 peak load profile to the `txma/clientEnrichment.ts` performance test script. This profile will be used for Iteration 4 peak testing of the TxMA ESP and Audit-Service.


#### Changes:
Adds the `perf006Iteration4PeakTest` load profile with:
  - Target throughput: 2,423 journeys per second
  - Ramp-up: 66 seconds

---

### Why?
To execute an Iteration 4 peak test for TxMA ESP & Audit-Service
---


