### PR TITLE
QA-1282 : Add Perf006 Iteration 6 peak profile to AIS script 

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -79,6 +79,10 @@ const profiles: ProfileList = {
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignInScenario('persistIV', 30, 3, 15),
     ...createI3SpikeSignInScenario('retrieveIV', 486, 3, 74)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignInScenario('persistIV', 30, 3, 15),
+    ...createI4PeakTestSignInScenario('retrieveIV', 312, 3, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1282

### What?
This PR is to add Perf006 Iteration 6 peak profile into AIS script

#### Changes:
- Added perf006Iteration6PeakTest profile in the ais/test.ts script to target the peak volume of
  - persistIV : 30 iters/sec, rampup 15 seconds
  - retrieveIV : 312 iters/sec, rampup 48 seconds


---

### Why?
To conduct Iteration 6 peak test

---
