### PR TITLE
QA-1176 : Add Iteration 5 Peak test profile for OLH

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -463,7 +463,7 @@ export function createOLHPeakTestScenario(
   const maxVUs = target * iterationDuration
   list[exec] = {
     executor: 'ramping-arrival-rate',
-    startRate: 12,
+    startRate: 4,
     timeUnit: '1m',
     preAllocatedVUs,
     maxVUs,

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -12,7 +12,8 @@ import {
   LoadProfile,
   createI3SpikeOLHScenario,
   createI3SpikeSignInScenario,
-  createOLHPeakTestScenario
+  createOLHPeakTestScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { SharedArray } from 'k6/data'
 import { timeGroup } from '../common/utils/request/timing'
@@ -375,7 +376,7 @@ const profiles: ProfileList = {
     ...createOLHPeakTestScenario('changePassword', 4, 21, 1),
     ...createOLHPeakTestScenario('changePhone', 4, 24, 1),
     ...createOLHPeakTestScenario('deleteAccount', 4, 18, 1),
-    ...createOLHPeakTestScenario('landingPage', 374, 9, 3)
+    ...createI4PeakTestSignInScenario('landingPage', 6, 9, 4)
   }
 }
 


### PR DESCRIPTION
## QA-1176

### What?
This pull request is to add the Iteration 5 peak test profile into OLH script

---

#### Changes:
Added `perf006Iteration5PeakTest` profile with below volume
Change Password : 4 iters/min
Change Email: 4 iters/min
Change Phone: 4 iters/min
Delete Account: 4 iters/min
Landing Page: 374 iters/min

---

### Why?
To conduct Iteration 5 OLH peak test

---

