### PR TITLE
[QA-1153]: Add spike test profile for TxMA client enrichment scenario

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -76,6 +76,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2423, 3, 66)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 6261, 5, 169)
   }
 }
 

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -78,7 +78,7 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2423, 3, 66)
   },
   perf006Iteration4SpikeTest: {
-    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 6261, 5, 169)
+    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 6261, 3, 169)
   }
 }
 


### PR DESCRIPTION
## QA-1153 <!--Jira Ticket Number-->

### What?
Add spike test profile for TxMA client enrichment scenario

#### Changes:
- Add spike test profile for TxMA client enrichment scenario (Target 6261 events/s, Ramp up - 169 s & Estimated maximum iteration duration - 3s)

---

### Why?
To run iteration 4 spike test for TxMA