### PR TITLE
[QA-1665] : Add I9 StressProfile to Mobile BE

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -7,7 +7,9 @@ import {
   selectProfile,
   createI3SpikeSignUpScenario,
   createI4PeakTestSignInScenario,
-  createI3SpikeSignInScenario
+  createI3SpikeSignInScenario,
+  createStressTestSignUpScenario,
+  createStressTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { Options } from 'k6/options'
 import { getThresholds } from '../common/utils/config/thresholds'
@@ -122,6 +124,10 @@ const profiles: ProfileList = {
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignUpScenario('getClientAttestation', 1280, 12, 601),
     ...createI3SpikeSignInScenario('walletCredentialIssuance', 38, 27, 18)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignUpScenario('getClientAttestation', 150, 12, 600),
+    ...createStressTestSignInScenario('walletCredentialIssuance', 38, 27, 15, 195)
   }
 }
 

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -126,7 +126,7 @@ const profiles: ProfileList = {
     ...createI3SpikeSignInScenario('walletCredentialIssuance', 38, 27, 18)
   },
   perf006Iteration9StressTest: {
-    ...createStressTestSignUpScenario('getClientAttestation', 150, 12, 600),
+    ...createStressTestSignUpScenario('getClientAttestation', 1500, 12, 600),
     ...createStressTestSignInScenario('walletCredentialIssuance', 38, 27, 15, 195)
   }
 }


### PR DESCRIPTION
QA-1665

### What?
Add stress test profile for Combined Test Mobile Platform BE


#### Changes:
- Added stress test profile for ClientAttestation journey at 150 j/s.
- Added stress test profile for wallet Credential Issuance at 38 j/s.

---

### Why?
To conduct a stress test for Combined Test Mobile Platform BE

---


