### PR TITLE
QA-1200 : Add Perf006 I5 PeakTestProfile to DCMAW -Mobile (FE+BE) script

### DIFF
--- a/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
+++ b/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
@@ -84,6 +84,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('mamIphonePassport', 450, 48, 451)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('mamIphonePassport', 540, 48, 541)
   }
 }
 


### PR DESCRIPTION
## QA-1200

### What?
This PR is to add I5 peak test profile to DCMAW - Mobile (FE+BE) script

#### Changes:
Added `perf006Iteration5PeakTest` profile with throughput 54 iters/sec and rampup 541 secs

---

### Why?
To conduct I5 peak test

---

