### PR TITLE
QA-1212 I5 peak test profile for IPVR

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -99,6 +99,10 @@ const profiles: ProfileList = {
   perf006Iteration4PeakTest: {
     ...createI4PeakTestSignUpScenario('allEvents', 12, 20, 13),
     ...createI4PeakTestSignInScenario('authEvent', 43, 5, 21)
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('allEvents', 14, 20, 15),
+    ...createI4PeakTestSignInScenario('authEvent', 65, 5, 30)
   }
 }
 


### PR DESCRIPTION
## QA-1212 <!--Jira Ticket Number-->

### What?
I5 peak test profile for IPVR ( allEvents and authEvent)

#### Changes:
- allEvents: Target throughput - 1.4 j/sec and rampup: 15 sec
- authevent: Target throughput - 65 j/sec and rampup: 30 sec

---

### Why?
To Perform PERF006 Iteration 5 testing

---

### Related:

