### PR TITLE
[QA-1218]: IPVCore: Add profile for I5 Spike test

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -376,6 +376,10 @@ const profiles: ProfileList = {
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 570, 36, 571),
     ...createI4PeakTestSignInScenario('idReuse', 65, 6, 30)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('identity', 1130, 36, 1131),
+    ...createI3SpikeSignInScenario('idReuse', 162, 6, 74)
   }
 }
 


### PR DESCRIPTION
## QA-1218 <!--Jira Ticket Number-->

### What?
This pull request adds a new load profile, `perf006Iteration5SpikeTest`, to the ipv-core.ts performance script, to execute the I5 spike test for IPV Core.

#### Changes:
- Added `perf006Iteration5SpikeTest` to the profiles with a Target throughput and ramp-up of 
-- 113 TPS for Identity proving with a ramp-up of 1131s
-- 162 TPS for Id Reuse with a ramp-up of 74s 

---

### Why?
- To execute the iteration 5 spike test for Mobile-backend.

---

