### PR TITLE
[QA-1289] CRILime-DLA-Fix incorrect groupmap reporting

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -762,16 +762,16 @@ export function drivingLicenceAttestation(): void {
         }),
       { isStatusCode302 }
     )
+    //02_StubCall
+    res = timeGroup(
+      groups[6].split('::')[1],
+      () =>
+        http.get(res.headers.Location, {
+          headers: { Authorization: `Basic ${encodedCredentials}` }
+        }),
+      { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
+    )
   })
-  //02_StubCall
-  res = timeGroup(
-    groups[6].split('::')[1],
-    () =>
-      http.get(res.headers.Location, {
-        headers: { Authorization: `Basic ${encodedCredentials}` }
-      }),
-    { isStatusCode200, ...pageContentCheck('Verifiable Credentials') }
-  )
   iterationsCompleted.add(1)
 }
 


### PR DESCRIPTION
## QA-1289 <!--Jira Ticket Number-->

### What?
Corrected k6 group name reporting for the `drivingLicenceAttestation` scenario.

#### Changes:
-   Ensured `B04_DLattestation_03_ConfirmConsentform::02_CoreStubCall` metric is correctly nested within its parent `timeGroup` to display full hierarchical group name for nested step.


---

### Why?
To ensure accurate and complete group names are reported in k6 test results, improving report clarity and analysis.
