### PR TITLE
[QA-1230]: I5 Spike Test profile for Address

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -184,6 +184,11 @@ const profiles: ProfileList = {
       ],
       exec: 'addressME'
     }
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('address', 100, 15, 101),
+    ...createI3SpikeSignUpScenario('addressME', 1018, 15, 1019),
+    ...createI3SpikeSignUpScenario('internationalAddress', 12, 12, 13)
   }
 }
 


### PR DESCRIPTION
## QA-1230 <!--Jira Ticket Number-->

### What?
Add I5 Spike Test profile for Address

#### Changes:
-    address - Target throughput is 10 j/s, Rampup is 101 sec
      address Manual Entry - Target throughput is 101.8 J/s, Rampup is 1019 sec),
      internationalAddress - Target throughput is 1.2 J/sec, Rampup is 13 sec)


---

### Why?
To Perform PERF006 - I5 Testing

---

### Related:

