### PR TITLE
[QA-1745]:AIS Add I10 Peak Load  Profile

### DIFF
--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -107,7 +107,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10PeakTest: {
     ...createI4PeakTestSignInScenario('persistIV', 30, 3, 900),
-    ...createI4PeakTestSignInScenario('retrieveIV', 801, 3, 122)
+    ...createI4PeakTestSignInScenario('retrieveIV', 801, 3, 122, 778)
   }
 }
 

--- a/deploy/scripts/src/ais/test.ts
+++ b/deploy/scripts/src/ais/test.ts
@@ -104,6 +104,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignInScenario('persistIV', 30, 3, 15, 33),
     ...createStressTestSignInScenario('retrieveIV', 750, 3, 115)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignInScenario('persistIV', 30, 3, 900),
+    ...createI4PeakTestSignInScenario('retrieveIV', 801, 3, 122)
   }
 }
 


### PR DESCRIPTION
## QA-1745 <!--Jira Ticket Number-->

### What?
AIS Add I10 Peak Load  Profile

#### Changes:
Add Iteration 10 Peak Load Profile: to the AIS test.
persistIV @ 20 Journeys per sec
RetrieveIV @ 801 Journeys per sec

---

### Why?
To run the iteration 10 test for AIS

---


