### PR TITLE
QA-1154 - Add I4 spike test profile to BAV script

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -65,7 +65,7 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignUpScenario('BAV', 5, 24, 6)
   },
   perf006Iteration4SpikeTest: {
-    ...createI3SpikeSignUpScenario('BAV', 11, 21, 12)
+    ...createI3SpikeSignUpScenario('BAV', 11, 24, 12)
   }
 }
 

--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -63,6 +63,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('BAV', 5, 24, 6)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('BAV', 11, 21, 12)
   }
 }
 


### PR DESCRIPTION
## QA-1154

### What?
To add Iteration 4 spike test profile to BAV Script

---

#### Changes:
Add Iteration 4 spike test profile to BAV Script

-  1% of Sign Up & ID Proving
-  I4 spike target 113 t/s
-  BAV target 1.1 iters/sec

---

### Why?
To Perform I4 BAV spike test

---

