### PR TITLE
[QA-1326]: Correct ramp up duration for Retrieve

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -86,7 +86,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration6SpikeTest: {
     ...createI3SpikeSignInScenario('persistIV', 30, 3, 15),
-    ...createI3SpikeSignInScenario('retrieveIV', 780, 3, 74)
+    ...createI3SpikeSignInScenario('retrieveIV', 780, 3, 119)
   }
 }
 


### PR DESCRIPTION
## QA-1326 <!--Jira Ticket Number-->

### What?
AIS - Corrected the ramp up duration for Retrieve IV scenario.

#### Changes:
- Corrected the ramp up duration for Retrieve IV scenario to 119 seconds.

---

### Why?
To run a spike test for AIS