### PR TITLE
[QA-1128]: SPoT | Add Load Profile for I4 SpikeTest

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -52,6 +52,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignInScenario('spot', 90, 3, 21)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignInScenario('spot', 242, 3, 111)
   }
 }
 


### PR DESCRIPTION
## QA-1128 <!--Jira Ticket Number-->

### What?
This pull request adds the Iteration 4 spike load profile to the spot/test.ts performance test script.

#### Changes:
The following load profiles is introduced for SPoT

  - Target throughput: 242 iterations per second
  - Ramp-up time: 111 seconds

---

### Why?
This change enables execution of the Iteration 4 spike performance test for SPoT.

