### PR TITLE
DCMAW-21668: Update Status List Api performance tests using correct integration method

### DIFF
--- a/deploy/scripts/src/mobile/status-list/utils/config.ts
+++ b/deploy/scripts/src/mobile/status-list/utils/config.ts
@@ -9,6 +9,5 @@ export const config = {
   mockURL: getEnv(`STATUS_LIST_MOCK_URL_${environment}`),
   envURL: getEnv(`STATUS_LIST_URL_${environment}`),
   clientID: getEnv(`STATUS_LIST_CLIENT_ID_${environment}`),
-  isProxy: getEnv('STATUS_LIST_PROXY_API'),
   crsURL: getEnv(`STATUS_LIST_CRS_URL_${environment}`)
 }

--- a/deploy/scripts/src/mobile/statusList.ts
+++ b/deploy/scripts/src/mobile/statusList.ts
@@ -1,26 +1,26 @@
+import { SharedArray } from 'k6/data'
+import http, { type Response } from 'k6/http'
+import { type Options } from 'k6/options'
+import { AssumeRoleOutput } from '../common/utils/aws/types'
+import { isStatusCode200, isStatusCode202, pageContentCheck } from '../common/utils/checks/assertions'
+import { getEnv } from '../common/utils/config/environment-variables'
 import {
-  selectProfile,
+  createI3SpikeSignInScenario,
+  createI4PeakTestSignInScenario,
   createScenario,
   describeProfile,
   LoadProfile,
-  type ProfileList,
-  createI4PeakTestSignInScenario,
-  createI3SpikeSignInScenario
+  selectProfile,
+  type ProfileList
 } from '../common/utils/config/load-profiles'
-import { type Options } from 'k6/options'
-import http, { type Response } from 'k6/http'
-import { SharedArray } from 'k6/data'
+import { getThresholds } from '../common/utils/config/thresholds'
 import { iterationsCompleted, iterationsStarted } from '../common/utils/custom_metric/counter'
 import { timeGroup } from '../common/utils/request/timing'
-import { isStatusCode200, isStatusCode202, pageContentCheck } from '../common/utils/checks/assertions'
-import { getEnv } from '../common/utils/config/environment-variables'
 import { sleepBetween } from '../common/utils/sleep/sleepBetween'
 import { generateIssuePayload, generateRevokePayload } from './status-list/payloadGen/generator'
+import { config } from './status-list/utils/config'
+import { getIDX, getURI } from './status-list/utils/issueResponseValidation'
 import { signRequest } from './utils/signatureV4'
