### PR TITLE
[QA-1223] Adding the I5 SPOT spike load profile.

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -58,6 +58,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignInScenario('spot', 122, 3, 30)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignInScenario('spot', 275, 3, 126)
   }
 }
 


### PR DESCRIPTION
## QA-1223 <!--Jira Ticket Number-->

### What?
Adds the I5 Spike profile for SPOT

#### Changes:
- adds the `perf006Iteration5SpikeTest` load profile for `spot` in the `spot/test.js` script.

---

### Why?
To run an I5 SPOT spike test.
