### PR TITLE
[QA-1160] Profile change for  Mobile wallet Credential Issuance for BE and STS 

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -71,7 +71,7 @@ const profiles: ProfileList = {
       maxVUs: 1428,
       stages: [
         { target: 38, duration: '18s' },
-        { target: 38, duration: '60m' }
+        { target: 38, duration: '55m' }
       ],
       exec: 'walletCredentialIssuance'
     }

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -50,7 +50,7 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('getClientAttestation', 450, 12, 451)
   },
-  walletPerfTestSTS: {
+  walletPerfTestBackend: {
     getClientAttestation: {
       executor: 'ramping-arrival-rate',
       startRate: 2,

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -67,7 +67,7 @@ const profiles: ProfileList = {
       maxVUs: 1428,
       stages: [
         { target: 38, duration: '18s' },
-        { target: 38, duration: '60m' }
+        { target: 38, duration: '55m' }
       ],
       exec: 'walletCredentialIssuance'
     }


### PR DESCRIPTION
## QA-1160 <!--Jira Ticket Number-->

### What?
Profile change for  Mobile wallet Credential Issuance for BE and STS 

#### Changes:
- Mobile Wallet Backend Credential Issuance
   Ramp up 18 sec and Steady state duration is 55 min
- Mobile Wallet STS Credential Issuance
   Ramp up 18 sec and Steady state duration is 55 min
---

### Why?
To perform Peak testing for Wallet

---

### Related:

