### PR TITLE
[QA-1753] : Lime - Add Iteration 10 peak test profile for Lime scripts

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -350,6 +350,12 @@ const profiles: ProfileList = {
     ...createStressTestSignUpScenario('drivingLicence', 79, 9, 80),
     ...createStressTestSignUpScenario('drivingLicenceAttestation', 132, 9, 133),
     ...createStressTestSignUpScenario('fraud', 630, 6, 631)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('passport', 20, 6, 21),
+    ...createI4PeakTestSignUpScenario('drivingLicence', 25, 9, 26),
+    ...createI4PeakTestSignUpScenario('drivingLicenceAttestation', 42, 9, 43),
+    ...createI4PeakTestSignUpScenario('fraud', 200, 6, 201)
   }
 }
 


### PR DESCRIPTION
## QA-1753 <!--Jira Ticket Number-->

### What?
Lime - Add Iteration 10 peak test profile for Lime scripts

#### Changes:
- Passport CRI @ 2 journeys per second
- Driving Licence @ 2.5 journeys per second.
- DL Attestation @ 4.2 journeys per second.
- Fraud @ 20 journeys per second.

<img width="1000" height="124" alt="image" src="https://github.com/user-attachments/assets/a3d5fa1c-3f8d-4e0e-851a-4bafe7571cdd" />


---

### Why?
To conduct peak test for Lime CRIs in Iteration 10