### PR TITLE
[QA-1672]Add I9 peakProf to ClientEnrichment

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -7,8 +7,7 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignInScenario,
-  createI4PeakTestSignInScenario,
-  createStressTestSignInScenario
+  createI4PeakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -102,8 +101,8 @@ const profiles: ProfileList = {
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 7135, 3, 631)
   },
-  perf006Iteration9StressTest: {
-    ...createStressTestSignInScenario('sendRegularEventWithEnrichment', 2500, 3, 631)
+  perf006Iteration9PeakTest: {
+    ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2500, 3, 631)
   }
 }
 

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -7,7 +7,8 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignInScenario,
-  createI4PeakTestSignInScenario
+  createI4PeakTestSignInScenario,
+  createStressTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -100,6 +101,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeSignInScenario('sendRegularEventWithEnrichment', 7135, 3, 631)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignInScenario('sendRegularEventWithEnrichment', 2500, 3, 631)
   }
 }
 


### PR DESCRIPTION
## QA-1672 <!--Jira Ticket Number-->

### What?
TxMA Data Shared Signal - Add I9 peak test profile for sendRegularEventWithEnrichment scenario .

#### Changes:
- Added a I9 Peak test profile for sendRegularEventWithEnrichment at 2500 journeys per second.

---

### Why?
To enable the I9 peak test.

---

