### PR TITLE
QA-1769: To update ticfSIRA2ItersTest profile for TICF fraud tests

### DIFF
--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -94,9 +94,6 @@ const profiles: ProfileList = {
       exec: 'silentLogin'
     }
   },
-  ticfSIRA10ItersTest: {
-    ...createI4PeakTestSignInScenario('ticf', 10, 66, 6)
-  },
   ticfSIRA2ItersTest: {
     ...createI4PeakTestSignInScenario('ticf', 2, 66, 2)
   }

--- a/deploy/scripts/src/fraud/ticf.ts
+++ b/deploy/scripts/src/fraud/ticf.ts
@@ -96,6 +96,9 @@ const profiles: ProfileList = {
   },
   ticfSIRA10ItersTest: {
     ...createI4PeakTestSignInScenario('ticf', 10, 66, 6)
+  },
+  ticfSIRA2ItersTest: {
+    ...createI4PeakTestSignInScenario('ticf', 2, 66, 2)
   }
 }
 


### PR DESCRIPTION
## QA-1769

### What?
To add a new load profile for 2 iters per second, based on the product team request

#### Changes:
- Added `ticfSIRA2ItersTest` profile using `createI4PeakTestSignInScenario('ticf', 2, 66, 2)`

---

### Why?
Based on the request from product team

---

