### PR TITLE
[QA-1209]: MobileBE: Add profile for I5 Peak test

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -75,6 +75,9 @@ const profiles: ProfileList = {
       ],
       exec: 'walletCredentialIssuance'
     }
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541)
   }
 }
 


### PR DESCRIPTION
## QA-1209 <!--Jira Ticket Number-->

### What?
This pull request adds a new load profile, `perf006Iteration5PeakTest`, to the` mobile-backend.ts` performance script, to execute the I5 peak test for Mobile BE.

#### Changes:
- Added perf006Iteration5PeakTest to the profiles with a Target throughput of 54 TPS and ramp-up of 541s for getClientAttestation scenario

---

### Why?
- To execute the iteration 5 peak test for Mobile-backend.

