### PR TITLE
QA-1705: Add high volume SPOT load profile for Cribl log ingestion validation

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -584,3 +584,12 @@ export function createSoakTestSignInScenario(
 ): ScenarioList {
   return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '6h', signInConfig)
 }
+
+export function createHighVolumeSignInScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpDuration: number
+): ScenarioList {
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '1h', signInConfig)
+}

--- a/deploy/scripts/src/trust-and-reuse/spot.ts
+++ b/deploy/scripts/src/trust-and-reuse/spot.ts
@@ -8,7 +8,8 @@ import {
   LoadProfile,
   createI3SpikeSignInScenario,
   createI4PeakTestSignInScenario,
-  createStressTestSignInScenario
+  createStressTestSignInScenario,
+  createHighVolumeSignInScenario
 } from '../common/utils/config/load-profiles'
 import { AWSConfig, SQSClient } from '../common/utils/jslib/aws-sqs'
 import { type AssumeRoleOutput } from '../common/utils/aws/types'
@@ -82,6 +83,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration9StressTest: {
     ...createStressTestSignInScenario('spot', 313, 3, 115)
+  },
+  criblHighVolumeTest: {
+    ...createHighVolumeSignInScenario('spot', 3000, 3, 1350)
   }
 }
 


### PR DESCRIPTION
## QA-1705

### What?
This PR is to add a new load profile `criblHighVolumeTest` to spot test script to support a high volume test, validating that the Cribl instance for the new logging solution can sustain high volumes of log ingestion in an hour.

#### Changes:
- **`load-profiles.ts`**: included a new helper `createHighVolumeSignInScenario` that  wraps `createPerfTestScenario` with a 1-hour hold duration
- **`spot.ts`**: Added `criblHighVolumeTest` profile using the new helper — ramps up to 3000 req/s in 22.5 minutes then run for 60 minutes

---

### Why?
To support Cribl instance implementation

---