### PR TITLE
[QA-1789]: Kiwi - Add I10 peak test profiles for CIC and F2F

### DIFF
--- a/deploy/scripts/src/cri-kiwi/f2f-cic.ts
+++ b/deploy/scripts/src/cri-kiwi/f2f-cic.ts
@@ -118,6 +118,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('FaceToFace', 16, 42, 17),
     ...createStressTestSignUpScenario('CIC', 16, 21, 17)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('FaceToFace', 5, 42, 6),
+    ...createI4PeakTestSignUpScenario('CIC', 5, 21, 6)
   }
 }
 


### PR DESCRIPTION
## QA-1789 <!--Jira Ticket Number-->

### What?
Kiwi - Add I10 peak test profiles for CIC and F2F

#### Changes:
- Added peak test profile for CIC @ 0.5 journeys per second
- Added peak test profile for F2F @ 0.5 journeys per second

---

### Why?
To conduct peak test for F2F and CIC in Iteration 10