### PR TITLE
[QA:1225] IPVR: Add profile for I5 Spike test

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -100,9 +100,9 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignUpScenario('allEvents', 12, 20, 13),
     ...createI4PeakTestSignInScenario('authEvent', 43, 5, 21)
   },
-  perf006Iteration5PeakTest: {
-    ...createI4PeakTestSignUpScenario('allEvents', 28, 20, 29),
-    ...createI4PeakTestSignInScenario('authEvent', 162, 5, 74)
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('allEvents', 28, 20, 29),
+    ...createI3SpikeSignInScenario('authEvent', 162, 5, 74)
   }
 }
 


### PR DESCRIPTION
## QA-1225 <!--Jira Ticket Number-->

### What?
Add the I5 Spike test profile for IPVR

#### Changes:
- adds the `perf006Iteration5SpikeTest` load profile for IPVR in the cri-kiwi/ipvr.ts script.
- For All events scenario the target throughput is 2.8 TPS with a ramp-up of 29s
- For auth scenario the target throughput is 162 TPS with a ramp-up of 74s

---

### Why?
- To execute the I5 IVR Spike test


