### PR TITLE
[QA-1320] Authentication: Add I6 Spike test profile

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -288,6 +288,10 @@ const profiles: ProfileList = {
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('signUp', 920, 33, 921),
     ...createI4PeakTestSignInScenario('signIn', 104, 18, 48)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignUpScenario('signUp', 1830, 33, 1831),
+    ...createI3SpikeSignInScenario('signIn', 260, 18, 119)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1320 <!--Jira Ticket Number-->

### What?
Adds I6 spike test load profile in `deploy/scripts/src/authentication/test.ts`

#### Changes:
Adds the perf006Iteration6SpikeTest with the following target throughput:
- For **signUp** scenario the target throughput is 183 iterations per seconds with a ramp-up of 1831 seconds.
- For **signIn** scenario the target throughput is 260 iterations per seconds with a ramp-up of 119 seconds.


---

### Why?
To execute the Iteration 6 spike test for Auth&Orch.

