### PR TITLE
[QA-1726]: AMC - Update Passkey sign in volume proportions and add fresh test data

### DIFF
--- a/deploy/scripts/src/authentication/test.ts
+++ b/deploy/scripts/src/authentication/test.ts
@@ -1271,9 +1271,9 @@ export function passkeyCreationSignIn(): void {
     }
   })
 
-  // 20% of users will sign in with a Passkey
+  // 67% of users who create a passkey will sign in with a Passkey which is 20% of the total Sign in volume.
 
-  if (Math.random() <= 0.2) {
+  if (Math.random() <= 0.67) {
     // B04_SignInWithPasskey_01_StubSubmit
     if (route === 'RP') {
       res = rpStubSubmit(groups)


### PR DESCRIPTION
## QA-1726 <!--Jira Ticket Number-->

### What?
AMC - Update Passkey sign in volume proportions and add fresh test data

#### Changes:
- Update Passkey sign in volume proportions. Up until now, we were testing Sign in with Passkey at 20% of Passkey Creation. We should be testing this at 20% of total Sign in volumes. - `deploy/scripts/src/authentication/test.ts`
- Add fresh test data for Passkey scenarios - `deploy/scripts/src/authentication/data/passkeyData.csv`

---

### Why?
To run another round of performance test for Passkey scenarios