### PR TITLE
[QA-1146]: Add Regression Test Profiles for IPV Core

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -346,7 +346,33 @@ const profiles: ProfileList = {
       ],
       exec: 'idReuse'
     }
-  }
+  },
+  perf006I4RegressionTest: {
+    identity: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 9,
+      maxVUs: 18,
+      stages: [
+        { target: 5, duration: '6s' },
+        { target: 5, duration: '5m' }
+      ],
+      exec: 'identity'
+    },
+    idReuse: {
+      executor: 'ramping-arrival-rate',
+      startRate: 6,
+      timeUnit: '1m',
+      preAllocatedVUs: 1,
+      maxVUs: 1,
+      stages: [
+        { target: 6, duration: '1s' },
+        { target: 6, duration: '5m' }
+      ],
+      exec: 'idReuse'
+    }
+  },
 }
 
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1146 <!--Jira Ticket Number-->

### What?
This pull request adds regression test load profiles for the IPV Core service, covering both `identity` and `id-reuse` scenarios, based on April-25's actual traffic volumes.


#### Changes:
* Added the `perf006I4RegressionTest` load profile to the `ipv-core/test.ts` script. This profile includes configurations for both `identity` and `id-reuse` scenarios.

* **Regression Test Profile (`perf006I4RegressionTest`):**

    * **`identity`:**
        * Start Rate: 1
        * timeUnit: '10s',
        * Pre-allocated VUs: 9
        * Max VUs: 18
        * Stages: Ramp up to 0.5 iterations per second over 6 seconds, then hold at 0.5 iterations per second for 5 minutes.

    * **`idReuse`:**
        * Start Rate: 6
        *  timeUnit: '1m',
        * Pre-allocated VUs: 1
        * Max VUs: 1
        * Stages: Ramp up to 0.1 iterations per second over 1 second, then hold at 0.1 iterations per second for 5 minutes.

---

### Why?

These changes enable the execution of regression tests using load profile that reflect the actual traffic volumes observed in April-25.
---
