### PR TITLE
[QA-1689]: Auth - Add redis failover test profile

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -314,6 +314,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('signUp', 960, 33, 961),
     ...createStressTestSignInScenario('signIn', 250, 18, 115, 283)
+  },
+  redisFailoverTest: {
+    ...createI4PeakTestSignUpScenario('signUp', 100, 33, 101),
+    ...createI4PeakTestSignInScenario('signIn', 10, 18, 6)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1689 <!--Jira Ticket Number-->

### What?
Auth - Add redis failover test profile

#### Changes:
- Added a profile for Sign Up & Sign in at 10 j/s

---

### Why?
To run a failover test for Auth