### PR TITLE
[QA-1201] Adding TiCF CRI I5 load profiles

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -45,6 +45,12 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignInScenario('ticf', 129, 66, 60)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignInScenario('ticf', 65, 66, 31)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignInScenario('ticf', 162, 66, 75)
   }
 }
 


### PR DESCRIPTION
## QA-1201 <!--Jira Ticket Number-->

### What?
Adds the iteration 5 peak and spike load profiles to the TiCF CRI script

#### Changes:
- Adds the `perf006Iteration5PeakTest` and `perf006Iteration5SpikeTest` load profiles to the `fraud/ticf.js` script.

---

### Why?
To run iteration 5 tests for TiCF CRI

