### PR TITLE
[QA-1741]: Add CIMIT Peak test load profile for I10

### DIFF
--- a/deploy/scripts/src/trust-and-reuse/cimit.ts
+++ b/deploy/scripts/src/trust-and-reuse/cimit.ts
@@ -78,6 +78,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('cimitIDProvingAPIs', 2520, 19, 631),
     ...createStressTestSignInScenario('cimitSignInAPI', 250, 6, 115, 172)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('cimitIDProvingAPIs', 800, 19, 201),
+    ...createI4PeakTestSignInScenario('cimitSignInAPI', 267, 6, 122, 79)
   }
 }
 


### PR DESCRIPTION
## QA-1741 <!--Jira Ticket Number-->

### What?
Add I10 CIMIT Peak test load profile

#### Changes:
- cimitIDProvingAPIs : Target Throughput  is 80 J/Sec and Ramp-up is 201s
-  cimitSignInAPI:  Target Throughput is 267, and Ramp up is 122s

---

### Why?
To Conduct I10 Peak test 

---


