### PR TITLE
QA-1279: Add Perf006 Iteration 6 peak profile to Spot script

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -61,6 +61,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignInScenario('spot', 275, 3, 126)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignInScenario('spot', 161, 3, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1279

### What?
This PR is to add Perf006 Iteration 6 peak profile into spot script

#### Changes:
- Added `perf006Iteration6PeakTest` profile in the /spot/test.ts script to target peak volume of 161 iterations per second and rampup of 48 seconds

---

### Why?
To conduct Iteration 6 peak test

---
