### PR TITLE
QA-1303a: Mobile Combined(STS Auth, Re-Auth & Cred Issuance) - Update re-auth test data & conduct combined peak test

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -123,7 +123,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('authentication', 190, 27, 191),
-    ...createI4PeakTestSignInScenario('reauthentication', 6, 27, 4),
+    ...createI4PeakTestSignInScenario('reauthentication', 16, 27, 4),
     ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 27, 18)
   }
 }

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -123,7 +123,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('authentication', 190, 27, 191),
-    ...createI4PeakTestSignInScenario('reauthentication', 16, 27, 4),
+    ...createI4PeakTestSignInScenario('reauthentication', 16, 27, 8),
     ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 39, 18)
   }
 }

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -1,6 +1,7 @@
 import {
   createI3SpikeSignUpScenario,
   createI4PeakTestSignUpScenario,
+  createI4PeakTestSignInScenario,
   createScenario,
   describeProfile,
   LoadProfile,
@@ -119,6 +120,11 @@ const profiles: ProfileList = {
   },
   perf006Iteration5SpikeTest: {
     ...createI3SpikeSignUpScenario('authentication', 1074, 30, 1075)
+  },
+  perf006Iteration6PeakTest: {
+    ...createI4PeakTestSignUpScenario('authentication', 190, 27, 19),
+    ...createI4PeakTestSignInScenario('reauthentication', 6, 27, 4),
+    ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 27, 18)
   }
 }
 

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -122,7 +122,7 @@ const profiles: ProfileList = {
     ...createI3SpikeSignUpScenario('authentication', 1074, 30, 1075)
   },
   perf006Iteration6PeakTest: {
-    ...createI4PeakTestSignUpScenario('authentication', 190, 27, 19),
+    ...createI4PeakTestSignUpScenario('authentication', 190, 27, 191),
     ...createI4PeakTestSignInScenario('reauthentication', 6, 27, 4),
     ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 27, 18)
   }

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -124,7 +124,7 @@ const profiles: ProfileList = {
   perf006Iteration6PeakTest: {
     ...createI4PeakTestSignUpScenario('authentication', 190, 27, 191),
     ...createI4PeakTestSignInScenario('reauthentication', 16, 27, 4),
-    ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 27, 18)
+    ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 39, 18)
   }
 }
 


### PR DESCRIPTION
## QA-1303a

### What?
PR to update the Re-Auth test data(persistentSessionId) and conduct combined peak test

#### Changes:
- Created a new set of test data(persistentSessionId) and uploaded into mobile/data folder
- Created a new profile perf006Iteration6PeakTest for authentication, reauthentication & walletCredentialIssuance peak tests

---

### Why?
To conduct combined peak test

---

