### PR TITLE
[QA-1156]: Update assume role session duration to 5400 seconds

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -570,7 +570,7 @@ Resources:
                 - |
                   sed -e "s#{URL}#$DYNATRACE_URL#" -e "s#{APITOKEN}#$DYNATRACE_APITOKEN#" -e "s#{ID}#$CODEBUILD_BUILD_NUMBER#" $OTEL_TEMPLATE > $OTEL_CONFIG
                 - /otel/otelcol-contrib  --config=$OTEL_CONFIG > $OTEL_LOG 2>&1 &
-                - export EXECUTION_CREDENTIALS=$(aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER)
+                - export EXECUTION_CREDENTIALS=$(aws sts assume-role --role-arn $EXECUTION_ROLE --role-session-name $CODEBUILD_BUILD_NUMBER --duration-seconds 5400)
                 - source ${REPORTING_DIR}/slack.sh POST
             build:
               commands:


### PR DESCRIPTION
## QA-1156 <!--Jira Ticket Number-->

### What?
Update assume role session duration to 5400 seconds

#### Changes:
- Update assume role session duration to 5400 seconds in the Codebuild `pre_build` command

---

### Why?
The maximum duration of the STS assume role is 3600 seconds. This results in HTTP-403 errors (due to token expiry) after 1 hour for tests where this role is assumed and of those tests are longer than 1 hour. This PR is to increase the duration of session token to 5400 seconds.