### PR TITLE
[QA-1107]: Account(Bravo)-VC Storage-Add Load Profile for I4 SpikeTest

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -135,6 +135,11 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignUpScenario('persistVC', 470, 5, 471),
     ...createI4PeakTestSignUpScenario('updateVC', 470, 7, 471),
     ...createI4PeakTestSignInScenario('summariseVC', 43, 6, 21)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('persistVC', 1130, 5, 1131),
+    ...createI3SpikeSignUpScenario('updateVC', 1130, 7, 1131),
+    ...createI3SpikeSignInScenario('summariseVC', 129, 6, 60)
   }
 }
 


### PR DESCRIPTION
## QA-1107 <!--Jira Ticket Number-->

### What?
This pull request adds the Iteration 4 spike load profile to the `bravo/vc-storage.ts` performance test script for testing the VC Storage service.


#### Changes:
The following load profiles are introduced for the specified capability:

* **PersistVC:**
    * Target throughput: 113 iterations per second
    * Ramp-up time: 1131 seconds
* **UpdateVC:**
    * Target throughput: 113 iterations per second
    * Ramp-up time: 1131 seconds
* **SummariseVC:**
    * Target throughput: 129 iterations per second
    * Ramp-up time: 60 seconds
---

### Why?
This change enables execution of the Iteration 4 spike performance test for the VC Storage service.

