### PR TITLE
[QA-1235] Auth&Orch: Fix signIn iteration count

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -815,7 +815,6 @@ export function signIn(): void {
         })
       }
     }
-    iterationsCompleted.add(1)
 
     if (acceptNewTerms) {
       // B02_SignIn_06_AcceptTermsConditions
@@ -849,7 +848,7 @@ export function signIn(): void {
           })
         }
       })
-      iterationsCompleted.add(1)
     }
   })
+  iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-1235 <!--Jira Ticket Number-->

### What?
Corrected the iteration counting logic within the `signIn` scenario of authentication/test.ts script.

#### Changes:
- Removed two instances of `iterationsCompleted.add(1)` that were conditionally placed.
- Added a single `iterationsCompleted.add(1)` call at the very end of the `signIn` function.


---

### Why?
The previous implementation led to `iterationsCompleted` being higher than `iterationsStarted` due to duplicate increments for a single logical iteration (specifically when the 'accept new terms' flow was executed). This fix ensures accurate iteration tracking.

---
