### PR TITLE
[QA-1155]: Increase the MaxSessionDuration of PerformanceTesterRole

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -178,6 +178,7 @@ Resources:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-admin_*" # Prod Admin Control Tower Role
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_AWSPowerUserAccess_*" # Prod Power User Control Tower Role
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_di-perf-test-prod-testers_*" # Prod Tester Control Tower Role
+      MaxSessionDuration: 5400
       PermissionsBoundary:
         !If [
           UsePermissionsBoundary,


### PR DESCRIPTION
## QA-1155 <!--Jira Ticket Number-->

### What?
Increases the `MaxSessionDuration` of `PerformanceTesterRole`

#### Changes:
- Increases the `MaxSessionDuration` of `PerformanceTesterRole` to 5400 seconds (default 3600 seconds)

---

### Why?
The maximum session duration of the PerformanceTester role is 3600 seconds. This results in HTTP-403 errors (due to token expiry) after 1 hour for tests where this role is assumed and of those tests are longer than 1 hour. This PR is to increase the Maximum Session Duration to 5400 seconds.