### PR TITLE
QA-1182 AIS update I5 Spike test load

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -75,6 +75,10 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignInScenario('persistIV', 30, 3, 15),
     ...createI4PeakTestSignInScenario('retrieveIV', 129, 3, 21)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignInScenario('persistIV', 30, 3, 15),
+    ...createI3SpikeSignInScenario('retrieveIV', 486, 3, 74)
   }
 }
 


### PR DESCRIPTION
## QA-1182

### What?
Update AIS script to add Iteration 5 spike test load profiles

#### Changes:
- Add Iteration 5 spike test load profiles
---

### Why?
To run spike tests at Iteration 5 targets
---
