### PR TITLE
[QA-1661]: Add I9 Stress test Load profile for DCMAW

### DIFF
--- a/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
+++ b/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
@@ -7,7 +7,8 @@ import {
   createScenario,
   LoadProfile,
   createI4PeakTestSignUpScenario,
-  createI3SpikeSignUpScenario
+  createI3SpikeSignUpScenario,
+  createStressTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import {
   postSelectDevice,
@@ -96,6 +97,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignUpScenario('mamIphonePassport', 600, 48, 601)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignUpScenario('mamIphonePassport', 600, 48, 601)
   }
 }
 


### PR DESCRIPTION
## QA-1661 <!--Jira Ticket Number-->

### What?
Add I9 Stress test profile for DCMAW (Combined Journey - FE+BE)

#### Changes:
- Added  I9 Stress test profile for DCMAW is as below
DCMAW : Target Throughput: 60 journeys per second, Ramp up is 600 sec

Smoke Test executed in the local:

---

### Why?
To conduct I9 Stress Testing 

---

### Related:

