### PR TITLE
[QA-1774]:Orange Ex KBV - Add I10 peak load profile

### DIFF
--- a/deploy/scripts/src/cri-orange/kbv.ts
+++ b/deploy/scripts/src/cri-orange/kbv.ts
@@ -111,6 +111,9 @@ const profiles: ProfileList = {
   },
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('kbv', 63, 12, 64)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('kbv', 20, 12, 21)
   }
 }
 


### PR DESCRIPTION
## QA-1774 <!--Jira Ticket Number-->

### What?
Add Iteration 10 peak load Test profile:


#### Changes:
Add Iteration 10 peak load Test profile:
-KBV at 2 Journeys per sec.

---

### Why?
To test the i10 peak test profiles

---


