### PR TITLE
[QA-1679]: Add I9 Stress Test Load profile for Event Streaming Platform(ESP) and Audit Service

### DIFF
--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -7,7 +7,8 @@ import {
   createScenario,
   LoadProfile,
   createI3SpikeSignInScenario,
-  createI4PeakTestSignInScenario
+  createI4PeakTestSignInScenario,
+  createStressTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { uuidv4 } from '../common/utils/jslib/index.js'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
@@ -103,6 +104,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration9PeakTest: {
     ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2500, 3, 631)
+  },
+  perf006Iteration9StressTest: {
+    ...createStressTestSignInScenario('sendRegularEventWithEnrichment', 7135, 3, 631)
   }
 }
 

--- a/deploy/scripts/src/txma/clientEnrichment.ts
+++ b/deploy/scripts/src/txma/clientEnrichment.ts
@@ -106,7 +106,7 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignInScenario('sendRegularEventWithEnrichment', 2500, 3, 631)
   },
   perf006Iteration9StressTest: {
-    ...createStressTestSignInScenario('sendRegularEventWithEnrichment', 7135, 3, 631)
+    ...createStressTestSignInScenario('sendRegularEventWithEnrichment', 7706, 3, 631)
   }
 }
 


### PR DESCRIPTION
## QA-1679 <!--Jira Ticket Number-->

### What?
Add I9 Stress Test Load profile for Event Streaming Platform(ESP) and Audit Service

#### Changes:
- Added Stress Test load profile for Event Streaming Platform(ESP) and Audit Service is as below

   sendRegularEventWithEnrichment : Target Throughput is 7706 Events/sec

---

### Why?
To Conduct I9 Stress Test

---

### Related:

