### PR TITLE
[QA-1724]: Load Profiles - Align the steady state durations of Sign Up and Sign in scenarios

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -341,8 +341,8 @@ const profiles: ProfileList = {
   },
   perf006Iteration10PeakTest: {
     ...createI4PeakTestSignUpScenario('signUp', 75, 43, 751),
-    ...createI4PeakTestSignInScenario('signIn', 187, 23, 86),
-    ...createI4PeakTestSignInScenario('passkeyCreationSignIn', 80, 55, 37),
+    ...createI4PeakTestSignInScenario('signIn', 214, 23, 98, 653),
+    ...createI4PeakTestSignInScenario('passkeyCreationSignIn', 80, 55, 37, 714),
     ...createI4PeakTestSignInScenario('amcHealthCheck', 80, 3, 37)
   }
 }

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -358,8 +358,9 @@ function createPerfTestScenario(
   target: number,
   iterationDuration: number,
   rampUpDuration: number,
-  holdDuration: string,
-  config: RampUpConfig
+  steadyStateDuration: string,
+  config: RampUpConfig,
+  phaseDelay: number = 0
 ): ScenarioList {
   const list: ScenarioList = {}
   const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
@@ -372,8 +373,9 @@ function createPerfTestScenario(
     preAllocatedVUs,
     maxVUs,
     stages: [
+      ...(phaseDelay > 0 ? [{ target: config.startRate, duration: `${phaseDelay}s` }] : []),
       { target, duration: `${rampUpDuration}s` },
-      { target, duration: holdDuration }
+      { target, duration: steadyStateDuration }
     ],
     exec
   }
@@ -385,18 +387,20 @@ export function createI4PeakTestSignUpScenario(
   exec: string,
   target: number,
   iterationDuration: number,
-  rampUpDuration: number
+  rampUpDuration: number,
+  phaseDelay: number = 0
 ): ScenarioList {
-  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signUpConfig)
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signUpConfig, phaseDelay)
 }
 
 export function createI4PeakTestSignInScenario(
   exec: string,
   target: number,
   iterationDuration: number,
-  rampUpDuration: number
+  rampUpDuration: number,
+  phaseDelay: number = 0
 ): ScenarioList {
-  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signInConfig)
+  return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signInConfig, phaseDelay)
 }
 
 export function createI3SpikeOLHScenario(


### PR DESCRIPTION
## QA-1724 <!--Jira Ticket Number-->

### What?
Load Profiles - Align the steady state durations of Sign Up and Sign in scenarios

#### Changes:
- Currently for all our peak tests, the steady state timeline for Sign Up and Sign in is different as the ramp up durations are different. This results in the steady state load not being aligned for the entire duration.
- We are updating the createPerfTestScenario() function to add a phaseDelay parameter. 
- For scenarios with shorter ramp up duration we should add a phaseDelay value which would be the difference between the longer ramp up duration and the shorter ramp up duration.
- With this PR, we are also updating the volume targets for Authentication Iteration 10 testing. Attaching a screenshot showing evidence that the change has been validated locally and the steady state durations are now aligned

<img width="887" height="210" alt="image" src="https://github.com/user-attachments/assets/4e8f1560-735d-43f5-9d2e-fbc4a181ce7a" />


---

### Why?
To align the steady state durations of Sign Up and Sign in scenarios