### PR TITLE
[QA-1132]: IPV Core - Add Load Profile for I4 Soak and Stress Test

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -280,8 +280,8 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 5,
-      maxVUs: 11,
+      preAllocatedVUs: 54,
+      maxVUs: 108,
       stages: [
         { target: 30, duration: '31s' },
         { target: 30, duration: '6h' }

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -280,11 +280,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 1,
       timeUnit: '10s',
-      preAllocatedVUs: 54,
-      maxVUs: 108,
+      preAllocatedVUs: 36,
+      maxVUs: 72,
       stages: [
-        { target: 30, duration: '31s' },
-        { target: 30, duration: '6h' }
+        { target: 20, duration: '31s' },
+        { target: 20, duration: '6h' }
       ],
       exec: 'identity'
     },
@@ -292,11 +292,11 @@ const profiles: ProfileList = {
       executor: 'ramping-arrival-rate',
       startRate: 2,
       timeUnit: '1s',
-      preAllocatedVUs: 12,
-      maxVUs: 24,
+      preAllocatedVUs: 6,
+      maxVUs: 12,
       stages: [
-        { target: 4, duration: '3s' },
-        { target: 4, duration: '6h' }
+        { target: 2, duration: '3s' },
+        { target: 2, duration: '6h' }
       ],
       exec: 'idReuse'
     }

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -274,6 +274,78 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 470, 36, 471),
     ...createI4PeakTestSignInScenario('idReuse', 43, 6, 21)
+  },
+  perf006Iteration4SoakTest: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 5,
+      maxVUs: 11,
+      stages: [
+        { target: 30, duration: '31s' },
+        { target: 30, duration: '6h' }
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 12,
+      maxVUs: 24,
+      stages: [
+        { target: 4, duration: '3s' },
+        { target: 4, duration: '6h' }
+      ],
+      exec: 'idReuse'
+    }
+  },
+  perf006Iteration4StressTest: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 1728,
+      maxVUs: 3456,
+      stages: [
+        { target: 160, duration: '161s' },
+        { target: 160, duration: '300s' },
+        { target: 320, duration: '161s' },
+        { target: 320, duration: '300s' },
+        { target: 480, duration: '161s' },
+        { target: 480, duration: '300s' },
+        { target: 640, duration: '161s' },
+        { target: 640, duration: '300s' },
+        { target: 800, duration: '161s' },
+        { target: 800, duration: '300s' },
+        { target: 960, duration: '161s' },
+        { target: 960, duration: '300s' }
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 432,
+      maxVUs: 864,
+      stages: [
+        { target: 24, duration: '13s' },
+        { target: 24, duration: '448s' },
+        { target: 48, duration: '13s' },
+        { target: 48, duration: '448s' },
+        { target: 72, duration: '13s' },
+        { target: 72, duration: '448s' },
+        { target: 96, duration: '13s' },
+        { target: 96, duration: '448s' },
+        { target: 120, duration: '13s' },
+        { target: 120, duration: '448s' },
+        { target: 144, duration: '13s' },
+        { target: 144, duration: '448s' }
+      ],
+      exec: 'idReuse'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1132 <!--Jira Ticket Number-->

### What?
This pull request adds soak and stress test load profiles for the IPV Core (`identity` and `id-reuse` scenarios).


#### Changes:
* **Added two load profiles:**  `perf006Iteration4SoakTest` and `perf006Iteration4StressTest` in `ipv-core\test.ts` script.  Each profile defines configurations for both `identity` and `id-reuse` scenarios.

* **Soak Test Profile (`perf006Iteration4SoakTest`):**
    * **`identity`:**
        * Start Rate: 1
        * Time Unit: 10s
        * Pre-allocated VUs: 54
        * Max VUs: 108
        * Stages: Ramp up to 3 VUs over 31 seconds, then hold at 3 VUs for 6 hours.
    * **`idReuse`:**
        * Start Rate: 2
        * Time Unit: 1s
        * Pre-allocated VUs: 12
        * Max VUs: 24
        * Stages: Ramp up to 4 VUs over 3 seconds, then hold at 4 VUs for 6 hours.
     
* **Stress Test Profile (`perf006Iteration4StressTest`):**
    * **`identity`:**
        * Start Rate: 1
        * Time Unit: 10s
        * Pre-allocated VUs: 1728
        * Max VUs: 3456
        * Stages:  A series of ramp-up and hold stages, increasing the target VUs from 160 to 960 in increments of 160, with each stage lasting 161 seconds for ramp-up and 300 seconds for the hold period.
    * **`idReuse`:**
        * Start Rate: 2
        * Time Unit: 1s
        * Pre-allocated VUs: 432
        * Max VUs: 864
        * Stages: A series of ramp-up and hold stages, increasing the target VUs from 24 to 144 in increments of 24, with each stage lasting 13 seconds for ramp-up and 448 seconds for the hold period.
           

---

### Why?
These changes enable soak and stress testing of the IPV Core service to assess its performance and stability under sustained and high-intensity loads. 

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
