### PR TITLE
[QA-1323]: IPVcore I6 spike test profile

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -384,6 +384,10 @@ const profiles: ProfileList = {
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 570, 36, 571),
     ...createI4PeakTestSignInScenario('idReuse', 104, 6, 48)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeSignUpScenario('identity', 570, 36, 571),
+    ...createI3SpikeSignInScenario('idReuse', 260, 6, 119)
   }
 }
 


### PR DESCRIPTION
## QA-1323 <!--Jira Ticket Number-->

### What?
 Adding IPVcore I6 spike test profile

#### Changes:
- Identity': Target Throughput is 570 Journeys/sec, Ramp up is 571 sec
-  IdReuse', Target Throughput is 260 Journeys/sec, Ramp up is 119 sec

---

### Why?
To perform PERF006 testing

---

### Related:
