### PR TITLE
[QA-1740]: Transit Gateway: Remove content validation from client lambda call

### DIFF
--- a/deploy/scripts/src/tgw/test.ts
+++ b/deploy/scripts/src/tgw/test.ts
@@ -115,8 +115,7 @@ export function tgwClientLambda(): void {
 
   //  B01_TransitGateway_01_InvokeLambda
   timeGroup(groups[0], () => http.post(signedRequest.url, lambdaPayload, { headers: signedRequest.headers }), {
-    isStatusCode200,
-    ...pageContentCheck(env.targetUrl)
+    isStatusCode200
   })
 
   iterationsCompleted.add(1)


### PR DESCRIPTION
## QA-1740 <!--Jira Ticket Number-->

### What?
Transit Gateway: Remove content validation from `client` lambda call

#### Changes:
- Remove the page content validation from the `client` lambda call.

---

### Why?
The lambda invocation just returns a 200 OK response with a blank response body. We have cross checked the application logs and the lambda is working as expected.