### PR TITLE
[QA-1664] Add I9 stress test Load profile for STS combined scenarios

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -7,7 +7,9 @@ import {
   describeProfile,
   LoadProfile,
   ProfileList,
-  selectProfile
+  selectProfile,
+  createStressTestSignInScenario,
+  createStressTestSignUpScenario
 } from '../common/utils/config/load-profiles'
 import { Options } from 'k6/options'
 import { getThresholds } from '../common/utils/config/thresholds'
@@ -156,6 +158,12 @@ const profiles: ProfileList = {
     ...createI3SpikeSignInScenario('reauthentication', 8, 27, 4),
     ...createI3SpikeSignInScenario('walletCredentialIssuance', 38, 39, 18),
     ...createI3SpikeSignInScenario('accountIntervention', 80, 15, 37)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignUpScenario('authentication', 600, 36, 601),
+    ...createStressTestSignInScenario('reauthentication', 30, 27, 15, 195),
+    ...createStressTestSignInScenario('walletCredentialIssuance', 38, 39, 18, 194),
+    ...createStressTestSignInScenario('accountIntervention', 20, 15, 10, 197)
   }
 }
 


### PR DESCRIPTION
## QA-1664 <!--Jira Ticket Number-->

### What?
Add I9 stress test Load profile for STS combined scenarios

#### Changes:
- I9 stress test Load profile for STS combined scenarios added as below
   - authentication and RefreshTokens : Target Throughput is 60 jps
   - Reauthentication :  Target Throughput is 30 jps
   - Wallet Credential Issuance : Target Throughput is 38 jps
   - Account Intervention: Target Throughput is 20 jps

Local Execution:
<img width="934" height="534" alt="image" src="https://github.com/user-attachments/assets/f6e2e73b-b142-41a3-ae7b-049cfc6b1dba" />


---

### Why?
To conduct I9 Stress test

---

### Related:

