### PR TITLE
QA-1106 Fix DL Spike Test profile

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -317,7 +317,7 @@ const profiles: ProfileList = {
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('passport', 113, 6, 114),
     ...createI3SpikeSignUpScenario('drivingLicence', 141, 9, 142),
-    ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 113, 9, 114),
+    ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 237, 9, 238),
     ...createI3SpikeSignUpScenario('fraud', 1130, 6, 1131)
   }
 }


### PR DESCRIPTION
## QA-1106

### What?
Fix DL Spike Test profile

#### Changes:
- Update driving licence attestation test targets and ramp up duration for Iteration 4 spike tests

---

### Why?
To run  Iteration 4 spike tests on driving licence and driving licence attestation

---
