### PR TITLE
QA-1248: Add Mobile BE- I5 Spike Profile to the script

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -4,7 +4,8 @@ import {
   describeProfile,
   LoadProfile,
   ProfileList,
-  selectProfile
+  selectProfile,
+  createI3SpikeSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { Options } from 'k6/options'
 import { getThresholds } from '../common/utils/config/thresholds'
@@ -78,6 +79,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('getClientAttestation', 1074, 12, 1075)
   }
 }
 


### PR DESCRIPTION
## QA-1248

### What?
To add Mobile backend Iteration 5 spike profile to the script

#### Changes:
- Created a new profile `perf006Iteration5SpikeTest` with `getClientAttestation` scenario for Iteration 5 spike volume

---

### Why?
To conduct Iteration 5 spike tests

---

