### PR TITLE
[QA-1214] Adding the I5 peak load profile to Mobile STS.

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -112,6 +112,9 @@ const profiles: ProfileList = {
       ],
       exec: 'reauthentication'
     }
+  },
+  perf006Iteration5PeakTest: {
+    ...createI4PeakTestSignUpScenario('authentication', 540, 30, 541)
   }
 }
 


### PR DESCRIPTION
## QA-1214 <!--Jira Ticket Number-->

### What?
Adds the I5 peak load profile to the Mobile STS script for the `authentication` scenario.

#### Changes:
- Adds the `perf006Iteration5PeakTest` profile for the `authentication` scenario in the mobile STS script.

---

### Why?
To run an I5 peak test for mobile STS

