### PR TITLE
QA-1196 - PR to add Iteration 5 Peak profile to KIWI BAV script

### DIFF
--- a/deploy/scripts/src/cri-kiwi/BAV.ts
+++ b/deploy/scripts/src/cri-kiwi/BAV.ts
@@ -66,6 +66,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('BAV', 11, 24, 12)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('BAV', 6, 24, 7)
   }
 }
 


### PR DESCRIPTION
## QA-1196

### What?
This PR is to add iteration 5 peak profile to Kiwi BAV script

#### Changes:
- Added `perf006Iteration5PeakTest` load profile
  - Target Throughput : 0.6 iters/sec
  - Rampup - 7 secs

---

### Why?
To conduct Iteration 5 BAV peak test

---

