### PR TITLE
[QA-1205]: Mobile:IdCheckAsync: Add profile for I5 Peak test

### DIFF
--- a/deploy/scripts/src/mobile-id-check-async/test.ts
+++ b/deploy/scripts/src/mobile-id-check-async/test.ts
@@ -37,6 +37,10 @@ const profiles: ProfileList = {
   perf006Iteration4CombinedPeakTest: {
     ...createI4PeakTestSignUpScenario('idCheckAsyncSignUp', 450, 27, 451),
     ...createI4PeakTestSignInScenario('idCheckAsyncSignIn', 43, 3, 21)
+  },
+  perf006Iteration5CombinedPeakTest: {
+    ...createI4PeakTestSignUpScenario('idCheckAsyncSignUp', 540, 30, 541),
+    ...createI4PeakTestSignInScenario('idCheckAsyncSignIn', 65, 3, 30)
   }
 }
 


### PR DESCRIPTION
## QA-1205 <!--Jira Ticket Number-->

### What?
- This pull request adds a new load profile, `perf006Iteration5CombinedPeakTest`, to the `test.ts` performance script, to  execute the I5 combined peak test for both the `idCheckAsyncSignUp` and `idCheckAsyncSignIn` scenarios.

#### Changes:
- Added `perf006Iteration5CombinedPeakTest` to the `profiles`.
- Configured `perf006Iteration5CombinedPeakTest` with :
    - `idCheckAsyncSignUp`: Target throughput = 54 TPS and ramp-up = 541s .
    - `idCheckAsyncSignIn` :Target throughput = 65 TPS and ramp-up = 30s .


### Why?
- To execute the iteration 5 combined peak test for Mobile-idCheckAsync.