-import { AssumeRoleOutput } from '../common/utils/aws/types'
-import { getURI, getIDX } from './status-list/utils/issueResponseValidation'
-import { environment, config } from './status-list/utils/config'
-import { getThresholds } from '../common/utils/config/thresholds'
 
 const profiles: ProfileList = {
   smoke: {
@@ -94,11 +94,9 @@ const loadProfile = selectProfile(profiles)
 const groupMap = {
   issueAndRevokeStatusList: [
     'B01_IssueAndRevokeStatusList_01_SignIssuePayLoad',
-    'B01_IssueAndRevokeStatusList_02_IssueAPICallViaProxy', //pragma: allowlist secret
-    'B01_IssueAndRevokeStatusList_03_IssueAPICallViaPrivateAPI',
-    'B01_IssueAndRevokeStatusList_04_SignRevokePayload',
-    'B01_IssueAndRevokeStatusList_05_RevokeCallViaProxy', //pragma: allowlist secret
-    'B01_IssueAndRevokeStatusList_06_RevokeCallViaPrivateAPI'
+    'B01_IssueAndRevokeStatusList_02_IssueAPICall',
+    'B01_IssueAndRevokeStatusList_03_SignRevokePayload',
+    'B01_IssueAndRevokeStatusList_04_RevokeCall'
   ],
   getStatusList: ['B02_GetStatusList_01_GetStatusList']
 }
@@ -124,18 +122,12 @@ export function setup(): void {
   describeProfile(loadProfile)
 }
 
-const statusListHeaders = {
-  headers: {
-    'Content-Type': 'application/jwt'
-  }
-}
 const credentials = (JSON.parse(getEnv('EXECUTION_CREDENTIALS')) as AssumeRoleOutput).Credentials
 
 export function issueAndRevokeStatusList(): void {
   const groups = groupMap.issueAndRevokeStatusList
   let res: Response
   const issuePayload = JSON.stringify(generateIssuePayload(config.clientID))
-  const environmentName = environment.toLowerCase()
 
   const signedRequestMockIssue = signRequest(
     getEnv('AWS_REGION'),
@@ -163,39 +155,27 @@ export function issueAndRevokeStatusList(): void {
 
   sleepBetween(1, 3)
 
-  if (config.isProxy === 'True') {
-    const signedRequestProxyIssue = signRequest(
-      getEnv('AWS_REGION'),
-      credentials,
-      'POST',
-      config.envURL.split('https://')[1],
-      '/issue',
-      {
-        'Content-Type': 'application/jwt'
-      },
-      res.body as string
-    )
+  const signedRequestProxyIssue = signRequest(
+    getEnv('AWS_REGION'),
+    credentials,
+    'POST',
+    config.envURL.split('https://')[1],
+    '/issue',
+    {
+      'Content-Type': 'application/jwt'
+    },
+    res.body as string
+  )
 
-    //  B01_IssueAndRevokeStatusList_02_IssueAPICallViaProxy
-    res = timeGroup(
-      groups[1],
-      () => http.post(signedRequestProxyIssue.url, res.body, { headers: signedRequestProxyIssue.headers }),
-      {
-        isStatusCode200,
-        ...pageContentCheck('idx')
-      }
-    )
-  } else {
-    // B01_IssueAndRevokeStatusList_03_IssueAPICallViaPrivateAPI
-    res = timeGroup(
-      groups[2],
-      () => http.post(`${config.envURL}/${environmentName}/issue`, res.body, statusListHeaders),
-      {
-        isStatusCode200,
-        ...pageContentCheck('idx')
-      }
-    )
-  }
+  // B01_IssueAndRevokeStatusList_02_IssueAPICall
+  res = timeGroup(
+    groups[1],
+    () => http.post(signedRequestProxyIssue.url, res.body, { headers: signedRequestProxyIssue.headers }),
+    {
+      isStatusCode200,
+      ...pageContentCheck('idx')
+    }
+  )
 
   const uriValue = getURI(res)
   const idxValue = getIDX(res)
@@ -220,7 +200,7 @@ export function issueAndRevokeStatusList(): void {
   // 90% of the users call /revoke
 
   if (Math.random() <= 0.9) {
-    // B01_IssueAndRevokeStatusList_04_SignRevokePayload
+    // B01_IssueAndRevokeStatusList_03_SignRevokePayload
     res = timeGroup(
       groups[3],
       () => http.post(signedRequestMockRevoke.url, revokePayload, { headers: signedRequestMockRevoke.headers }),
@@ -230,39 +210,27 @@ export function issueAndRevokeStatusList(): void {
     )
     sleepBetween(1, 3)
 
-    if (config.isProxy === 'True') {
-      const signedRequestProxyRevoke = signRequest(
-        getEnv('AWS_REGION'),
-        credentials,
-        'POST',
-        config.envURL.split('https://')[1],
-        '/revoke',
-        {
-          'Content-Type': 'application/jwt'
-        },
-        res.body as string
-      )
+    const signedRequestProxyRevoke = signRequest(
+      getEnv('AWS_REGION'),
+      credentials,
+      'POST',
+      config.envURL.split('https://')[1],
+      '/revoke',
+      {
+        'Content-Type': 'application/jwt'
+      },
+      res.body as string
+    )
 
-      // B01_IssueAndRevokeStatusList_05_RevokeCallViaProxy
-      res = timeGroup(
-        groups[4],
-        () => http.post(signedRequestProxyRevoke.url, res.body, { headers: signedRequestProxyRevoke.headers }),
-        {
-          isStatusCode202,
-          ...pageContentCheck('Request processed for revocation')
-        }
-      )
-    } else {
-      //B01_IssueAndRevokeStatusList_06_RevokeCallViaPrivateAPI
-      res = timeGroup(
-        groups[5],
-        () => http.post(`${config.envURL}/${environmentName}/revoke`, res.body, statusListHeaders),
-        {
-          isStatusCode202,
-          ...pageContentCheck('Request processed for revocation')
-        }
-      )
-    }
+    // B01_IssueAndRevokeStatusList_04_RevokeCall
+    res = timeGroup(
+      groups[4],
+      () => http.post(signedRequestProxyRevoke.url, res.body, { headers: signedRequestProxyRevoke.headers }),
+      {
+        isStatusCode202,
+        ...pageContentCheck('Request processed for revocation')
+      }
+    )
   }
 
   iterationsCompleted.add(1)

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -657,7 +657,6 @@ Resources:
               SLACK_OAUTH_TOKEN: "/perfTest/slack/OAuthToken"
               STATUS_LIST_CLIENT_ID_DEV: "/perfTest/statusList/dev/clientID"
               STATUS_LIST_MOCK_URL_DEV: "/perfTest/statusList/dev/mockURL"
-              STATUS_LIST_PROXY_API: "/perfTest/statusList/isProxy"
               STATUS_LIST_URL_DEV: "/perfTest/statusList/dev/statsListURL"
               STATUS_LIST_CLIENT_ID_BUILD: "/perfTest/statusList/build/clientID"
               STATUS_LIST_MOCK_URL_BUILD: "/perfTest/statusList/build/mockURL"


### PR DESCRIPTION
# Status List Performance Tests

The Status list are moving from a private api gateway secured at a network level using a vpc endpoint to a public Status Api secured with a sigv4 header. This is the same access pattern currently used for the "proxy" api allowing ther performance tests to be tested outside of the vpc.

The Status List have now removed the proxy api in favour of the status api. The old private API will be removed once all integrations hav moved across (there are two other integrations, the example credential issuer from on boarding products and Dvla in the integration environment)

Have validated the script in build locally. This is working fine.
<img width="1048" height="517" alt="image" src="https://github.com/user-attachments/assets/ffd64fc3-404f-4224-b6d9-22ef1d7db36e" />
