### PR TITLE
[QA-1701]: Add checkHMRC Adhoc peak test profile

### DIFF
--- a/deploy/scripts/src/cri-orange/nino-check.ts
+++ b/deploy/scripts/src/cri-orange/nino-check.ts
@@ -106,6 +106,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('ninoCheck', 6, 6, 7)
+  },
+  perf006AdhocPeakTest: {
+    ...createI4PeakTestSignUpScenario('ninoCheck', 200, 6, 201)
   }
 }
 


### PR DESCRIPTION
## QA-1701 <!--Jira Ticket Number-->

### What?
Add checkHMRC Adhoc peak test profile with 20 j/s ( 20 times higher than I8 volume)

#### Changes:
- 'Check HMRC/ninoCheck' :  Target Throughput 20 Journeys/sec, Ramup up is 201 sec

---

### Why?
To perform Adhoc peak test with updated ECS container count and Scaling pocies

---
Smoke Test Executed and Sample 1 min run for Adhoc profile in below attachment
<img width="1093" height="336" alt="image" src="https://github.com/user-attachments/assets/5cdfcc1d-dffc-4995-b341-68a9589e1209" />

