### PR TITLE
[QA-1690]: Add I9 soak test load profile for Authentication and Orchestration

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -21,7 +21,9 @@ import {
   createI4PeakTestSignUpScenario,
   createI4PeakTestSignInScenario,
   createStressTestSignInScenario,
-  createStressTestSignUpScenario
+  createStressTestSignUpScenario,
+  createSoakTestSignUpScenario,
+  createSoakTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { getThresholds } from '../common/utils/config/thresholds'
 import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
@@ -318,6 +320,10 @@ const profiles: ProfileList = {
   redisFailoverTest: {
     ...createI4PeakTestSignUpScenario('signUp', 100, 33, 101),
     ...createI4PeakTestSignInScenario('signIn', 10, 18, 6)
+  },
+  perf006Iteration9SoakTest: {
+    ...createSoakTestSignUpScenario('signUp', 110, 33, 111),
+    ...createSoakTestSignInScenario('signIn', 15, 6, 8)
   }
 }
 const loadProfile = selectProfile(profiles)


### PR DESCRIPTION
## QA-1690 <!--Jira Ticket Number-->

### What?
Add Load profile for Authentication and Orchestration's I9 Soak Test 

#### Changes:
- I9 Soak Test load profile added as below for Authentication and Orchestration
   signUp: Target throughput : 11 j/sec
   signIn:  Target throughput : 15 j/sec

- Smoke tested locally and validated the soak profile by executing 1 min
<img width="997" height="312" alt="image" src="https://github.com/user-attachments/assets/e7d850d2-5d4d-40e9-8d09-0e5628c6e074" />

---

### Why?
To Conduct I9 soak test

---

### Related:

