### PR TITLE
QA-1203: Add Perf006 I5 PeakTestProfile to KIWI CIC & F2F scripts

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -97,6 +97,10 @@ const profiles: ProfileList = {
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignUpScenario('FaceToFace', 28, 42, 29),
     ...createI3SpikeSignUpScenario('CIC', 28, 21, 29)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('FaceToFace', 14, 42, 15),
+    ...createI4PeakTestSignUpScenario('CIC', 14, 21, 15)
   }
 }
 


### PR DESCRIPTION
## QA-1203

### What?
This PR is to add I5 peak test profile to KIWI CIC & F2F cri scripts

---

#### Changes:
- Added `perf006Iteration5PeakTest` profile to both CIC & F2F scripts, with throughput 1.4 iters/sec and rampup 15 secs

---

### Why?
To perform Iteration 5 peak tests

---
