### PR TITLE
QA-1216 : CIMIT -  Correct group name and scenario Name mismatch

### DIFF
--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -62,7 +62,7 @@ const groupMap = {
     'B01_CIMITSignUp_02_PostMitigations',
     'B01_CIMITSignUp_03_GetContraIndicatorCredentials'
   ],
-  cimitSignInAPIs: ['B02_CIMITSignIn_01_GetContraIndicatorCredentials']
+  cimitSignInAPI: ['B02_CIMITSignIn_01_GetContraIndicatorCredentials']
 } as const
 
 export const options: Options = {
@@ -154,7 +154,7 @@ export async function cimitSignUpAPIs(): Promise<void> {
 
 export async function cimitSignInAPI(): Promise<void> {
   const retrieveData = csvData[execution.vu.idInTest - 1]
-  const groups = groupMap.cimitSignInAPIs
+  const groups = groupMap.cimitSignInAPI
   const params = {
     headers: {
       'govuk-signin-journey-id': uuidv4(),


### PR DESCRIPTION
## QA-1216

### What?
This PR is to correct the mismatch in scenario & group names

#### Changes:
- In the `cimitSignIn` scenario, the group name was not matching with the scenario name. Hence the smoke test has reported '`level=warning msg="Warning: Scenario 'cimitSignInAPI' does not exist in group name map.` This PR is to correct the group name to match with scenario name - 'cimitSignInAPI'

---

### Why?
To validate the newly created/updated cimitSignin & cimitSignUp scenarios

---
