### PR TITLE
QA-1195 Check HMRC Add I5 Peak prof

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -93,6 +93,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('ninoCheck', 11, 6, 12)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('ninoCheck', 6, 6, 7)
   }
 }
 


### PR DESCRIPTION
## QA-1195

### What?
Add Iteration 5 peak test load profile to Check HMRC script

#### Changes:
- Use createI4PeakTestSignUpScenario to add Iteration 5 load profiles

---

### Why?
Run performance tests against Iteration 5 targets
---

