### PR TITLE
[QA-1720]:Correct the Iteration 10 peak‑test landing‑page target iteration value.

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -423,7 +423,7 @@ const profiles: ProfileList = {
     ...createOLHPeakTestScenario('changePassword', 12, 33, 1),
     ...createOLHPeakTestScenario('changePhone', 12, 38, 1),
     ...createOLHPeakTestScenario('deleteAccount', 12, 28, 1),
-    ...createI4PeakTestSignInScenario('landingPage', 1038, 13, 6),
+    ...createI4PeakTestSignInScenario('landingPage', 18, 13, 6),
     ...createOLHPeakTestScenario('setUpPasskey', 12, 33, 1),
     ...createOLHPeakTestScenario('removePasskey', 12, 33, 1)
   },

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -419,13 +419,13 @@ const profiles: ProfileList = {
   },
 
   perf006Iteration10PeakTest: {
-    ...createOLHPeakTestScenario('changeEmail', 12, 38, 1),
-    ...createOLHPeakTestScenario('changePassword', 12, 33, 1),
-    ...createOLHPeakTestScenario('changePhone', 12, 38, 1),
-    ...createOLHPeakTestScenario('deleteAccount', 12, 28, 1),
-    ...createI4PeakTestSignInScenario('landingPage', 18, 13, 6),
-    ...createOLHPeakTestScenario('setUpPasskey', 12, 33, 1),
-    ...createOLHPeakTestScenario('removePasskey', 12, 33, 1)
+    ...createOLHPeakTestScenario('changeEmail', 17, 38, 1),
+    ...createOLHPeakTestScenario('changePassword', 17, 33, 1),
+    ...createOLHPeakTestScenario('changePhone', 17, 38, 1),
+    ...createOLHPeakTestScenario('deleteAccount', 17, 28, 1),
+    ...createI4PeakTestSignInScenario('landingPage', 26, 13, 6),
+    ...createOLHPeakTestScenario('setUpPasskey', 17, 33, 1),
+    ...createOLHPeakTestScenario('removePasskey', 17, 33, 1)
   },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeOLHScenario('changeEmail', 12, 24, 1),

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -417,16 +417,6 @@ const profiles: ProfileList = {
     ...createOLHPeakTestScenario('deleteAccount', 6, 18, 1),
     ...createI4PeakTestSignInScenario('landingPage', 12, 9, 6)
   },
-
-  perf006Iteration10PeakTest: {
-    ...createOLHPeakTestScenario('changeEmail', 17, 38, 1),
-    ...createOLHPeakTestScenario('changePassword', 17, 33, 1),
-    ...createOLHPeakTestScenario('changePhone', 17, 38, 1),
-    ...createOLHPeakTestScenario('deleteAccount', 17, 28, 1),
-    ...createI4PeakTestSignInScenario('landingPage', 26, 13, 6),
-    ...createOLHPeakTestScenario('setUpPasskey', 17, 33, 1),
-    ...createOLHPeakTestScenario('removePasskey', 17, 33, 1)
-  },
   perf006Iteration8SpikeTest: {
     ...createI3SpikeOLHScenario('changeEmail', 12, 24, 1),
     ...createI3SpikeOLHScenario('changePassword', 12, 21, 1),
@@ -440,6 +430,16 @@ const profiles: ProfileList = {
     ...createStressTestOLHScenario('changePhone', 18, 24, 1),
     ...createStressTestOLHScenario('deleteAccount', 18, 18, 1),
     ...createStressTestSignInScenario('landingPage', 24, 6, 12)
+  },
+
+  perf006Iteration10PeakTest: {
+    ...createOLHPeakTestScenario('changeEmail', 17, 38, 1),
+    ...createOLHPeakTestScenario('changePassword', 17, 33, 1),
+    ...createOLHPeakTestScenario('changePhone', 17, 38, 1),
+    ...createOLHPeakTestScenario('deleteAccount', 17, 28, 1),
+    ...createI4PeakTestSignInScenario('landingPage', 26, 13, 6),
+    ...createOLHPeakTestScenario('setUpPasskey', 17, 33, 1),
+    ...createOLHPeakTestScenario('removePasskey', 17, 33, 1)
   }
 }
 


### PR DESCRIPTION
## QA-1720 <!--Jira Ticket Number-->

### What?
Correct the value of the landing page.

#### Changes:
- Detail individual changes in bullet points

Correct the value of the landing page function target from 1038  per to 18  so it runs at 1038 journeys per sec/18 journeys per min.

### Why?
To run the I10 peak test at the correct journeys rate for landing page 

---


