### PR TITLE
QA-1747: To Adding Iteration 10 Peak profile into Mobile STS script

### DIFF
--- a/deploy/scripts/src/mobile/sts.ts
+++ b/deploy/scripts/src/mobile/sts.ts
@@ -164,6 +164,12 @@ const profiles: ProfileList = {
     ...createStressTestSignInScenario('reauthentication', 30, 27, 15, 195),
     ...createStressTestSignInScenario('walletCredentialIssuance', 38, 39, 18, 194),
     ...createStressTestSignInScenario('accountIntervention', 20, 15, 10, 197)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('authentication', 180, 36, 181),
+    ...createI4PeakTestSignInScenario('reauthentication', 9, 27, 5, 176),
+    ...createI4PeakTestSignInScenario('walletCredentialIssuance', 38, 39, 18, 163),
+    ...createI4PeakTestSignInScenario('accountIntervention', 6, 15, 4, 177)
   }
 }
 


### PR DESCRIPTION
## QA-1747

### What?
This PR is to add Iteration 10 peak test profile into deploy/scripts/src/mobile/sts.ts

#### Changes:
Added a new profile `perf006Iteration10PeakTest` with below details

- authentication (SignUp) targeting 18 TPH, with a ramp-up duration of 181s
- reauthentication (SignIn) targeting 9 TPH, with a ramp-up duration of 5s
- walletCredentialIssuance (SignIn) targeting 38 TPH, with a ramp-up duration of 18s
- accountIntervention (SignIn) targeting 6 TPH, with a ramp-up duration of 4s

---

### Why?
To conduct Iteration 10 peak test

---