### PR TITLE
[QA-1109] changing the TxMA Event Date Formats for the TiCF Script.

### DIFF
--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -292,7 +292,7 @@ export function generateIPVDLCRIVCIssued(userID: string, journeyID: string, even
           activityHistoryScore: 4,
           checkDetails: [
             {
-              activityFrom: '20200101',
+              activityFrom: '2020-01-01',
               checkMethod: 'vpip',
               identityCheckPolicy: 'policy'
             }
@@ -318,8 +318,8 @@ export function generateIPVDLCRIVCIssued(userID: string, journeyID: string, even
       ],
       drivingPermit: [
         {
-          expiryDate: '20300101',
-          issueDate: '20200101',
+          expiryDate: '2030-01-01',
+          issueDate: '2020-01-01',
           issueNumber: '1234',
           issuedBy: 'DVLA',
           personalNumber: '12345'
@@ -376,8 +376,8 @@ export function generateIPVAddressCRIVCIssued(
           postalCode: 'AB12 3CD',
           streetName: 'HIGH STREET',
           uprn: 123456789012,
-          validFrom: '19900101',
-          validUntil: '20300101'
+          validFrom: '1990-01-01',
+          validUntil: '2030-01-01'
         }
       ]
     },


### PR DESCRIPTION
## QA-1109 <!--Jira Ticket Number-->

### What?
Edits the date formats in the TxMA events used in the `ticf` script

#### Changes:
- changes the date formats from 'xxxxxxxx' to 'xxxx-xx-xx' in the `IPV_ADDRESS_CRI_VC_ISSUED` and `IPV_DL_CRI_VC_ISSUED` payloads.

---

### Why?
To send the correct payloads during a `ticf` performance test.
