### PR TITLE
[QA-1295]: Adds I6 load profile for ID Check Async

### DIFF
--- a/deploy/scripts/src/mobile-id-check-async/test.ts
+++ b/deploy/scripts/src/mobile-id-check-async/test.ts
@@ -41,6 +41,10 @@ const profiles: ProfileList = {
   perf006Iteration5CombinedPeakTest: {
     ...createI4PeakTestSignUpScenario('idCheckAsyncSignUp', 540, 30, 541),
     ...createI4PeakTestSignInScenario('idCheckAsyncSignIn', 65, 3, 30)
+  },
+  perf006Iteration6CombinedPeakTest: {
+    ...createI4PeakTestSignUpScenario('idCheckAsyncSignUp', 540, 30, 541),
+    ...createI4PeakTestSignInScenario('idCheckAsyncSignIn', 104, 3, 48)
   }
 }
 


### PR DESCRIPTION
## QA-1295 <!--Jira Ticket Number-->

### What?
Adds I6 load profile for ID Check Async

#### Changes:
- 'idCheckAsyncSignUp' -: Target Throughput is  54 journeys/sec , Ramp up is  541 sec
- 'idCheckAsyncSignIn' : Target Throughput is  104 journeys/sec , Ramp up is  48 sec
---

### Why?
Tp Perform PERF006 Iteration 6 testing

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
