### PR TITLE
QA-1185: Add Perf006 Iteration 5 Peak profile to IPVCore Script

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -375,7 +375,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 570, 36, 571),
-    ...createI4PeakTestSignInScenario('idReuse', 65, 6, 31)
+    ...createI4PeakTestSignInScenario('idReuse', 65, 6, 30)
   }
 }
 


### PR DESCRIPTION
## QA-1185

### What?
To add Iteration 5 peak load profile to IPVCore script

---

#### Changes:

- Added `perf006Iteration5PeakTest` profile for scenarios
  - Identity : 57 iters/sec, rampup - 571 secs
  - idReuse: 65 iters/sec, rampup - 31 secs

---

### Why?
To conduct I5 peak test Run1

---
