### PR TITLE
[QA-1460]: Add Stub Call Suffix and Clean Up Step Names in the Mobile scripts

### DIFF
--- a/deploy/scripts/src/mobile-id-check-async/test.ts
+++ b/deploy/scripts/src/mobile-id-check-async/test.ts
@@ -72,17 +72,17 @@ export const groupMap = {
   idCheckAsyncSignUp: [
     'B01_IDCheckSignUpV2_00_POST_/async/token', //pragma: allowlist secret
     'B01_IDCheckSignUpV2_01_POST_/async/credential', //pragma: allowlist secret
-    'B01_IDCheckSignUpV2_02_POST_sts-mock /token',
+    'B01_IDCheckSignUpV2_02_POST_sts-mock/token_StubCall', //pragma: allowlist secret
     'B01_IDCheckSignUpV2_03_GET_/async/activeSession', //pragma: allowlist secret
     'B01_IDCheckSignUpV2_04_POST_/async/biometricToken', //pragma: allowlist secret
-    'B01_IDCheckSignUpV2_05_GET_/async/.well-known/jwks.json',
+    'B01_IDCheckSignUpV2_05_GET_/async/.well-known/jwks.json', //pragma: allowlist secret
     'B01_IDCheckSignUpV2_06_POST_/async/txmaEvent', //pragma: allowlist secret
-    'B01_IDCheckSignUpV2_07_POST_readid-mock /postSetupBiometricSessionByScenario',
+    'B01_IDCheckSignUpV2_07_POST_readid-mock/postSetupBiometricSessionByScenario', //pragma: allowlist secret
     'B01_IDCheckSignUpV2_08_POST_async/finishBiometricSession', //pragma: allowlist secret
-    'B01_IDCheckSignUpV2_09_POST async/abortSession'
+    'B01_IDCheckSignUpV2_09_POST_async/abortSession' //pragma: allowlist secret
   ],
   idCheckAsyncSignIn: [
-    'B02_IDCheckSignInV2_00_POST_sts-mock /token',
+    'B02_IDCheckSignInV2_00_POST_sts-mock/token_StubCall', //pragma: allowlist secret
     'B02_IDCheckSignInV2_01_GET_/async/activeSession' //pragma: allowlist secret
   ]
 } as const

