### PR TITLE
[QA-1658] Add I9 Stress Test profile for SIS User Identity

### DIFF
--- a/deploy/scripts/src/trust-and-reuse/sis.ts
+++ b/deploy/scripts/src/trust-and-reuse/sis.ts
@@ -5,7 +5,8 @@ import {
   createScenario,
   LoadProfile,
   createI4PeakTestSignInScenario,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createStressTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import http, { type Response } from 'k6/http'
 
@@ -36,6 +37,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignInScenario('useridentity', 227, 15, 104)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignInScenario('useridentity', 250, 15, 115)
   }
 }
 


### PR DESCRIPTION
## QA-1658 <!--Jira Ticket Number-->

### What?
Add I9 Stress Test profile for SIS User Identity

#### Changes:
-  SignIn Stress test profile for user Identity as below
   'useridentity' : Target Throughput 250 TPS  and Rampup is 115

---

### Why?
To conduct I9 Stress testing

---

### Related:

