### PR TITLE
QA-1682 : Iteration 9 Soak test profile update for IPVCore test script

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -563,3 +563,62 @@ export function createStressTestOLHScenario(
     vuFactor: 1
   })
 }
+
+interface SoakTestConfig {
+  startRate: number
+  timeUnit: string
+  vuFactor: number
+}
+
+function createSoakTestScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number,
+  config: SoakTestConfig
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
+  const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
+
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: config.startRate,
+    timeUnit: config.timeUnit,
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target, duration: `${rampUpDuration}s` },
+      { target, duration: '6h' }
+    ],
+    exec
+  }
+
+  return list
+}
+
+export function createSoakTestSignUpScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number
+): ScenarioList {
+  return createSoakTestScenario(exec, target, iterationDuration, rampUpDuration, {
+    startRate: 1,
+    timeUnit: '10s',
+    vuFactor: 0.1
+  })
+}
+
+export function createSoakTestSignInScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number
+): ScenarioList {
+  return createSoakTestScenario(exec, target, iterationDuration, rampUpDuration, {
+    startRate: 2,
+    timeUnit: '1s',
+    vuFactor: 1
+  })
+}

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -344,30 +344,50 @@ export function createI3SpikeSignInScenario(
   return list
 }
 
+interface RampUpConfig {
+  startRate: number
+  timeUnit: string
+  vuFactor: number
+}
+
+const signUpConfig: RampUpConfig = { startRate: 1, timeUnit: '10s', vuFactor: 0.1 }
+const signInConfig: RampUpConfig = { startRate: 2, timeUnit: '1s', vuFactor: 1 }
+
+function createPerfTestScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number,
+  holdDuration: string,
+  config: RampUpConfig
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
+  const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
+
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: config.startRate,
+    timeUnit: config.timeUnit,
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      { target, duration: `${rampUpDuration}s` },
+      { target, duration: holdDuration }
+    ],
+    exec
+  }
+
+  return list
+}
+
 export function createI4PeakTestSignUpScenario(
   exec: string,
   target: number,
   iterationDuration: number,
   rampUpDuration: number
 ): ScenarioList {
-  const list: ScenarioList = {}
-  const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
-  const maxVUs = Math.round((target / 10) * iterationDuration)
-
-  list[exec] = {
-    executor: 'ramping-arrival-rate',
-    startRate: 1,
-    timeUnit: '10s',
-    preAllocatedVUs,
-    maxVUs,
-    stages: [
-      { target, duration: `${rampUpDuration}s` },
-      { target, duration: `30m` }
-    ],
-    exec
-  }
-
-  return list
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signUpConfig)
 }
 
 export function createI4PeakTestSignInScenario(
@@ -376,24 +396,7 @@ export function createI4PeakTestSignInScenario(
   iterationDuration: number,
   rampUpDuration: number
 ): ScenarioList {
-  const list: ScenarioList = {}
-  const preAllocatedVUs = Math.round((target * iterationDuration) / 2)
-  const maxVUs = target * iterationDuration
-
-  list[exec] = {
-    executor: 'ramping-arrival-rate',
-    startRate: 2,
-    timeUnit: '1s',
-    preAllocatedVUs,
-    maxVUs,
-    stages: [
-      { target, duration: `${rampUpDuration}s` },
-      { target, duration: `30m` }
-    ],
-    exec
-  }
-
-  return list
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signInConfig)
 }
 
 export function createI3SpikeOLHScenario(
@@ -564,50 +567,13 @@ export function createStressTestOLHScenario(
   })
 }
 
-interface SoakTestConfig {
-  startRate: number
-  timeUnit: string
-  vuFactor: number
-}
-
-function createSoakTestScenario(
-  exec: string,
-  target: number,
-  iterationDuration: number,
-  rampUpDuration: number,
-  config: SoakTestConfig
-): ScenarioList {
-  const list: ScenarioList = {}
-  const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
-  const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
-
-  list[exec] = {
-    executor: 'ramping-arrival-rate',
-    startRate: config.startRate,
-    timeUnit: config.timeUnit,
-    preAllocatedVUs,
-    maxVUs,
-    stages: [
-      { target, duration: `${rampUpDuration}s` },
-      { target, duration: '6h' }
-    ],
-    exec
-  }
-
-  return list
-}
-
 export function createSoakTestSignUpScenario(
   exec: string,
   target: number,
   iterationDuration: number,
   rampUpDuration: number
 ): ScenarioList {
-  return createSoakTestScenario(exec, target, iterationDuration, rampUpDuration, {
-    startRate: 1,
-    timeUnit: '10s',
-    vuFactor: 0.1
-  })
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '6h', signUpConfig)
 }
 
 export function createSoakTestSignInScenario(
@@ -616,9 +582,5 @@ export function createSoakTestSignInScenario(
   iterationDuration: number,
   rampUpDuration: number
 ): ScenarioList {
-  return createSoakTestScenario(exec, target, iterationDuration, rampUpDuration, {
-    startRate: 2,
-    timeUnit: '1s',
-    vuFactor: 1
-  })
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '6h', signInConfig)
 }

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -13,7 +13,9 @@ import {
   createI4PeakTestSignUpScenario,
   createI4PeakTestSignInScenario,
   createStressTestSignUpScenario,
-  createStressTestSignInScenario
+  createStressTestSignInScenario,
+  createSoakTestSignUpScenario,
+  createSoakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
@@ -414,6 +416,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('identity', 630, 42, 631),
     ...createStressTestSignInScenario('idReuse', 250, 6, 115, 172)
+  },
+  perf006Iteration9SoakTest: {
+    ...createSoakTestSignUpScenario('identity', 100, 42, 101),
+    ...createSoakTestSignInScenario('idReuse', 15, 6, 8)
   }
 }
 


### PR DESCRIPTION
## QA-1682

### What?
This PR is to add Iteration 9 soak test profile into IPVCore test script `ipv-core/test.ts`. The profile runs two scenarios identity and idReuse

#### Changes:

- Added common function `createPerfTestScenario` to create load profiles for peak and soak test
- Updated `createI4PeakTestSignUpScenario` and `createI4PeakTestSignInScenario` to use the `createPerfTestScenario` function
- Added `createSoakTestSignUpScenario` and `createSoakTestSignInScenario` with 6 hours as the steady state duration using the `createPerfTestScenario` function.
- Added `perf006Iteration9SoakTest` profile to `ipv-core/test.ts` with two scenarios sustaining for 6 hours:
  - identity: target 10 iterations/sec, rampUp 101s
  - idReuse: target 15 iterations/sec, rampUp 8s
 

---
Smoke Test results:
<img width="1219" height="233" alt="image" src="https://github.com/user-attachments/assets/89d18ae4-e66a-4b1f-b4bb-f87654e41d5e" />

I4 Peak Test Profile Validation (As it has been changed)
<img width="1004" height="235" alt="image" src="https://github.com/user-attachments/assets/ce56dbc6-8280-4f94-b5dc-6ba630b37bf7" />

Soak Test Profile Validation
<img width="991" height="235" alt="image" src="https://github.com/user-attachments/assets/df49096d-aded-4ae6-b153-f0625e94f856" />


### Why?
To support Iteration 9 IPVCore soak test

---