### PR TITLE
[QA-1221] Adding the I5 spike profile for EVCS.

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -144,6 +144,10 @@ const profiles: ProfileList = {
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('updateVC', 570, 7, 571),
     ...createI4PeakTestSignInScenario('summariseVC', 65, 6, 30)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('updateVC', 1130, 7, 1131),
+    ...createI3SpikeSignInScenario('summariseVC', 162, 6, 74)
   }
 }
 


### PR DESCRIPTION
## QA-1221 <!--Jira Ticket Number-->

### What?
Adds the I5 spike profile for EVCS

#### Changes:
- adds the `perf006Iteration5SpikeTest` profile for `updateVC` and `summariseVC` in the `vc-storage.ts` test.

---

### Why?
To run an I5 spike test for EVCS
