### PR TITLE
[QA-1771]: Lime CRI - Update getUserDetails to fix invalid date

### DIFF
--- a/deploy/scripts/src/cri-lime/test.ts
+++ b/deploy/scripts/src/cri-lime/test.ts
@@ -908,7 +908,7 @@ function getUserDetails(): User {
   return {
     firstName: `perfFirst${Math.floor(Math.random() * 99998) + 1}`,
     lastName: `perfLast${Math.floor(Math.random() * 99998) + 1}`,
-    day: Math.floor(Math.random() * 29) + 1,
+    day: Math.floor(Math.random() * 28) + 1,
     month: Math.floor(Math.random() * 12) + 1,
     year: Math.floor(Math.random() * 71) + 1950,
     buildNum: Math.floor(Math.random() * 999) + 1,


### PR DESCRIPTION
## QA-1771 <!--Jira Ticket Number-->

### What?
Lime CRI - Update `getUserDetails()` to fix invalid date

#### Changes:
- Lime CRI - Update `getUserDetails()` to not generate 29th February as a date for a non-leap year.

---

### Why?
To fix invalid date errors in performance tests.