### PR TITLE
[QA-1261]: CIMIT I6 Peak profile and SubjectID log for Data creation

### DIFF
--- a/deploy/scripts/src/cimit/test.ts
+++ b/deploy/scripts/src/cimit/test.ts
@@ -90,6 +90,10 @@ const profiles: ProfileList = {
       ],
       exec: 'cimitSignInAPI'
     }
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignUpScenario('cimitIDProvingAPIs', 4720, 19, 921),
+    ...createI4PeakTestSignInScenario('cimitSignInAPI', 104, 6, 48)
   }
 }
 
@@ -188,6 +192,8 @@ export async function cimitIDProvingAPIs(): Promise<void> {
   })
 
   iterationsCompleted.add(1)
+
+  console.log(subjectID)
 }
 
 export async function cimitSignInAPI(): Promise<void> {


### PR DESCRIPTION
## QA-1261] <!--Jira Ticket Number-->

### What?
Adds I6 Peak test profile for CIMIT
Adding log statement for subject ID

#### Changes:
- 'cimitIDProvingAPIs' : Target Throughput 472 j/jec, Rampup is 921 sec
   'cimitSignInAPI', : Target throughput 104 j/sec and Rampup is  48 sec


---

### Why?
To perform PERF006 Iteration 6 testing 

---

### Related:

