### PR TITLE
[QA-1671]: Add I9 stress test load profile for IPVR (KIWI)

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -9,7 +9,9 @@ import {
   createI3SpikeSignUpScenario,
   createI3SpikeSignInScenario,
   createI4PeakTestSignUpScenario,
-  createI4PeakTestSignInScenario
+  createI4PeakTestSignInScenario,
+  createStressTestSignUpScenario,
+  createStressTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import {
@@ -115,6 +117,10 @@ const profiles: ProfileList = {
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignUpScenario('allEvents', 16, 20, 17),
     ...createI3SpikeSignInScenario('authEvent', 227, 5, 104)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignUpScenario('allEvents', 16, 20, 17, 33),
+    ...createStressTestSignInScenario('authEvent', 250, 5, 115)
   }
 }
 


### PR DESCRIPTION
## QA-1671 <!--Jira Ticket Number-->

### What?
Add I9 stress test load profile for IPVR (KIWI)

#### Changes:
Added I9 Stress Test load profile for All Events and AuthEvents as below
- allEvents - Target Throughput is 1.6 j/sec
- authEvent -Target Throughput is 250 j/sec

Executed Smoke Test locally and Sample run for Load profile
<img width="912" height="648" alt="image" src="https://github.com/user-attachments/assets/f644e169-c751-44a3-8a0f-f38ce1003b3e" />

---

### Why?
To Conduct PERF006 - I9 Stress Tests

---

