### PR TITLE
[QA-1716]: Koa-Stub - Upgrade NodeJS version in koa-stub from v20 to v24

### DIFF
--- a/.github/workflows/koa-stub-main.yaml
+++ b/.github/workflows/koa-stub-main.yaml
@@ -25,10 +25,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v20
+      - name: Setup nodeJS v24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci
@@ -63,10 +63,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v20
+      - name: Setup nodeJS v24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
 

--- a/.github/workflows/koa-stub-pr.yaml
+++ b/.github/workflows/koa-stub-pr.yaml
@@ -46,10 +46,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v20
+      - name: Setup nodeJS v24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## QA-1716 <!--Jira Ticket Number-->

### What?
Koa-Stub - Upgrade NodeJS version in koa-stub from v20 to v24

#### Changes:
- Upgraded nodeJS version from v20 to v24 in `.github/workflows/koa-stub-main.yaml`
- Upgraded nodeJS version from v20 to v24 in `.github/workflows/koa-stub-pr.yaml`

---

### Why?
This is to fix the github actions error for Koa stub.