### PR TITLE
QA-1125 : Orange I4 Spike Test profile update for Address & CheckHMRC

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -163,6 +163,10 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
+    ...createI3SpikeSignUpScenario('addressME', 1030, 15, 1031)
   }
 }
 

--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -90,6 +90,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('ninoCheck', 5, 6, 6)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('ninoCheck', 11, 6, 12)
   }
 }
 


### PR DESCRIPTION
## QA-1125

### What?
I4 Spike Test load profile update for Address & CheckHMRC CRIs
#### Changes:
Based on the iteration 4,

- Total Address spike target is 113 iters/sec
   - Address happy path : 10 iters/sec
   - Address Manual entry : 103 iters/sec
-   CheckHMRC : 1.1 iters/sec

---

### Why?
To Perform Iteration 4 spike tests
---
