### PR TITLE
SPT-1518: Update CODEOWNERS to reflect SPOT team name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,5 @@
 /deploy/scripts/src/fraud @govuk-one-login/performance-testers @govuk-one-login/fraud-ssf-team
 /deploy/scripts/src/ipv-core @govuk-one-login/performance-testers @govuk-one-login/core-team
 /deploy/scripts/src/mobile @govuk-one-login/performance-testers @govuk-one-login/mobile-id-check-backend
-/deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/spot-team
+/deploy/scripts/src/spot @govuk-one-login/performance-testers @govuk-one-login/trust-and-reuse-team
 /deploy/scripts/src/txma @govuk-one-login/performance-testers @govuk-one-login/txma-team


### PR DESCRIPTION
## SPT-1518 <!--Jira Ticket Number-->

### What?

Replace references to `spot-team` with `trust-and-reuse-team` in `CODEOWNERS`.

#### Changes:
- Replace references to `spot-team` with `trust-and-reuse-team` in `CODEOWNERS`.

---

### Why?

The SPOT team have rebranded as Trust and Reuse and have new Github teams, the old teams are going to be removed.

