### PR TITLE
[QA-1210] Adding TxMA I5 load profiles

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -79,6 +79,12 @@ const profiles: ProfileList = {
   },
   perf006Iteration4SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 6261, 3, 169)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 3309, 3, 89)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 7753, 3, 208)
   }
 }
 


### PR DESCRIPTION
## QA-1210 <!--Jira Ticket Number-->

### What?
Adds the I5 peak and spike load profiles to the TxMA client enrichment script.

#### Changes:
- Adds `perf006Iteration5PeakTest` and `perf006Iteration5SpikeTest` load profiles to the `txma/clientEnrichment.ts` script.

---

### Why?
To run Iteration 5 tests for TxMA ESP & audit-service
