### PR TITLE
QA-1260: Add Perf006 Iteration 6 Peak test profile to EVCS script

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -148,6 +148,10 @@ const profiles: ProfileList = {
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignUpScenario('updateVC', 1130, 7, 1131),
     ...createI3SpikeSignInScenario('summariseVC', 162, 6, 74)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignUpScenario('updateVC', 920, 7, 921),
+    ...createI4PeakTestSignInScenario('summariseVC', 104, 6, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1260


### What?
PR to add Iteration 6  Peak test profile to Bravo EVCS script

#### Changes:
- Added `perf006Iteration6PeakTest` profile with `updateVC` 92 iters/sec and `summariseVC` 104 iters/sec

---

### Why?
To conduct Perf006 iteration 6 peak test

