### PR TITLE
[QA-1118] Adding load profiles to the TiCF Script

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -1,5 +1,10 @@
 import { type Options } from 'k6/options'
-import { selectProfile, type ProfileList, createScenario, LoadProfile } from '../common/utils/config/load-profiles'
+import {
+  selectProfile,
+  type ProfileList,
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignInScenario
+} from '../common/utils/config/load-profiles'
 import { getEnv } from '../common/utils/config/environment-variables'
 import { iterationsStarted, iterationsCompleted } from '../common/utils/custom_metric/counter'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -24,8 +29,22 @@ import { isStatusCode202 } from '../common/utils/checks/assertions'
 import { timeGroup } from '../common/utils/request/timing'
 
 const profiles: ProfileList = {
-  smoke: {
-    ...createScenario('ticf', LoadProfile.smoke)
+  ticfSmoke: {
+    ticf: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 1,
+      maxVUs: 1,
+      stages: [{ target: 1, duration: '5m' }],
+      exec: 'ticf'
+    }
+  },
+  perf006Iteration4PeakTest: {
+    ...createI4PeakTestSignInScenario('ticf', 47, 12, 23)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignInScenario('ticf', 129, 12, 60)
   }
 }
 


### PR DESCRIPTION
## QA-1118 <!--Jira Ticket Number-->

### What?
Adds a longer smoke test, an I4 peak test, and I4 Spike test load profiles to the `ticf` script. 

#### Changes:
- Adds a smoke test with a 5 minute duration for the `ticf` scenario 
- Adds an iteration 4 peak test profile with a target of 47j/s for the `ticf` scenario 
- Adds an iteration 4 spike test profile with a target of 129j/s for the `ticf` scenario 

---

### Why?
So we can run `ticf` performance tests at desired volumes.

