### PR TITLE
[QA-1755]: I10 - Address Peak Test profile updated from Signup profile name

### DIFF
--- a/deploy/scripts/src/cri-orange/address.ts
+++ b/deploy/scripts/src/cri-orange/address.ts
@@ -237,7 +237,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10PeakTest: {
     ...createI4PeakTestSignUpScenario('address', 100, 15, 101),
-    ...createStressTestSignUpScenario('addressME', 98, 15, 99, 2),
+    ...createI4PeakTestSignUpScenario('addressME', 98, 15, 99, 2),
     ...createI4PeakTestSignUpScenario('internationalAddress', 2, 12, 3, 98)
   }
 }


### PR DESCRIPTION
## QA-1755 <!--Jira Ticket Number-->

### What?
Update correct profile function for Address I10 peak test

#### Changes:
- For the `addressME` scenario, use the correct peak test load profile function `createI4PeakTestSignUpScenario` instead of `createStressTestSignUpScenario`

---

### Why?
To perform I10 Peak performance test using the correct load profile.