### PR TITLE
QA-1139 : OLH - Add Iteration 4 Spike Test Load Profile

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -367,7 +367,7 @@ const profiles: ProfileList = {
     ...createI3SpikeOLHScenario('changePassword', 8, 21, 1),
     ...createI3SpikeOLHScenario('changePhone', 8, 24, 1),
     ...createI3SpikeOLHScenario('deleteAccount', 8, 18, 1),
-    ...createI3SpikeSignInScenario('landingPage', 12, 6, 7) // rounded the to 12 from 12.4
+    ...createI3SpikeSignInScenario('landingPage', 12, 6, 7) // rounded the target to 12 from 12.4
   }
 }
 


### PR DESCRIPTION
## QA-1139

### What?
Pull request to add OLH Perf006 Iteration 4 spike load test profile to the script deploy/scripts/src/olh/test.ts

---
#### Changes:
Added `perf006Iteration4SpikeTest` profile with below spike target
Landing Page : `12 iters/secs `(Rounded from 12.4 to 12)
All other scenarios : `8 iters/minute`

---

### Why?
To conduct Spike test as part of Perf006 Iteration 4 tersts

---

