### PR TITLE
[QA-1162]:Correct redirect URL in 02_CoreCall

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -601,7 +601,8 @@ export function identity(stubOnly: boolean = false): void {
       { isStatusCode302 }
     )
     // 02_CoreCall
-    res = timeGroup(groups[10].split('::')[1], () => http.get(env.ipvCoreURL + res.headers.Location), {
+
+    res = timeGroup(groups[10].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
       ...pageContentCheck('Enter your UK passport details')
     })


### PR DESCRIPTION
## QA-1162 <!--Jira Ticket Number-->

### What?
- This pull request corrects the URL used for the redirect in the `02_CoreCall` step of IPVCore identity scenario test script.


#### Changes:
- Removed `env.ipvCoreURL` from the `http.get` call in `02_CoreCall` and used `res.headers.Location` directly.


---

### Why?
- The previous code was prepending `env.ipvCoreURL` to the redirect URL obtained from `res.headers.Location`, resulting in a duplicated URL and causing the redirect to fail.  This change uses the complete redirect URL directly from the `Location` header, resolving the URL duplication issue.

---

