### PR TITLE
[QA-1311]: EVCS adding I6 spike Test profile

### DIFF
--- a/deploy/scripts/src/bravo/vc-storage.ts
+++ b/deploy/scripts/src/bravo/vc-storage.ts
@@ -152,6 +152,10 @@ const profiles: ProfileList = {
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('updateVC', 920, 7, 921),
     ...createI4PeakTestSignInScenario('summariseVC', 104, 6, 48)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignUpScenario('updateVC', 570, 7, 571),
+    ...createI3SpikeSignInScenario('summariseVC', 260, 6, 119)
   }
 }
 


### PR DESCRIPTION
## QA-1311 <!--Jira Ticket Number-->

### What?
 EVCS adding I6 spike test profile

#### Changes:
- UpdateVC: Target Throughput is 57 iterations/sec and Rampup is 571  sec
- Summarise VC: Target Throughput is 260 Iterations/sec and Rampup is 119 sec

---

### Why?
To Perform PERF006 I6 testing

---

### Related:

