### PR TITLE
[QA-1258] Authentication: Disable static content downloads

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -381,7 +381,7 @@ if (!validRoute.includes(route)) throw new Error(`Route '${route}' not in [${val
 
 const env = {
   stubEndpoint: getEnv(`ACCOUNT_${route}_STUB`),
-  staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true',
+  staticResources: __ENV.K6_NO_STATIC_RESOURCES == 'true',
   authStagingURL: getEnv('ACCOUNT_STAGING_URL')
 }
 


### PR DESCRIPTION
## QA-1258 <!--Jira Ticket Number-->

### What?
This pull request modifies the authentication script to **prevent the downloading of static content** .

#### Changes:
- Updated the `env.staticResources` variable logic within the k6 scripts to disable static content fetching by default.


---

### Why?
- To prevent downloading static content.
