### PR TITLE
[QA-1737]: Remove statsD output from k6 run command

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -674,7 +674,7 @@ Resources:
             build:
               commands:
                 - echo "Run performance test"
-                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out output-statsd --out json=$JSON_RESULTS
+                - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=$AWS_ACCOUNT_ID --out json=$JSON_RESULTS
             post_build:
               commands:
                 - echo "Uploading test results to s3"


### PR DESCRIPTION
## QA-1737 <!--Jira Ticket Number-->

### What?
Remove statsD output from k6 run command in Codebuild build design.

#### Changes:
- Remove statsD output from k6 run command
- We are currently getting connection refused errors while trying to send statsD output to Dynatrace
- This PR removes the statsD output temporarily.

---

### Why?
To allow test executions to continue without statsD output while this is investigated separately.