### PR TITLE
[QA-1300]: I6 Regression Load profile for MobileBE

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -78,12 +78,6 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration5PeakTest: {
-    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541)
-  },
-  perf006Iteration5SpikeTest: {
-    ...createI3SpikeSignUpScenario('getClientAttestation', 1074, 12, 1075)
-  },
-  perf006Iteration6RegressionTest: {
     ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541),
     walletCredentialIssuance: {
       executor: 'ramping-arrival-rate',
@@ -97,6 +91,9 @@ const profiles: ProfileList = {
       ],
       exec: 'walletCredentialIssuance'
     }
+  },
+  perf006Iteration5SpikeTest: {
+    ...createI3SpikeSignUpScenario('getClientAttestation', 1074, 12, 1075)
   }
 }
 

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -82,6 +82,21 @@ const profiles: ProfileList = {
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignUpScenario('getClientAttestation', 1074, 12, 1075)
+  },
+  perf006Iteration6RegressionTest: {
+    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541),
+    walletCredentialIssuance: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 513,
+      maxVUs: 1026,
+      stages: [
+        { target: 38, duration: '18s' },
+        { target: 38, duration: '55m' }
+      ],
+      exec: 'walletCredentialIssuance'
+    }
   }
 }
 

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -5,7 +5,8 @@ import {
   LoadProfile,
   ProfileList,
   selectProfile,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { Options } from 'k6/options'
 import { getThresholds } from '../common/utils/config/thresholds'
@@ -85,7 +86,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration6RegressionTest: {
     ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541),
-    ...createI4PeakTestSignUpScenario('walletCredentialIssuance', 380, 27, 381)
+    ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 27, 18)
   }
 }
 

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -78,22 +78,14 @@ const profiles: ProfileList = {
     }
   },
   perf006Iteration5PeakTest: {
-    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541),
-    walletCredentialIssuance: {
-      executor: 'ramping-arrival-rate',
-      startRate: 2,
-      timeUnit: '1s',
-      preAllocatedVUs: 513,
-      maxVUs: 1026,
-      stages: [
-        { target: 38, duration: '18s' },
-        { target: 38, duration: '55m' }
-      ],
-      exec: 'walletCredentialIssuance'
-    }
+    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541)
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignUpScenario('getClientAttestation', 1074, 12, 1075)
+  },
+  perf006Iteration6RegressionTest: {
+    ...createI4PeakTestSignUpScenario('getClientAttestation', 540, 12, 541),
+    ...createI4PeakTestSignUpScenario('walletCredentialIssuance', 380, 27, 381)
   }
 }
 


### PR DESCRIPTION
## QA-1300 <!--Jira Ticket Number-->

### What?
QA-1300 I6 Regression Load profile for MobileBE

#### Changes:
- Mobile BE getClientAttestation- 54 TPS 
- Mobile BE WalletCredentialIssuance- 38 TPS

---

### Why?
to perform PERF006 Iteration 6 testing

---

### Related:
- [Link]() to any relevant documentation or relevant pull requests
- Delete this section if not needed
