### PR TITLE
[QA-1192]: Mobile-STS: Update profiles for combined test

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -61,7 +61,7 @@ const profiles: ProfileList = {
       maxVUs: 480,
       stages: [
         { target: 16, duration: '8s' },
-        { target: 16, duration: '60m' }
+        { target: 16, duration: '55m' }
       ],
       exec: 'authentication'
     },
@@ -76,6 +76,18 @@ const profiles: ProfileList = {
         { target: 38, duration: '55m' }
       ],
       exec: 'walletCredentialIssuance'
+    },
+    reauthentication: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 156,
+      maxVUs: 312,
+      stages: [
+        { target: 8, duration: '5s' },
+        { target: 8, duration: '55m' }
+      ],
+      exec: 'reauthentication'
     }
   },
   dataCreationForReAuthentication: {


### PR DESCRIPTION
## QA-1192 <!--Jira Ticket Number-->

### What?
This pull request updates the `walletPerfTestSTS` profile to include the reauthentication scenario, enabling a combined performance test.

#### Changes:
- The `walletPerfTestSTS` profile in the k6 script (/mobile/sts.ts) has been modified to include the `reauthentication` scenario alongside the existing `authentication` and `walletCredentialIssuance` scenarios.  This allows for a combined test running all three scenarios concurrently.
---

### Why?
- This change enables running a combined performance test that includes STS authentication (16 tps), STS reauthentication (8 tps), and Wallet Credential Issuance (38 tps) concurrently. The combined test allows us to evaluate the performance of these interconnected services under a representative load profile.

---

