### PR TITLE
QA-1364: PR to include Dynamic(EPOCH) journID for TXMA

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -118,14 +118,14 @@ const awsConfig = new AWSConfig({
 
 const sqs = new SQSClient(awsConfig)
 
-export function setup(): string {
+export function setup() {
   describeProfile(loadProfile)
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '') // YYMMDDTHHmmss
   const testID = `perfTestID${timestamp}`
   const userID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestCommonSubjectId`
   const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
-  const journeyID = 'journeyID'
+  const journeyID = Math.floor(Date.now() / 1000).toString()
   const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
   const authReqParsedPayloadEnrichment = JSON.stringify(generateAuthReqParsedEnrichment(journeyID, testID))
 
@@ -136,15 +136,14 @@ export function setup(): string {
   console.log('Sending primer event 2')
   sqs.sendMessage(env.sqs_queue, authReqParsedPayloadEnrichment)
   console.log('Primer event 2 sent')
-  return authCreateAccPayload
+  return { authCreateAccPayload: authCreateAccPayload, journeyID: journeyID }
 }
 
-export function sendRegularEventWithEnrichment(authCreateAccPayload: string): void {
+export function sendRegularEventWithEnrichment(authCreateAccPayload: string, journeyID: string): void {
   iterationsStarted.add(1)
   const authCreatePayload = JSON.parse(authCreateAccPayload)
   const testID = JSON.stringify(authCreatePayload.event_id).substring(1, 26)
   const eventID = `${testID}_${uuidv4()}`
-  const journeyID = 'journeyID'
   const authLogInSuccessPayloadEnrichment = JSON.stringify(
     generateAuthLogInSuccessEnrichment(
       eventID,

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -125,7 +125,7 @@ export function setup() {
   const userID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestCommonSubjectId`
   const pairWiseID = `${testID}_performanceTestClientId_perfUserID${uuidv4()}_performanceTestRpPairwiseId`
   const emailID = `perfEmail${uuidv4()}@digital.cabinet-office.gov.uk`
-  const journeyID = Math.floor(Date.now() / 1000).toString()
+  const journeyID = `perfJourneyID_${Math.floor(Date.now() / 1000)}`
   const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
   const authReqParsedPayloadEnrichment = JSON.stringify(generateAuthReqParsedEnrichment(journeyID, testID))
 


### PR DESCRIPTION
## QA-1364

### What?
This PR is to replace the current static journeyID in the TXMA test script to a dynamic value(EPOCH timestamp), which would help in debugging

#### Changes:
- Replaced the current static value of journeyID with Math.floor(Date.now() / 1000).toString() in the setup function, so that the value remains same for each test
- journeyID is returned from the setup function and used in the sendRegularEventWithEnrichment function

### Why?
A unique journeyID for each test would help in filtering, debugging etc.

---

