### PR TITLE
QA-1730-TiCF CRI :  Update TiCF test to support testing against build environment with SIRA connected

### DIFF
--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -22,7 +22,9 @@ export function generateAuthCreateAccount(
   userID: string,
   emailID: string,
   pairWiseID: string,
-  journeyID: string
+  journeyID: string,
+  randomIP: string,
+  randomPhoneNumber: string
 ): AuthCreateAccount {
   return {
     event_id: `perfTestID_${uuidv4()}`,
@@ -34,11 +36,11 @@ export function generateAuthCreateAccount(
     user: {
       user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       email: emailID,
       session_id: uuidv4(),
       persistent_session_id: uuidv4(),
-      phone: '07777777777'
+      phone: randomPhoneNumber
     },
     extensions: {
       phone_number_country_code: 44,
@@ -47,7 +49,7 @@ export function generateAuthCreateAccount(
     restricted: {
       device_information: {
         request_timestamp_ms: Math.floor(Date.now()),
-        ip_address: '1.2.3.4',
+        ip_address: randomIP,
         connection_port: 12345,
         country_code: 'GB',
         user_agent: 'k6/0.52.0 (https://k6.io/)',
@@ -58,7 +60,13 @@ export function generateAuthCreateAccount(
   }
 }
 
-export function generateAuthLogInSuccess(userID: string, emailID: string, journeyID: string): AuthLogInSuccess {
+export function generateAuthLogInSuccess(
+  userID: string,
+  emailID: string,
+  journeyID: string,
+  randomIP: string,
+  randomPhoneNumber: string
+): AuthLogInSuccess {
   return {
     event_id: `perfTestID_${uuidv4()}`,
     event_name: 'AUTH_LOG_IN_SUCCESS',
@@ -69,11 +77,11 @@ export function generateAuthLogInSuccess(userID: string, emailID: string, journe
     user: {
       user_id: userID, // `${testID}_performanceTestClientId_${userID}_performanceTestCommonSubjectId`,
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       session_id: uuidv4(),
       email: emailID,
       persistent_session_id: uuidv4(),
-      phone: '07777777777'
+      phone: randomPhoneNumber
     },
     extensions: {
       phone_number_country_code: 44
@@ -81,7 +89,7 @@ export function generateAuthLogInSuccess(userID: string, emailID: string, journe
     restricted: {
       device_information: {
         request_timestamp_ms: Math.floor(Date.now()),
-        ip_address: '1.2.3.4',
+        ip_address: randomIP,
         connection_port: 12345,
         country_code: 'GB',
         user_agent: 'k6/0.52.0 (https://k6.io/)',
@@ -139,7 +147,7 @@ export function generateDcmawAbortWeb(userID: string, journeyID: string, emailID
   }
 }
 
-export function generateAuthAuthorisationInitiated(journeyID: string): AuthAuthorisationInitiated {
+export function generateAuthAuthorisationInitiated(journeyID: string, randomIP: string): AuthAuthorisationInitiated {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -153,14 +161,19 @@ export function generateAuthAuthorisationInitiated(journeyID: string): AuthAutho
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4()
     }
   }
 }
 
-export function generateAuthCodeVerified(emailID: string, journeyID: string, userID: string): AuthCodeVerified {
+export function generateAuthCodeVerified(
+  emailID: string,
+  journeyID: string,
+  userID: string,
+  randomIP: string
+): AuthCodeVerified {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -179,7 +192,7 @@ export function generateAuthCodeVerified(emailID: string, journeyID: string, use
     user: {
       email: emailID,
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4(),
       user_id: userID
@@ -190,7 +203,9 @@ export function generateAuthCodeVerified(emailID: string, journeyID: string, use
 export function generateAuthUpdatePhone(
   emailID: string,
   journeyID: string,
-  userID: string
+  userID: string,
+  randomIP: string,
+  randomPhoneNumber: string
 ): AuthUpdateProfilePhoneNumber {
   return {
     client_id: 'performanceTestClientId',
@@ -207,16 +222,16 @@ export function generateAuthUpdatePhone(
     user: {
       email: emailID,
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
-      phone: '07123456789',
+      phone: randomPhoneNumber,
       session_id: uuidv4(),
       user_id: userID
     }
   }
 }
 
-export function generateIPVJourneyStart(journeyID: string, userID: string): IPVJourneyStart {
+export function generateIPVJourneyStart(journeyID: string, userID: string, randomIP: string): IPVJourneyStart {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -235,14 +250,14 @@ export function generateIPVJourneyStart(journeyID: string, userID: string): IPVJ
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       session_id: uuidv4(),
       user_id: userID
     }
   }
 }
 
-export function generateIPVSubJourneyStart(journeyID: string, userID: string): IPVSubJourneyStart {
+export function generateIPVSubJourneyStart(journeyID: string, userID: string, randomIP: string): IPVSubJourneyStart {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -260,14 +275,14 @@ export function generateIPVSubJourneyStart(journeyID: string, userID: string): I
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       session_id: uuidv4(),
       user_id: userID
     }
   }
 }
 
-export function generateIPVDLCRIVCIssued(userID: string, journeyID: string): IPVDLCRIVCIssued {
+export function generateIPVDLCRIVCIssued(userID: string, journeyID: string, randomIP: string): IPVDLCRIVCIssued {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -331,7 +346,7 @@ export function generateIPVDLCRIVCIssued(userID: string, journeyID: string): IPV
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4(),
       user_id: userID
@@ -339,7 +354,11 @@ export function generateIPVDLCRIVCIssued(userID: string, journeyID: string): IPV
   }
 }
 
-export function generateIPVAddressCRIVCIssued(journeyID: string, userID: string): IPVAddressCRIVCIssued {
+export function generateIPVAddressCRIVCIssued(
+  journeyID: string,
+  userID: string,
+  randomIP: string
+): IPVAddressCRIVCIssued {
   return {
     client_id: 'performanceTestClientId',
     event_id: `perfTestID_${uuidv4()}`,
@@ -368,7 +387,7 @@ export function generateIPVAddressCRIVCIssued(journeyID: string, userID: string)
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4(),
       user_id: userID
@@ -376,7 +395,7 @@ export function generateIPVAddressCRIVCIssued(journeyID: string, userID: string)
   }
 }
 
-export function generateIPVKBVCRIStart(journeyID: string, userID: string): IPVKBVCRIStart {
+export function generateIPVKBVCRIStart(journeyID: string, userID: string, randomIP: string): IPVKBVCRIStart {
   return {
     client_id: 'performanceTestClientID',
     event_id: `perfTestID_${uuidv4()}`,
@@ -391,7 +410,7 @@ export function generateIPVKBVCRIStart(journeyID: string, userID: string): IPVKB
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4(),
       user_id: userID
@@ -399,7 +418,7 @@ export function generateIPVKBVCRIStart(journeyID: string, userID: string): IPVKB
   }
 }
 
-export function generateIPVKBVCRIEnd(journeyID: string, userID: string): IPVKBVCRIEnd {
+export function generateIPVKBVCRIEnd(journeyID: string, userID: string, randomIP: string): IPVKBVCRIEnd {
   return {
     client_id: 'performanceTestClientID',
     event_id: `perfTestID_${uuidv4()}`,
@@ -409,7 +428,7 @@ export function generateIPVKBVCRIEnd(journeyID: string, userID: string): IPVKBVC
     timestamp: Math.floor(Date.now() / 1000),
     user: {
       govuk_signin_journey_id: journeyID,
-      ip_address: '1.2.3.4',
+      ip_address: randomIP,
       persistent_session_id: uuidv4(),
       session_id: uuidv4(),
       user_id: userID

--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -1,4 +1,5 @@
 import { uuidv4 } from '../utils/jslib/index'
+
 import {
   AuthLogInSuccess,
   AuthCreateAccount,
@@ -500,4 +501,12 @@ export function generateAuthReqParsedEnrichment(
       obfuscated: true
     }
   }
+}
+
+export function generateRandomIP(): string {
+  return Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
+}
+
+export function generateRandomPhoneNumber(): string {
+  return '07' + Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('')
 }

--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -132,20 +132,26 @@ export function signUpSuccess(groupName: string, userID: string, emailID: string
   const testID = `perfTestID${timestamp}`
   const pairWiseID = `performanceTestRpPairwiseId${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
+  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
+  const randomPhoneNumber = '07' + Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('')
 
-  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
   sleep(3)
 
-  const authCreateAccPayload = JSON.stringify(generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID))
+  const authCreateAccPayload = JSON.stringify(
+    generateAuthCreateAccount(testID, userID, emailID, pairWiseID, journeyID, randomIP, randomPhoneNumber)
+  )
   sqs.sendMessage(env.sqs_queue, authCreateAccPayload)
   sleep(3)
 
-  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID))
+  const authCodeVerifiedPayload = JSON.stringify(generateAuthCodeVerified(emailID, journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, authCodeVerifiedPayload)
   sleep(3)
 
-  const authUpdatePhonePayload = JSON.stringify(generateAuthUpdatePhone(emailID, journeyID, userID))
+  const authUpdatePhonePayload = JSON.stringify(
+    generateAuthUpdatePhone(emailID, journeyID, userID, randomIP, randomPhoneNumber)
+  )
   sqs.sendMessage(env.sqs_queue, authUpdatePhonePayload)
   sleep(3)
 
@@ -166,11 +172,16 @@ export function signUpSuccess(groupName: string, userID: string, emailID: string
 
 export function signInSuccess(groupName: string, userID: string, emailID: string): void {
   const journeyID = `perfJourney${uuidv4()}`
-  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
+  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
+  const randomPhoneNumber = '07' + Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('')
+
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
   sleep(3)
 
-  const authLogInSuccessPayload = JSON.stringify(generateAuthLogInSuccess(userID, emailID, journeyID))
+  const authLogInSuccessPayload = JSON.stringify(
+    generateAuthLogInSuccess(userID, emailID, journeyID, randomIP, randomPhoneNumber)
+  )
   sqs.sendMessage(env.sqs_queue, authLogInSuccessPayload)
   sleep(3)
 
@@ -189,8 +200,9 @@ export function signInSuccess(groupName: string, userID: string, emailID: string
 
 export function signInSilent(groupName: string, userID: string): void {
   const journeyID = `perfJourney${uuidv4()}`
+  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
-  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID))
+  const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
   sleep(3)
 
@@ -209,28 +221,29 @@ export function signInSilent(groupName: string, userID: string): void {
 
 export function identityProvingSuccess(groupName: string, userID: string): void {
   const journeyID = `perfJourney${uuidv4()}`
+  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
-  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID))
+  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvJourneyStartPayload)
   sleep(3)
 
-  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID))
+  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvSubJourneyStartPayload)
   sleep(3)
 
-  const ipvDLCRIVCIssuedPayload = JSON.stringify(generateIPVDLCRIVCIssued(userID, journeyID))
+  const ipvDLCRIVCIssuedPayload = JSON.stringify(generateIPVDLCRIVCIssued(userID, journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvDLCRIVCIssuedPayload)
   sleep(3)
 
-  const ipvAddressCRIVCIssuedPayload = JSON.stringify(generateIPVAddressCRIVCIssued(journeyID, userID))
+  const ipvAddressCRIVCIssuedPayload = JSON.stringify(generateIPVAddressCRIVCIssued(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvAddressCRIVCIssuedPayload)
   sleep(3)
 
-  const ipvKBVCRIStartPayload = JSON.stringify(generateIPVKBVCRIStart(journeyID, userID))
+  const ipvKBVCRIStartPayload = JSON.stringify(generateIPVKBVCRIStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvKBVCRIStartPayload)
   sleep(3)
 
-  const ipvKBVCRIEndPayload = JSON.stringify(generateIPVKBVCRIEnd(journeyID, userID))
+  const ipvKBVCRIEndPayload = JSON.stringify(generateIPVKBVCRIEnd(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvKBVCRIEndPayload)
   sleep(3)
 
@@ -255,12 +268,13 @@ export function identityProvingSuccess(groupName: string, userID: string): void 
 
 export function identityReuseSuccess(groupName: string, userID: string): void {
   const journeyID = `perfJourney${uuidv4()}`
+  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
-  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID))
+  const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvJourneyStartPayload)
   sleep(3)
 
-  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID))
+  const ipvSubJourneyStartPayload = JSON.stringify(generateIPVSubJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvSubJourneyStartPayload)
   sleep(3)
 

--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -22,7 +22,9 @@ import {
   generateIPVSubJourneyStart,
   generateIPVKBVCRIEnd,
   generateIPVKBVCRIStart,
-  generateAuthAuthorisationInitiated
+  generateAuthAuthorisationInitiated,
+  generateRandomIP,
+  generateRandomPhoneNumber
 } from '../common/requestGenerator/txmaReqGen'
 import { uuidv4 } from '../common/utils/jslib/index'
 import http from 'k6/http'
@@ -127,13 +129,17 @@ const awsConfig = new AWSConfig({
 
 const sqs = new SQSClient(awsConfig)
 
-export function signUpSuccess(groupName: string, userID: string, emailID: string): void {
+export function signUpSuccess(
+  groupName: string,
+  userID: string,
+  emailID: string,
+  randomIP: string,
+  randomPhoneNumber: string
+): void {
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '') // YYMMDDTHHmmss
   const testID = `perfTestID${timestamp}`
   const pairWiseID = `performanceTestRpPairwiseId${uuidv4()}`
   const journeyID = `perfJourney${uuidv4()}`
-  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
-  const randomPhoneNumber = '07' + Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('')
 
   const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
@@ -170,10 +176,14 @@ export function signUpSuccess(groupName: string, userID: string, emailID: string
   })
 }
 
-export function signInSuccess(groupName: string, userID: string, emailID: string): void {
+export function signInSuccess(
+  groupName: string,
+  userID: string,
+  emailID: string,
+  randomIP: string,
+  randomPhoneNumber: string
+): void {
   const journeyID = `perfJourney${uuidv4()}`
-  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
-  const randomPhoneNumber = '07' + Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('')
 
   const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
@@ -198,9 +208,8 @@ export function signInSuccess(groupName: string, userID: string, emailID: string
   })
 }
 
-export function signInSilent(groupName: string, userID: string): void {
+export function signInSilent(groupName: string, userID: string, randomIP: string): void {
   const journeyID = `perfJourney${uuidv4()}`
-  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
   const authAuthorisationInitiatedPayload = JSON.stringify(generateAuthAuthorisationInitiated(journeyID, randomIP))
   sqs.sendMessage(env.sqs_queue, authAuthorisationInitiatedPayload)
@@ -219,9 +228,8 @@ export function signInSilent(groupName: string, userID: string): void {
   })
 }
 
-export function identityProvingSuccess(groupName: string, userID: string): void {
+export function identityProvingSuccess(groupName: string, userID: string, randomIP: string): void {
   const journeyID = `perfJourney${uuidv4()}`
-  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
   const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvJourneyStartPayload)
@@ -266,9 +274,8 @@ export function identityProvingSuccess(groupName: string, userID: string): void 
   )
 }
 
-export function identityReuseSuccess(groupName: string, userID: string): void {
+export function identityReuseSuccess(groupName: string, userID: string, randomIP: string): void {
   const journeyID = `perfJourney${uuidv4()}`
-  const randomIP = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.')
 
   const ipvJourneyStartPayload = JSON.stringify(generateIPVJourneyStart(journeyID, userID, randomIP))
   sqs.sendMessage(env.sqs_queue, ipvJourneyStartPayload)
@@ -300,16 +307,18 @@ export function identityReuseSuccess(groupName: string, userID: string): void {
 export function ticf(): void {
   const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
   const emailID = `perfHappyPath${uuidv4()}@digital.cabinet-office.gov.uk`
+  const randomIP = generateRandomIP()
+  const randomPhoneNumber = generateRandomPhoneNumber()
 
   iterationsStarted.add(1)
 
-  signUpSuccess(groupMap.ticf[0], userID, emailID)
+  signUpSuccess(groupMap.ticf[0], userID, emailID, randomIP, randomPhoneNumber)
   sleep(3)
-  signInSuccess(groupMap.ticf[1], userID, emailID)
+  signInSuccess(groupMap.ticf[1], userID, emailID, randomIP, randomPhoneNumber)
   sleep(3)
-  identityProvingSuccess(groupMap.ticf[2], userID)
+  identityProvingSuccess(groupMap.ticf[2], userID, randomIP)
   sleep(3)
-  identityReuseSuccess(groupMap.ticf[3], userID)
+  identityReuseSuccess(groupMap.ticf[3], userID, randomIP)
 
   iterationsCompleted.add(1)
 }
@@ -317,14 +326,16 @@ export function ticf(): void {
 export function silentLogin(): void {
   const userID = `urn:fdc:gov.uk:2022:${uuidv4()}`
   const emailID = `perfSilentLogin${uuidv4()}@digital.cabinet-office.gov.uk`
+  const randomIP = generateRandomIP()
+  const randomPhoneNumber = generateRandomPhoneNumber()
 
   iterationsStarted.add(1)
 
-  signUpSuccess(groupMap.silentLogin[0], userID, emailID)
+  signUpSuccess(groupMap.silentLogin[0], userID, emailID, randomIP, randomPhoneNumber)
   sleep(3)
-  signInSuccess(groupMap.silentLogin[1], userID, emailID)
+  signInSuccess(groupMap.silentLogin[1], userID, emailID, randomIP, randomPhoneNumber)
   sleep(3)
-  identityProvingSuccess(groupMap.silentLogin[2], userID)
+  identityProvingSuccess(groupMap.silentLogin[2], userID, randomIP)
 
   iterationsCompleted.add(1)
 }


### PR DESCRIPTION
## QA-1730

### What?
This PR is to update the TiCF performance test scripts to correctly populate randomised IP addresses and phone numbers across TxMA event payloads, enabling accurate testing of the TiCF journey in the build environment while connected to SIRA.

#### Changes:
**txmaReqGen.ts :** 
1. Updated generateAuthLogInSuccess, generateAuthCodeVerified, generateAuthUpdatePhone, generateIPVJourneyStart, generateIPVSubJourneyStart, generateIPVDLCRIVCIssued, generateIPVAddressCRIVCIssued, generateIPVKBVCRIStart and generateIPVKBVCRIEnd to accept randomIP and/or randomPhoneNumber as parameters instead of using hardcoded values
2. Updated generateAuthCreateAccount device_information ip_address to use randomIP instead of the hardcoded 1.2.3.4

**ticf.ts:**
1. Updated signUpSuccess, signInSuccess, signInSilent, identityProvingSuccess and identityReuseSuccess to generate a randomIP per journey and pass it through to all event generator calls
2. Updated signInSuccess to also generate randomPhoneNumber and pass it to generateAuthLogInSuccess

---

### Why?
Previously while build environment was connected to SIRA mock,  TxMA event generator functions in the TiCF test script used hardcoded IP addresses (1.2.3.4) and phone numbers (07777777777). While testing against the build environment with SIRA connected, production realistic and varied request data is required to properly mimic the SIRA risk assessment. 

---
