### PR TITLE
[QA-1263] IPVCore: Add profile for I6 Peak test

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -380,6 +380,10 @@ const profiles: ProfileList = {
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignUpScenario('identity', 1130, 36, 1131),
     ...createI3SpikeSignInScenario('idReuse', 162, 6, 74)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignUpScenario('identity', 920, 36, 921),
+    ...createI4PeakTestSignInScenario('idReuse', 104, 6, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1263 <!--Jira Ticket Number-->

### What?
This pull request adds a new load profile, `perf006Iteration6PeakTest`, to the `ipv-core.ts` performance script.

#### Changes:
- Added perf006Iteration6PeakTest to the profiles with a Target throughput and ramp-up of
- 92 TPS for Identity proving with a ramp-up of 921s
- 104 TPS for Id Reuse with a ramp-up of 48s

---

### Why?
- To execute the iteration 6 peak test and assess the performance at this volume level.
