### PR TITLE
[QA-1197] Corrected the the Address I5 profile

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -168,7 +168,7 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('address', 100, 15, 101),
     ...createI3SpikeSignUpScenario('addressME', 1030, 15, 1031)
   },
-  perf006Iteration5SpikeTest: {
+  perf006Iteration5PeakTest: {
     ...createI3SpikeSignUpScenario('address', 100, 15, 101),
     ...createI3SpikeSignUpScenario('addressME', 465, 15, 466),
     ...createI3SpikeSignUpScenario('internationalAddress', 6, 12, 7)

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -169,9 +169,9 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('addressME', 1030, 15, 1031)
   },
   perf006Iteration5PeakTest: {
-    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
-    ...createI3SpikeSignUpScenario('addressME', 465, 15, 466),
-    ...createI3SpikeSignUpScenario('internationalAddress', 6, 12, 7)
+    ...createI4PeakTestSignUpScenario('address', 100, 15, 101),
+    ...createI4PeakTestSignUpScenario('addressME', 465, 15, 466),
+    ...createI4PeakTestSignUpScenario('internationalAddress', 6, 12, 7)
   }
 }
 


### PR DESCRIPTION
## QA-1197 <!--Jira Ticket Number-->

### What?
Corrected the Address I5 Profile

#### Changes:
-  addressHappy path target is 10 j/s, rampup is  101 sec
-  addressME target is 46.5j/s,    rampup is 466 sec
-  internationalAddress target is 6j/s ,   rampup is  7 sec)

---

### Why?
To Perform I5 peak Test


