### PR TITLE
[1175]: SPOT-Add load profile for I5 peak test

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -55,6 +55,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignInScenario('spot', 242, 3, 111)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignInScenario('spot', 122, 3, 30)
   }
 }
 


### PR DESCRIPTION
## QA-1175 <!--Jira Ticket Number-->

### What?
This pull request adds the Iteration 5 Peak test load profile to the `spot/test.ts` performance test script.

#### Changes:
- A new profile, `perf006Iteration5PeakTest`, has been created for SPoT with the following target throughput:

 - Target throughput: 122 iterations per second
 - Ramp-up time: 30 seconds

---

### Why?
- This change enables execution of the Iteration 5 Peak test for SPoT 

---

