### PR TITLE
[QA-1177]: EVCS combined updateVC and Summarise VC - I5 peak profile

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -140,6 +140,10 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('persistVC', 1130, 5, 1131),
     ...createI3SpikeSignUpScenario('updateVC', 1130, 7, 1131),
     ...createI3SpikeSignInScenario('summariseVC', 129, 6, 60)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('updateVC', 570, 7, 571),
+    ...createI4PeakTestSignInScenario('summariseVC', 65, 6, 30)
   }
 }
 


### PR DESCRIPTION
## QA-1177 <!--Jira Ticket Number-->

### What?
Add EVCS combined updateVC and Summarise VC - I5 peak profile

#### Changes:
- update VC : Target Throughput - 57 iter/sec and ramp up is 571 sec
- summarise VC : Target Throughput - 65 iter/sec and ramp up is 30 sec
    

---

### Why?
to Perform I5 tests

---

### Related:
