### PR TITLE
[QA-1795]: Add I10 Peak test profile for IPVR (BE+FE)

### DIFF
--- a/deploy/scripts/src/cri-kiwi/ipvr.ts
+++ b/deploy/scripts/src/cri-kiwi/ipvr.ts
@@ -121,6 +121,10 @@ const profiles: ProfileList = {
   perf006Iteration9StressTest: {
     ...createStressTestSignUpScenario('allEvents', 16, 20, 17, 33),
     ...createStressTestSignInScenario('authEvent', 250, 5, 115)
+  },
+  perf006Iteration10PeakTest: {
+    ...createI4PeakTestSignUpScenario('allEvents', 5, 20, 6, 116),
+    ...createI4PeakTestSignInScenario('authEvent', 267, 5, 122)
   }
 }
 


### PR DESCRIPTION
## QA-1795 <!--Jira Ticket Number-->

### What?
Add I10 Peak test profile for IPVR (BE+FE)

#### Changes:
- Auth Event : Target Throughput - 267 ite/sec
- All Events including FE : Target Throughput - 0.5 ite/sec

---

### Why?
To perform PERF006 Iteration 10 Execution

---

### Related:
- Smoke test executed locally one Iteration on I10 peak profile
- 
<img width="982" height="351" alt="image" src="https://github.com/user-attachments/assets/d57e5033-0b50-4cc7-bfac-8e886223ebda" />

