### PR TITLE
[QA-1162]: IPVCore-Identity - Fix redirect handling (redirects: 0)

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -596,7 +596,7 @@ export function identity(stubOnly: boolean = false): void {
             requested_oauth_error_endpoint: 'auth',
             requested_oauth_error: 'access_denied'
           },
-          params: { redirects: 1 }
+          params: { redirects: 0 }
         }),
       { isStatusCode302 }
     )


### PR DESCRIPTION
## QA-1162 <!--Jira Ticket Number-->

### What?
This pull request corrects the handling of redirects in the IPV-Core(Identity) test script at `// B01_Identity_05_DCMAWContinue ::01_DCMAWStub` call.

#### Changes:
- Set `redirects: 0` in the `submitForm` function within the `01_DCMAWStub` group.

---

### Why?
- The previous setting (`redirects: 1`) caused the `submitForm` function to follow the redirect and include the time for both the initial request and the redirected request in the `01_DCMAWStub` measurement. This resulted in inflated and inaccurate response times.
---

