### PR TITLE
QA-1734: Add TiCF SIRA 10 iterations per second test profile

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -93,6 +93,9 @@ const profiles: ProfileList = {
       iterations: 1,
       exec: 'silentLogin'
     }
+  },
+  ticfSIRA10ItersTest: {
+    ...createI4PeakTestSignInScenario('ticf', 10, 66, 6)
   }
 }
 


### PR DESCRIPTION
## QA-1734

### What?
This PR is to add a new peak test profile `ticfSIRA10ItersTest` to the fraud/ticf.ts load test script.

#### Changes:
- Added `ticfSIRA10ItersTest` profile in ticf.ts using `createI4PeakTestSignInScenario` targeting 10 iterations/sec for the ticf scenario with a 6 second ramp-up duration
- Each iteration sends 14 SQS messages and makes 4 API calls

### Why?
To generate load & test ticf BUILD which is connected to UAT SIRA