### PR TITLE
[QA-1301]: TxMA ESP & Audit-Service: Add Iteration 6 Peak and Spike Test Load Profiles

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -85,6 +85,12 @@ const profiles: ProfileList = {
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 7753, 3, 208)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 3820, 3, 571)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 6472, 3, 571)
   }
 }
 


### PR DESCRIPTION
## QA-1301 <!--Jira Ticket Number-->

### What?
This pull request updates the `txma/clientEnrichment.ts` performance test script. It adds new load profiles for Iteration 6 peak and spike tests for the TxMA ESP and Audit-Service.

#### Changes:
The following load profiles have been added:
- perf006Iteration6PeakTest: Targets a throughput of 3,820 journeys per second with a 571-second ramp-up.
- perf006Iteration6SpikeTest: Targets a throughput of 6,472 journeys per second with a 571-second ramp-up.

---

### Why?
To execute Iteration 6 peak and spike tests and to assess the performance of the TxMA ESP & Audit Service.
