### PR TITLE
[QA-1308] SPOT: Add I6 Spike test load profile

### DIFF
--- a/deploy/scripts/src/spot/test.ts
+++ b/deploy/scripts/src/spot/test.ts
@@ -66,6 +66,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignInScenario('spot', 161, 3, 48)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignInScenario('spot', 317, 3, 119)
   }
 }
 


### PR DESCRIPTION
## QA-1308 <!--Jira Ticket Number-->

### What?
This pull request adds the Iteration 6 Spike test load profile to the spot/test.ts performance test script.


#### Changes:
- A new profile, `perf006Iteration6SpikeTest`, has been created for SPoT with the following target throughput:
- Target throughput: 317 iterations per second


---

### Why?
This change enables execution of the Iteration 6 Spike test for SPoT

