### PR TITLE
[QA-1238] STS I5 spike Profile

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -1,4 +1,5 @@
 import {
+  createI3SpikeSignUpScenario,
   createI4PeakTestSignUpScenario,
   createScenario,
   describeProfile,
@@ -115,6 +116,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('authentication', 540, 30, 541)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('authentication', 1074, 30, 1075)
   }
 }
 


### PR DESCRIPTION
## QA-1238 <!--Jira Ticket Number-->

### What?
Adds the I5 load profile for STS `authentication`

#### Changes:
- Adds the `perf006Iteration5SpikeTest` load profile to the STS script for the `authentication` scenario.

---

### Why?
To run an I5 spike test for STS.

