### PR TITLE
[QA-1783]:Add i10 peak test profile for status list

### DIFF
--- a/deploy/scripts/src/mobile/statusList.ts
+++ b/deploy/scripts/src/mobile/statusList.ts
@@ -59,6 +59,33 @@ const profiles: ProfileList = {
       ],
       exec: 'getStatusList'
     }
+  },
+  perf006Iteration10PeakTest: {
+    issueAndRevokeStatusList: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 837,
+      maxVUs: 1674,
+      stages: [
+        { target: 0, duration: '84s' }, //Phase delay
+        { target: 93, duration: '43s' },
+        { target: 93, duration: '55m' }
+      ],
+      exec: 'issueAndRevokeStatusList'
+    },
+    getStatusList: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 417,
+      maxVUs: 834,
+      stages: [
+        { target: 278, duration: '127s' },
+        { target: 278, duration: '55m' }
+      ],
+      exec: 'getStatusList'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1783 <!--Jira Ticket Number-->

### What?
Add I10 peak test profile for status list

#### Changes:
- issueAndRevokeStatusList : Target Throughput is 93 iterations/sec, Ramp up is 43 sec
- getStatusList : Target Throughput is 278 iterations/sec, Rampup is 127 sec

---

### Why?
Perf006 Iteration 10 execution

---

### Related:

