### PR TITLE
[QA-1106]: I4 Spike test Load profiles for LIME cri

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -313,6 +313,12 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignUpScenario('drivingLicence', 59, 9, 60),
     ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 99, 9, 100),
     ...createI4PeakTestSignUpScenario('fraud', 470, 6, 471)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('passport', 113, 6, 114),
+    ...createI3SpikeSignUpScenario('drivingLicence', 141, 9, 142),
+    ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 113, 9, 114),
+    ...createI3SpikeSignUpScenario('fraud', 1130, 6, 1131)
   }
 }
 


### PR DESCRIPTION
## QA-1106 <!--Jira Ticket Number-->

### What?
Adding Iteration 4 Spike Test Load profile for LIME CRI (passport, DL, DL attest and Fraud)

#### Changes:
- Passport : Target 11.3 j/sec  and ramp-up 114sec
- DL : Target 14.1 j/sec and ramp-up 142 sec
- Dl attest : Target 11.3 j/sec  and ramp-up 114 sec
- Fraud: Target 1130 j/sec  and ramp-up 1131 sec

---

### Why?
To Perform PERF006-Iteration 4 testing

---

### Related:

