### PR TITLE
[QA-1761]: Passport CRI - Update static resource flag to not call static requests in all the tests

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -416,7 +416,7 @@ const env = {
   drivingUrl: getEnv('IDENTITY_DRIVING_URL'),
   passportURL: getEnv('IDENTITY_PASSPORT_URL'),
   envName: getEnv('ENVIRONMENT'),
-  staticResources: __ENV.K6_NO_STATIC_RESOURCES !== 'true'
+  staticResources: __ENV.K6_NO_STATIC_RESOURCES === 'true'
 }
 
 const stubCreds = {


### PR DESCRIPTION
## QA-1761 <!--Jira Ticket Number-->

### What?
Passport CRI - Update static resource flag to not call static requests in all the tests

#### Changes:
- The flag `K6_NO_STATIC_RESOURCES` flag is incorrectly set to `false` which results in performance tests calling static assets in all the tests.
- Set `K6_NO_STATIC_RESOURCES` as `true` to ensure static assets are only called when needed for specific tests.

---

### Why?
To ensure static assets are only called when needed for specific tests.