### PR TITLE
QA-1731: To add ticfSingleIteration debug profile for single user and iteration

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -79,6 +79,20 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignInScenario('ticf', 250, 66, 115),
     ...createStressTestSignInScenario('silentLogin', 75, 63, 35, 26)
+  },
+  ticfSingleIteration: {
+    ticf: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 1,
+      exec: 'ticf'
+    },
+    silentLogin: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 1,
+      exec: 'silentLogin'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1731

### What?
This PR is to add a new single iteration, single user debug profile

#### Changes:
- Adds a new ticfSingleIteration profile to the TICF performance test script using the `per-vu-iterations` executor with vus: 1 and iterations: 1 for both `ticf` and `silentLogin` scenarios. 
---

### Why?
This allows a single controlled execution for one user - one iteration, making it easier to debug the downstream SIRA test data issues


