### PR TITLE
[QA-1657]: Add I9 Stress test profile NINOCheck

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -10,7 +10,8 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignUpScenario,
-  createI4PeakTestSignUpScenario
+  createI4PeakTestSignUpScenario,
+  createStressTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { isStatusCode200, isStatusCode302, pageContentCheck } from '../common/utils/checks/assertions'
@@ -102,6 +103,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignUpScenario('ninoCheck', 10, 6, 11)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignUpScenario('ninoCheck', 6, 6, 7)
   }
 }
 


### PR DESCRIPTION
## QA-1657 

### What?
Add I9 Stress test profile HMRC NINO Check 

#### Changes:
Add I9 Stress test profile HMRC NINO Check at 0.6j/s


### Why?
To enable I9 stress test for HMRC NINO Check .

---



