### PR TITLE
[QA-1256]: SIS - Remove metadata from the request body of the Identity call

### DIFF
--- a/deploy/scripts/src/sis/test.ts
+++ b/deploy/scripts/src/sis/test.ts
@@ -73,10 +73,7 @@ export async function identity(): Promise<void> {
     userId: subjectID,
     si: {
       jwt: identityJWT,
-      vot: 'P2',
-      metadata: {
-        xyz: 'abc'
-      }
+      vot: 'P2'
     }
   })
   const invalidateReqBody = JSON.stringify({

--- a/deploy/scripts/src/sis/test.ts
+++ b/deploy/scripts/src/sis/test.ts
@@ -117,7 +117,7 @@ export async function invalidate(): Promise<void> {
 
   // B02_SIS_01_InvalidateCall
   timeGroup(groups[0], () => http.post(env.envURL + '/v1/identity/invalidate', invalidateReqBody, params), {
-    isStatusCode204
+    isStatusCode404: r => r.status === 404
   })
 
   iterationsCompleted.add(1)


### PR DESCRIPTION
## QA-1256 <!--Jira Ticket Number-->

### What?
Remove metadata from the request body of the Identity call

#### Changes:
- Remove metadata from the request body of the Identity call
- Update the status code check for the invalidate call to verify for HTTP-404 status.

---

### Why?
To fix the smoke test errors.