### PR TITLE
[QA-1096]: CIMIT - Correct the load test target

### DIFF
--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -30,7 +30,7 @@ const profiles: ProfileList = {
     ...createScenario('cimitAPIs', LoadProfile.full, 400, 5)
   },
   perf006Iteration4PeakTest: {
-    ...createI4PeakTestSignUpScenario('cimitAPIs', 188, 19, 471)
+    ...createI4PeakTestSignUpScenario('cimitAPIs', 1880, 19, 471)
   }
 }
 


### PR DESCRIPTION
## QA-1096 <!--Jira Ticket Number-->

### What?
CIMIT - Correct the load test target

#### Changes:
- Updated the load test target to 1880 as we are using the `createI4PeakTestSignUpScenario`

---

### Why?
To run a performance test of CIMIT at 188 j/s