### PR TITLE
QA-1293: Add I6 Peak test profile into TiCF CRI script

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -51,6 +51,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignInScenario('ticf', 162, 66, 75)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignInScenario('ticf', 104, 66, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1293

### What?
This PR will add Perf006 I6 peak profile to TiCF CRI script

#### Changes:
- Created a new profile `perf006Iteration6PeakTest` to trigger 104 iters/sec at rampup duration of 48 secs

---

### Why?
To conduct Iteration 6 peak test

---

