### PR TITLE
[QA-1325] OLH: Add I6 Spike test load profile

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -391,6 +391,13 @@ const profiles: ProfileList = {
     ...createOLHPeakTestScenario('changePhone', 6, 24, 1),
     ...createOLHPeakTestScenario('deleteAccount', 6, 18, 1),
     ...createI4PeakTestSignInScenario('landingPage', 10, 9, 5)
+  },
+  perf006Iteration6SpikeTest: {
+    ...createI3SpikeOLHScenario('changeEmail', 16, 24, 1),
+    ...createI3SpikeOLHScenario('changePassword', 16, 21, 1),
+    ...createI3SpikeOLHScenario('changePhone', 16, 24, 1),
+    ...createI3SpikeOLHScenario('deleteAccount', 16, 18, 1),
+    ...createI3SpikeSignInScenario('landingPage', 25, 9, 12)
   }
 }
 


### PR DESCRIPTION
## QA-1325 <!--Jira Ticket Number-->

### What?
Adds I6 spike test load profile in `deploy/scripts/src/olh/test.ts`

#### Changes:
Adds the perf006Iteration6SpikeTest with the following target throughput:

- For ChangeEmail scenario the target throughput is 16 iterations per minute with a ramp-up of 1 seconds.
- For ChangePassword scenario the target throughput is 16 iterations per minute with a ramp-up of 1 seconds.
- For ChangePhone scenario the target throughput is 16 iterations per minute with a ramp-up of 1 seconds.
- For DeleteAccount scenario the target throughput is 16 iterations per minute with a ramp-up of 1 seconds.
- For LandingPage scenario the target throughput is 25 iterations per seconds with a ramp-up of 12 seconds.

---

### Why?
To execute the Iteration 6 spike test for OLH.