### PR TITLE
[QA-1778]: Mobile ID Check Async - Add Iteration 10 load profile

### DIFF
--- a/deploy/scripts/src/mobile-id-check-async/test.ts
+++ b/deploy/scripts/src/mobile-id-check-async/test.ts
@@ -64,6 +64,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('idCheckAsyncSignUp', 600, 30, 600),
     ...createStressTestSignInScenario('idCheckAsyncSignIn', 250, 3, 115, 162)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('idCheckAsyncSignUp', 180, 30, 181),
+    ...createI4PeakTestSignInScenario('idCheckAsyncSignIn', 267, 3, 122, 59)
   }
 }
 


### PR DESCRIPTION
## QA-1778 <!--Jira Ticket Number-->

### What?
Mobile ID Check Async - Add Iteration 10 load profile

#### Changes:
Add Iteration 10 load profile for ID Check Async scenarios with below test targets
- ID Check scenario - 18 journeys per second.
- Sign in scenario - 267 journeys per second

---

### Why?
To run Iteration 10 peak test for ID Check async scripts.