### PR TITLE
[QA-1120]: I4 Spike profile for (Orange CRI ) KBV

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -163,6 +163,10 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
+    ...createI3SpikeSignUpScenario('addressME', 1030, 15, 1031)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -163,10 +163,6 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
-  },
-  perf006Iteration4SpikeTest: {
-    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
-    ...createI3SpikeSignUpScenario('addressME', 1030, 15, 1031)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -92,6 +92,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('kbv', 47, 12, 48)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('kbv', 113, 12, 114)
   }
 }
 


### PR DESCRIPTION
## QA-1120 <!--Jira Ticket Number-->

### What?
Add I4 Spike profiles to Address and Address Manual Entry (ME)

#### Changes:
- KBV - Target Throughput 11.3 j/sec and Ramp up 114 Sec

---

### Why?
Why are these changes being made?

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
