### PR TITLE
QA-1733 -  Reduce ja3_fingerprint string length to 32 characters to support real SIRA BE test

### DIFF
--- a/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
+++ b/deploy/scripts/src/common/requestGenerator/txmaReqGen.ts
@@ -55,7 +55,7 @@ export function generateAuthCreateAccount(
         country_code: 'GB',
         user_agent: 'k6/0.52.0 (https://k6.io/)',
         accepted_language: 24234233,
-        ja3_fingerprint: uuidv4()
+        ja3_fingerprint: uuidv4().replace(/-/g, '')
       }
     }
   }
@@ -95,7 +95,7 @@ export function generateAuthLogInSuccess(
         country_code: 'GB',
         user_agent: 'k6/0.52.0 (https://k6.io/)',
         accepted_language: 24234233,
-        ja3_fingerprint: uuidv4()
+        ja3_fingerprint: uuidv4().replace(/-/g, '')
       }
     }
   }
@@ -470,7 +470,7 @@ export function generateAuthLogInSuccessEnrichment(
         country_code: 'GB',
         user_agent: 'k6/0.52.0 (https://k6.io/)',
         accepted_language: 24234233,
-        ja3_fingerprint: uuidv4()
+        ja3_fingerprint: uuidv4().replace(/-/g, '')
       }
     }
   }


### PR DESCRIPTION
## QA-1733

### What?
This PR is to apply the changes in txmaReqGen.ts scritp to reduced the ja3_fingerprint value from 36 characters to 32 characters by stripping hyphens from the generated UUID.

#### Changes:
- Updated ja3_fingerprint in generateAuthCreateAccount, generateAuthLogInSuccess, and generateAuthLogInSuccessEnrichment to use uuidv4().replace(/-/g, '') instead of raw uuidv4()

---

### Why?
The product team have confirmed that the ja3_fingerprint field be limited to 32 characters to align with the standard JA3 fingerprint format
