### PR TITLE
[QA-1184]: add CIMIT I5 peak test profile

### DIFF
--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -35,6 +35,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('cimitAPIs', 4520, 19, 1131)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('cimitAPIs', 2280, 19, 571)
   }
 }
 


### PR DESCRIPTION
## QA-1184 <!--Jira Ticket Number-->

### What?
add CIMIT I5 peak test profile

#### Changes:
- CIMIT target throughput : 228 iterations/sec and Rampup is 571 sec


---

### Why?
To perform PERF006 Iteration 5

---

### Related:

