### PR TITLE
[QA-1735]:IPV Core - Add I10PeakProfile,fix page verification, create test data

### DIFF
--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -876,7 +876,7 @@ export function idReuse(): void {
       () =>
         http.get(
           env.orchStubEndPoint +
-            `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=${env.vtrText}&targetEnvironment=${environment}&reproveIdentity=NOT_PRESENT&emailAddress=${idReuseUserID.emailID}&votText=&jsonPayload=&evidenceJsonPayload=&error=recoverable`,
+            `/authorize?journeyType=full&userIdText=${idReuseUserID.userID}&signInJourneyIdText=${signInJourneyId}&vtrText=${env.vtrText}&targetEnvironment=${environment}&emailAddress=${idReuseUserID.emailID}&error=recoverable`,
           {
             headers: { Authorization: `Basic ${encodedCredentials}` },
             redirects: 0

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -420,6 +420,10 @@ const profiles: ProfileList = {
   perf006Iteration9SoakTest: {
     ...createSoakTestSignUpScenario('identity', 100, 42, 101),
     ...createSoakTestSignInScenario('idReuse', 15, 6, 8)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('identity', 200, 42, 751),
+    ...createI4PeakTestSignInScenario('idReuse', 267, 6, 122, 629)
   }
 }
 
@@ -883,7 +887,7 @@ export function idReuse(): void {
     // 02_CoreCall
     res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('You have already proved your identity')
+      ...pageContentCheck('Confirm your details')
     })
   })
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -422,8 +422,8 @@ const profiles: ProfileList = {
     ...createSoakTestSignInScenario('idReuse', 15, 6, 8)
   },
   perf006Iteration10PeakTest: {
-    ...createI4PeakTestSignUpScenario('identity', 200, 42, 751),
-    ...createI4PeakTestSignInScenario('idReuse', 267, 6, 122, 629)
+    ...createI4PeakTestSignUpScenario('identity', 200, 42, 201),
+    ...createI4PeakTestSignInScenario('idReuse', 267, 6, 122, 79)
   }
 }
 
@@ -887,7 +887,7 @@ export function idReuse(): void {
     // 02_CoreCall
     res = timeGroup(groups[2].split('::')[1], () => http.get(res.headers.Location), {
       isStatusCode200,
-      ...pageContentCheck('Confirm your details')
+      ...pageContentCheck('You completed your identity check online or at a Post Office using these details')
     })
   })
 


### PR DESCRIPTION
## QA-1735 <!--Jira Ticket Number-->

### What?
Add I10PeakProfile, fix page verification, create test data

#### Changes:
- Add Iteration 10 Peak load Profile
  -   Identity at 20 journeys per sec
  -   IdReuse at 278 journeys per sec

- Fix page verification, 
  - Changed page verification to match product teams' changes to page title.

- Create test data as old was no longer valid
---

### Why?
To enable running the IPV-Core Iteration 10 Peak test
---

