### PR TITLE
[QA-1782]:Mobile BE - Add Iteration 10 load profile

### DIFF
--- a/deploy/scripts/src/mobile/mobile-backend.ts
+++ b/deploy/scripts/src/mobile/mobile-backend.ts
@@ -128,6 +128,33 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('getClientAttestation', 1500, 12, 600),
     ...createStressTestSignInScenario('walletCredentialIssuance', 38, 27, 15, 195)
+  },
+  perf006Iteration10PeakTest: {
+    getClientAttestation: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '10s',
+      preAllocatedVUs: 540,
+      maxVUs: 1080,
+      stages: [
+        { target: 450, duration: '181s' },
+        { target: 450, duration: '50m' }
+      ],
+      exec: 'getClientAttestation'
+    },
+    walletCredentialIssuance: {
+      executor: 'ramping-arrival-rate',
+      startRate: 2,
+      timeUnit: '1s',
+      preAllocatedVUs: 741,
+      maxVUs: 1482,
+      startTime: '166s',
+      stages: [
+        { target: 38, duration: '15s' },
+        { target: 38, duration: '50m' }
+      ],
+      exec: 'walletCredentialIssuance'
+    }
   }
 }
 


### PR DESCRIPTION
## QA-1782 <!--Jira Ticket Number-->

### What?
Mobile BE add 110 load profile

#### Changes:
Add Iteration 10 load profile for Mobile BE scenarios with below test targets

- Get Client Attestation - 45 journeys per second.

- Wallet Credential Issuance - 38 journeys per second

### Why?
To run iteration 10 peak test for Mobile BE Scenarios 

---
