### PR TITLE
[QA-1148]: IPV-Core - Script Update - page content check

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -544,7 +544,7 @@ export function identity(stubOnly: boolean = false): void {
     // 02_CoreCall
     res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('Do you live in the UK, the Channel Islands or the Isle of Man') // Do you live in the UK, the Channel Islands or the Isle of Man
+      ...pageContentCheck('Where do you live?') // Do you live in the UK, the Channel Islands or the Isle of Man
     })
   })
   if (stubOnly) {

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -544,7 +544,7 @@ export function identity(stubOnly: boolean = false): void {
     // 02_CoreCall
     res = timeGroup(groups[3].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('Where do you live?') // Do you live in the UK, the Channel Islands or the Isle of Man
+      ...pageContentCheck('Where do you live?')
     })
   })
   if (stubOnly) {


### PR DESCRIPTION
## QA-1148 <!--Jira Ticket Number-->

### What?
This pull request fixes a script at the `B01_Identity_02_GoToFullJourneyRoute` scenario, specifically the `02_CoreCall` step. The issue was caused by a change in the page content, which broke the existing page content check.

### Changes:

Updated the `pageContentCheck` in the `02_CoreCall` of the `B01_Identity_02_GoToFullJourneyRoute` step.  The expected text has been changed from "Do you live in the UK, the Channel Islands or the Isle of Man?" to "Where do you live?"

### Why?
To fix the script execution and execute the Regression test.
---
