### PR TITLE
[QA-1755]: Add Address Peak test load profile for I10

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -237,7 +237,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10PeakTest: {
     ...createI4PeakTestSignUpScenario('address', 100, 15, 101),
-    ...createStressTestSignUpScenario('addressME', 98, 15, 99, 101),
+    ...createStressTestSignUpScenario('addressME', 98, 15, 99, 2),
     ...createI4PeakTestSignUpScenario('internationalAddress', 2, 12, 3, 98)
   }
 }

--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -234,6 +234,11 @@ const profiles: ProfileList = {
     ...createStressTestSignUpScenario('address', 100, 15, 101, 174),
     ...createStressTestSignUpScenario('addressME', 520, 15, 622),
     ...createStressTestSignUpScenario('internationalAddress', 10, 12, 7, 205)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('address', 100, 15, 101),
+    ...createStressTestSignUpScenario('addressME', 98, 15, 99, 101),
+    ...createI4PeakTestSignUpScenario('internationalAddress', 2, 12, 3, 98)
   }
 }
 


### PR DESCRIPTION
## QA-1755 <!--Jira Ticket Number-->

### What?
I10 Load profiles: Adding Address Peak test profile 

#### Changes:
-  address - Target Throughput is 10 J/sec, Rampup is 101 sec
-  addressME - Target Throughput is 9.8 J/sec, Ramp up is 99 sec 
-  internationalAddress - Target Throughput is 2 J/sec, Rampup is 3 sec

---

### Why?
To Execute Iteration 10 Peak test

---

### 
-Related: Smoke test executed locally and 1 minute run on the Peak load profile is successful
<img width="1372" height="682" alt="image" src="https://github.com/user-attachments/assets/2e83c364-ad7c-4c7b-9582-6254618513ee" />
