### PR TITLE
QA-1797: Add Iteration 10 OLH Spike test Profile

### DIFF
--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -439,6 +439,15 @@ const profiles: ProfileList = {
     ...createI4PeakTestSignInScenario('landingPage', 26, 13, 6),
     ...createOLHPeakTestScenario('setUpPasskey', 17, 33, 1),
     ...createOLHPeakTestScenario('removePasskey', 17, 33, 1)
+  },
+  perf006Iteration10SpikeTest: {
+    ...createI3SpikeOLHScenario('changeEmail', 36, 24, 1),
+    ...createI3SpikeOLHScenario('changePassword', 36, 21, 1),
+    ...createI3SpikeOLHScenario('changePhone', 36, 24, 1),
+    ...createI3SpikeOLHScenario('deleteAccount', 36, 18, 1),
+    ...createI3SpikeSignInScenario('landingPage', 57, 13, 27),
+    ...createI3SpikeOLHScenario('setUpPasskey', 36, 33, 1),
+    ...createI3SpikeOLHScenario('removePasskey', 36, 33, 1)
   }
 }
 
@@ -1512,7 +1521,7 @@ export function removePasskey(): void {
       }),
     {
       isStatusCode200,
-      ...pageContentCheck('You’ve removed your paskey')
+      ...pageContentCheck('You’ve removed your passkey')
     }
   )
 

--- a/deploy/scripts/src/olh/test.ts
+++ b/deploy/scripts/src/olh/test.ts
@@ -441,10 +441,10 @@ const profiles: ProfileList = {
     ...createOLHPeakTestScenario('removePasskey', 17, 33, 1)
   },
   perf006Iteration10SpikeTest: {
-    ...createI3SpikeOLHScenario('changeEmail', 36, 24, 1),
-    ...createI3SpikeOLHScenario('changePassword', 36, 21, 1),
-    ...createI3SpikeOLHScenario('changePhone', 36, 24, 1),
-    ...createI3SpikeOLHScenario('deleteAccount', 36, 18, 1),
+    ...createI3SpikeOLHScenario('changeEmail', 36, 43, 1),
+    ...createI3SpikeOLHScenario('changePassword', 36, 38, 1),
+    ...createI3SpikeOLHScenario('changePhone', 36, 43, 1),
+    ...createI3SpikeOLHScenario('deleteAccount', 36, 28, 1),
     ...createI3SpikeSignInScenario('landingPage', 57, 13, 27),
     ...createI3SpikeOLHScenario('setUpPasskey', 36, 33, 1),
     ...createI3SpikeOLHScenario('removePasskey', 36, 33, 1)


### PR DESCRIPTION
## QA-1797

### What?
Adds the `perf006Iteration10SpikeTest` load profile to the OLH test script and fixes a typo in a page content assertion.

#### Changes:
- Added `perf006Iteration10SpikeTest` profile to deploy/scripts/src/olh/test.ts with spike scenarios for all 7 journeys:
  - changeEmail, changePassword, changePhone, deleteAccount, setUpPasskey, removePasskey — 36 iterations/min
  - landingPage — 57 iterations/sec
- Fixed typo in removePasskey function: 'You've removed your paskey' → 'You've removed your passkey'

#### Note: The iteration durations match the peak test profile values and is not calculated as 3× the number of transactions.
---

### Why?
To conduct iteration 10 spike test

