### PR TITLE
QA-1173 : Add I5 Peak test profile to Auth-Orch Script

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -271,6 +271,10 @@ const profiles: ProfileList = {
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('signUp', 1130, 33, 1131),
     ...createI3SpikeSignInScenario('signIn', 129, 18, 60)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('signUp', 570, 33, 571),
+    ...createI4PeakTestSignInScenario('signIn', 65, 18, 31)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1173

### What?
This PR is to add I5 peak test load profile to Auth-Orch script

#### Changes:
A new profile - `perf006Iteration5PeakTest` - has been created for the SignUp & SignIn scenarios, below are the targeted throughput.
- Sign Up & ID Verification - 57 journeys per second
- Sign In & ID resue - 65 journeys per second

---

### Why?
To conduct Iteration 5 Peak tests

---
