### PR TITLE
QA-1157 Update F2F CIC with I4 spike prof

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -93,6 +93,10 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('FaceToFace', 12, 42, 13),
     ...createI4PeakTestSignUpScenario('CIC', 12, 21, 13)
+  },
+  perf006Iteration4SpikeTest: {
+    ...createI3SpikeSignUpScenario('FaceToFace', 28, 42, 29),
+    ...createI3SpikeSignUpScenario('CIC', 28, 21, 29)
   }
 }
 


### PR DESCRIPTION
## QA-1157

### What?
Update F2F and CIC script with I4 Spike test profiles

#### Changes:
- Update F2F and CIC script with I4 Spike test profiles

---

### Why?
To enable Iteration 4 spike tests

---

