### PR TITLE
[QA-1315] SIS: Add I6 Spike test profile

### DIFF
--- a/deploy/scripts/src/sis/test.ts
+++ b/deploy/scripts/src/sis/test.ts
@@ -5,7 +5,9 @@ import {
   createScenario,
   LoadProfile,
   createI4PeakTestSignUpScenario,
-  createI4PeakTestSignInScenario
+  createI4PeakTestSignInScenario,
+  createI3SpikeSignUpScenario,
+  createI3SpikeSignInScenario
 } from '../common/utils/config/load-profiles'
 import http from 'k6/http'
 
@@ -28,6 +30,10 @@ const profiles: ProfileList = {
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 570, 11, 571),
     ...createI4PeakTestSignInScenario('invalidate', 104, 6, 48)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignUpScenario('identity', 570, 11, 571),
+    ...createI3SpikeSignInScenario('invalidate', 260, 6, 119)
   }
 }
 


### PR DESCRIPTION
## QA-1315 <!--Jira Ticket Number-->

### What?
Adds a I6 spike test load profile in `deploy/scripts/src/sis/test.ts`

#### Changes:
Adds the perf006Iteration6SpikeTest with the following target throughput:

- For `identity` scenario the target throughput is 57 iterations per seconds with a ramp-up of 571 seconds.
- For `invalidate` scenario the target throughput is 260 iterations per seconds with a ramp-up of 119 seconds.

---

### Why?
To execute the Iteration 6 spike test for SIS.