--- a/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
+++ b/deploy/scripts/src/mobile/fe-be-combine-e2e.test.ts
@@ -106,21 +106,21 @@ const profiles: ProfileList = {
 const loadProfile = selectProfile(profiles)
 const groupMap = {
   mamIphonePassport: [
-    'POST test client /start',
-    'GET /authorize',
-    'POST /selectDevice',
-    'POST /selectSmartphone',
-    'POST /validPassport',
-    'POST /biometricChip',
-    'POST /idCheckApp',
-    'GET /appInfo', //BE
-    'GET /biometricToken/v2',
-    'POST /txmaEvent', //BE
-    'POST /finishBiometricSession', //BE
-    'GET /redirect', //BE
-    'POST /token', //BE
-    'POST /v2/setupBiometricSessionByScenario/', //BE
-    'POST /userinfo/v2' //BE
+    '01_POST_testclient_/start',
+    '02_GET_/authorize',
+    '03_POST_/selectDevice',
+    '04_POST_/selectSmartphone',
+    '05_POST_/validPassport',
+    '06_POST_/biometricChip',
+    '07_POST_/idCheckApp',
+    '08_GET_/appInfo', //BE
+    '09_GET_/biometricToken/v2',
+    '10_POST_/txmaEvent', //BE
+    '11_POST_/finishBiometricSession', //BE
+    '12_GET_/redirect', //BE
+    '13_POST_/token', //BE
+    '14_POST_/v2/setupBiometricSessionByScenario/', //BE
+    '15_POST_/userinfo/v2' //BE
   ]
 } as const
 

--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -135,20 +135,20 @@ const loadProfile = selectProfile(profiles)
 export const groupMap = {
   getClientAttestation: [
     '01_GET_/appInfo',
-    '02_GET_/app-check-token',
+    '02_GET_/app-check-token_StubCall',
     '03_POST_/client-attestation',
     '04_GET_/.well-known/jwks.json'
   ],
   walletCredentialIssuance: [
-    '01 GET /authorize (STS)',
-    '02 GET /authorize (Orchestration)',
-    '03 GET /redirect',
-    '04 GET /app-check-token',
-    '05 POST /client-attestation',
-    '06 POST /token (authorization code exchange)',
-    '07 POST /token (access token exchange - TxMA event service token)',
-    '08 POST /txma-event (WALLET_CREDENTIAL_ADD_ATTEMPT event)',
-    '09 POST /txma-event (WALLET_CREDENTIAL_ADDED event)'
+    '01_GET_/authorize (STS)',
+    '02_GET_/authorize(Orchestration)_StubCall',
+    '03_GET_/redirect',
+    '04_GET_/app-check-token_StubCall',
+    '05_POST_/client-attestation',
+    '06_POST_/token(authorizationCodeExchange)',
+    '07_POST_/token(accessTokenExchange-TxMAeventServiceToken)',
+    '08_POST_/txma-event(WALLET_CREDENTIAL_ADD_ATTEMPTevent)',
+    '09_POST_/txma-event(WALLET_CREDENTIAL_ADDEDevent)'
   ]
 } as const
 

--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -170,58 +170,58 @@ const profiles: ProfileList = {
 const loadProfile = selectProfile(profiles)
 export const groupMap = {
   authentication: [
-    'B01_AUTHENTICATION_01 GET /authorize (STS)',
-    'B01_AUTHENTICATION_02 GET /.well-known/jwks.json (STS)',
-    'B01_AUTHENTICATION_03 GET /authorize (Orchestration)',
-    'B01_AUTHENTICATION_04 GET /redirect',
-    'B01_AUTHENTICATION_05 GET /.well-known/jwks.json (STS)',
-    'B01_AUTHENTICATION_06 POST /generate-client-attestation',
-    'B01_AUTHENTICATION_07 POST /token (authorization code exchange)',
-    'B01_AUTHENTICATION_08 POST /token (access token exchange)',
-    'B01_AUTHENTICATION_09 GET /.well-known/jwks.json (STS)',
-    'B01_EXCHANGE_REFRESH_TOKEN_10 POST /token (refresh token exchange)',
-    'B01_EXCHANGE_REFRESH_TOKEN_11 POST /token (access token exchange)',
-    'B01_EXCHANGE_REFRESH_TOKEN_12 GET /.well-known/jwks.json (STS)'
+    'B01_AUTHENTICATION_01_GET_/authorize(STS)',
+    'B01_AUTHENTICATION_02_GET_/.well-known/jwks.json(STS)',
+    'B01_AUTHENTICATION_03_GET_/authorize(Orchestration)_StubCall',
+    'B01_AUTHENTICATION_04_GET_/redirect',
+    'B01_AUTHENTICATION_05_GET_/.well-known/jwks.json(STS)',
+    'B01_AUTHENTICATION_06_POST_/generate-client-attestation_StubCall', //pragma: allowlist secret
+    'B01_AUTHENTICATION_07_POST_/token(authorizationCodeExchange)',
+    'B01_AUTHENTICATION_08_POST_/token(accessTokenExchange)',
+    'B01_AUTHENTICATION_09_GET_/.well-known/jwks.json(STS)',
+    'B01_EXCHANGE_REFRESH_TOKEN_10_POST_/token(refreshTokenExchange)',
+    'B01_EXCHANGE_REFRESH_TOKEN_11_POST_/token(accessTokenExchange)',
+    'B01_EXCHANGE_REFRESH_TOKEN_12_GET_/.well-known/jwks.json(STS)'
   ],
   reauthentication: [
-    'REAUTHENTICATION_01 GET /authorize (STS)',
-    'REAUTHENTICATION_02 GET /.well-known/jwks.json (STS)',
-    'REAUTHENTICATION_03 GET /authorize (Orchestration)',
-    'REAUTHENTICATION_04 GET /redirect',
-    'REAUTHENTICATION_05 GET /.well-known/jwks.json (STS)',
-    'REAUTHENTICATION_06 POST /generate-client-attestation',
-    'REAUTHENTICATION_07 POST /token (authorization code exchange)',
-    'REAUTHENTICATION_08 POST /token (access token exchange)',
-    'REAUTHENTICATION_09 GET /.well-known/jwks.json (STS)'
+    'REAUTHENTICATION_01_GET_/authorize(STS)',
+    'REAUTHENTICATION_02_GET_/.well-known/jwks.json(STS)',
+    'REAUTHENTICATION_03_GET_/authorize(Orchestration)_StubCall',
+    'REAUTHENTICATION_04_GET_/redirect',
+    'REAUTHENTICATION_05_GET_/.well-known/jwks.json(STS)',
+    'REAUTHENTICATION_06_POST_/generate-client-attestation_StubCall', //pragma: allowlist secret
+    'REAUTHENTICATION_07_POST_/token(authorizationCodeExchange)',
+    'REAUTHENTICATION_08_POST_/token(accessTokenExchange)',
+    'REAUTHENTICATION_09_GET_/.well-known/jwks.json(STS)'
   ],
   walletCredentialIssuance: [
-    'WALLET_CREDENTIAL_ISSUANCE_01 GET /authorize (STS)',
-    'WALLET_CREDENTIAL_ISSUANCE_02 GET /.well-known/jwks.json (STS)',
-    'WALLET_CREDENTIAL_ISSUANCE_03 GET /authorize (Orchestration)',
-    'WALLET_CREDENTIAL_ISSUANCE_04 GET /redirect',
-    'WALLET_CREDENTIAL_ISSUANCE_05 GET /.well-known/jwks.json (STS)',
-    'WALLET_CREDENTIAL_ISSUANCE_06 POST /generate-client-attestation',
-    'WALLET_CREDENTIAL_ISSUANCE_07 POST /token (authorization code exchange)',
-    'WALLET_CREDENTIAL_ISSUANCE_08 POST /token (access token exchange)',
-    'WALLET_CREDENTIAL_ISSUANCE_09 GET /.well-known/jwks.json (STS)',
-    'WALLET_CREDENTIAL_ISSUANCE_10 GET /generate-pre-auth-code',
-    'WALLET_CREDENTIAL_ISSUANCE_11 POST /token (access token exchange)',
-    'WALLET_CREDENTIAL_ISSUANCE_12 POST /token (pre-authorized code exchange)',
-    'WALLET_CREDENTIAL_ISSUANCE_13 GET /.well-known/jwks.json (STS)'
+    'WALLET_CREDENTIAL_ISSUANCE_01_GET_/authorize(STS)',
+    'WALLET_CREDENTIAL_ISSUANCE_02_GET_/.well-known/jwks.json(STS)',
+    'WALLET_CREDENTIAL_ISSUANCE_03_GET_/authorize(Orchestration)_StubCall',
+    'WALLET_CREDENTIAL_ISSUANCE_04_GET_/redirect',
+    'WALLET_CREDENTIAL_ISSUANCE_05_GET_/.well-known/jwks.json(STS)',
+    'WALLET_CREDENTIAL_ISSUANCE_06_POST_/generate-client-attestation_StubCall', //pragma: allowlist secret
+    'WALLET_CREDENTIAL_ISSUANCE_07_POST_/token (authorization code exchange)',
+    'WALLET_CREDENTIAL_ISSUANCE_08_POST_/token (access token exchange)',
+    'WALLET_CREDENTIAL_ISSUANCE_09_GET_/.well-known/jwks.json (STS)',
+    'WALLET_CREDENTIAL_ISSUANCE_10_GET_/generate-pre-auth-code_StubCall', //pragma: allowlist secret
+    'WALLET_CREDENTIAL_ISSUANCE_11_POST_/token(accessTokenExchange)',
+    'WALLET_CREDENTIAL_ISSUANCE_12_POST_/token(pre-authorizedCodeExchange)',
+    'WALLET_CREDENTIAL_ISSUANCE_13_GET_/.well-known/jwks.json(STS)'
   ],
   generateReauthenticationTestData: [
-    '01 GET /authorize (STS)',
-    '02 GET /authorize (Orchestration)',
-    '03 GET /redirect',
-    '04 POST /generate-client-attestation',
-    '05 POST /token (authorization code exchange)'
+    '01_GET_/authorize(STS)',
+    '02_GET_/authorize(Orchestration)_StubCall',
+    '03_GET_/redirect',
+    '04_POST_/generate-client-attestation_StubCall',
+    '05_POST_/token(authorizationCodeExchange)'
   ],
   accountIntervention: [
-    'B04_AIS_01 GET /authorize (STS)',
-    'B04_AIS_02 GET /authorize (Orchestration)',
-    'B04_AIS_03 GET /redirect',
-    'B04_AIS_04 POST /generate-client-attestation',
-    'B04_AIS_05 POST /token (authorization code exchange)'
+    'B04_AIS_01_GET_/authorize(STS)',
+    'B04_AIS_02_GET_/authorize(Orchestration)_StubCall',
+    'B04_AIS_03_GET_/redirect',
+    'B04_AIS_04_POST_/generate-client-attestation_StubCall',
+    'B04_AIS_05_POST_/token(authorizationCodeExchange)'
   ]
 } as const
 


### PR DESCRIPTION
## QA-1460<!--Jira Ticket Number-->

### What?
Added a "Stub Call" suffix to the scenario steps in the Mobile scripts. This helps clearly distinguish between stub and core service calls during test execution

#### Changes:
- STS: Added the "Stub Call" suffix to all scenarios and removed duplicate/unnecessary spaces from step names.
- Mobile BE: Added the "Stub Call" suffix to all scenarios and removed duplicate/unnecessary spaces from step names.
- MobileIDCheckAsync: Added the "Stub Call" suffix to all scenarios and removed duplicate/unnecessary spaces from step names.
- FE and BE Combined Test: Added sequential step numbers for better tracking and removed duplicate/unnecessary spaces from step names.

---

### Why?
To allow immediate visibility into whether a step is a stub call or a core call directly. This eliminates the need to cross-reference or dig through historical reports to verify the call type.

---

### Related:
-  Smoke Test executed locally for the changed scripts 
