### PR TITLE
[QA-1736]:Add  EVCS-SIS combined Peak test profile for I10

### DIFF
--- a/deploy/scripts/src/trust-and-reuse/evcs-sis.ts
+++ b/deploy/scripts/src/trust-and-reuse/evcs-sis.ts
@@ -94,6 +94,12 @@ const profiles: ProfileList = {
     ...createStressTestSignInScenario('invalidate', 250, 6, 115, 172),
     ...createStressTestSignUpScenario('updateVC', 630, 7, 631),
     ...createStressTestSignInScenario('summariseVC', 250, 6, 115, 172)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('identity', 200, 11, 201),
+    ...createI4PeakTestSignInScenario('invalidate', 267, 6, 122, 79),
+    ...createI4PeakTestSignUpScenario('updateVC', 200, 7, 201),
+    ...createI4PeakTestSignInScenario('summariseVC', 267, 6, 122, 79)
   }
 }
 


### PR DESCRIPTION
## QA-1736 <!--Jira Ticket Number-->

### What?
Add  EVCS-SIS combined  I10 Peak test profile

#### Changes:
- identity - Target Throughput is 20 j/sec, Ramp-up is  201 sec
- invalidate - Target Throughput is  267 j/sec , Ramp-up is 122 sec
- updateVC - Target Throughput is  20 j/sec , Ramp-up is 201 sec
- summariseVC - Target Throughput is  267 j/sec , Ramp-up is 122 sec 


---

### Why?
To Conduct I10 peak test

---



