### PR TITLE
QA-1174: Add Perf006 Iteration 5 Peak profiles for Lime(passport, DL, DLA & Fraud)

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -319,6 +319,12 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('drivingLicence', 141, 9, 142),
     ...createI3SpikeSignUpScenario('drivingLicenceAttestation', 237, 9, 238),
     ...createI3SpikeSignUpScenario('fraud', 1130, 6, 1131)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('passport', 57, 6, 58),
+    ...createI4PeakTestSignUpScenario('drivingLicence', 70, 9, 71),
+    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 120, 9, 121),
+    ...createI4PeakTestSignUpScenario('fraud', 570, 6, 571)
   }
 }
 


### PR DESCRIPTION
## QA-1174

---

### What?
This PR is to add iteration 5 peak test load profiles to Lime CRIs

---

#### Changes:

- Added perf006Iteration5PeakTest for the following scenarios
  - Passport: 5.7 iters/sec, rampup - 58secs
  - Driving Licence: 7 iters/sec, rampup - 71 secs
  - Driving Licence Attestation: 12 iters/sec, rampup - 121 secs
  - Fraud : 57 iters/sec, rampup - 571 secs

---

### Why?
To conduct Passport CRI test

