### PR TITLE
[QA-1246]: Add I5 spike test profile for Auth

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -275,6 +275,10 @@ const profiles: ProfileList = {
   perf006Iteration5PeakTest: {
     ...createI4PeakTestSignUpScenario('signUp', 570, 33, 571),
     ...createI4PeakTestSignInScenario('signIn', 65, 18, 31)
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('signUp', 1130, 33, 1131),
+    ...createI3SpikeSignInScenario('signIn', 162, 18, 74)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1246 <!--Jira Ticket Number-->

### What?
Add I5 spike test profile for Auth & Orch

#### Changes:
- Iteration 5 spike test profile with targets as - Sign Up (113 j/s) and Sign In (162 j/s)

---

### Why?
To run the I5 spike test for Auth & Orch