### PR TITLE
[QA-1801]: create spike test load profile function to fit the phase delay and to add I10 spike test profile for IPV Core

### DIFF
--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -403,6 +403,80 @@ export function createI4PeakTestSignInScenario(
   return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signInConfig, phaseDelay)
 }
 
+interface SpikeTestConfig {
+  startRate: number
+  timeUnit: string
+  holdTarget: number
+  vuFactor: number
+}
+
+export function createSpikeTestScenario(
+  exec: string,
+  target: number = 1,
+  iterationDuration: number,
+  phaseDelay: number,
+  config: SpikeTestConfig,
+  rampUpNFR: number
+): ScenarioList {
+  const list: ScenarioList = {}
+  const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
+  const maxVUs = Math.round((target / 10) * iterationDuration)
+  const step = Math.round(target / 3)
+  const spikeRamp = Math.round(rampUpNFR / 5)
+  list[exec] = {
+    executor: 'ramping-arrival-rate',
+    startRate: config.startRate,
+    timeUnit: config.timeUnit,
+    preAllocatedVUs,
+    maxVUs,
+    stages: [
+      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
+      { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
+      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
+      { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+      { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
+      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
+      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
+      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
+      { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+    ],
+    exec
+  }
+  return list
+}
+
+export function createSpikeTestSignUpScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpNFR: number,
+  phaseDelay: number = 0
+): ScenarioList {
+  return createStressTestScenario(exec, target, iterationDuration, rampUpNFR, phaseDelay, {
+    startRate: 1,
+    timeUnit: '10s',
+    holdTarget: 1,
+    vuFactor: 0.1
+  })
+}
+
+export function createSpikeTestSignInScenario(
+  exec: string,
+  target: number,
+  iterationDuration: number,
+  rampUpNFR: number,
+  phaseDelay: number = 0
+): ScenarioList {
+  return createStressTestScenario(exec, target, iterationDuration, rampUpNFR, phaseDelay, {
+    startRate: 2,
+    timeUnit: '1s',
+    holdTarget: 2,
+    vuFactor: 1
+  })
+}
+
 export function createI3SpikeOLHScenario(
   exec: string,
   target: number = 1,

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -403,24 +403,19 @@ export function createI4PeakTestSignInScenario(
   return createPerfTestScenario(exec, target, iterationDuration, rampUpDuration, '30m', signInConfig, phaseDelay)
 }
 
-interface SpikeTestConfig {
-  startRate: number
-  timeUnit: string
-  holdTarget: number
-  vuFactor: number
-}
-
 export function createSpikeTestScenario(
   exec: string,
-  target: number = 1,
+  target: number,
   iterationDuration: number,
-  phaseDelay: number = 0,
+  phaseDelay: number,
   config: SpikeTestConfig,
-  rampUpNFR: number
+  rampUpNFR: number,
+  spikeDelay: number = 0,
+  nfrDelay: number = 0
 ): ScenarioList {
   const list: ScenarioList = {}
-  const preAllocatedVUs = Math.round(((target / 10) * iterationDuration) / 2)
-  const maxVUs = Math.round((target / 10) * iterationDuration)
+  const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
+  const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
   const step = Math.round(target / 3)
   const spikeRamp = Math.round(rampUpNFR / 5)
   list[exec] = {
@@ -433,14 +428,14 @@ export function createSpikeTestScenario(
       ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
       { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
       { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before seocong ramp
-      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
-      { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
+      ...(spikeDelay > 0 ? [{ target: step, duration: `${spikeDelay}s` }] : []), // Hold at 33% to sync spike ramp start
+      { target, duration: `${spikeRamp}s` }, // Ramp up to 100% at 5x PERF008 growth rate
+      { target, duration: '5m' }, // Maintain steady state at 100% for 5 minutes
       { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
-      { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before third ramp
-      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
-      { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
+      { target: step, duration: '5m' }, // Maintain steady state at 33% for 5 minutes
+      ...(nfrDelay > 0 ? [{ target: step, duration: `${nfrDelay}s` }] : []), // Hold at 33% to sync NFR ramp start
+      { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% at the rate defined in PERF008
+      { target, duration: '5m' } // Maintain steady state at 100% for 5 minutes
     ],
     exec
   }
@@ -452,14 +447,24 @@ export function createSpikeTestSignUpScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  phaseDelay: number = 0
+  delays: { phaseDelay?: number; spikeDelay?: number; nfrDelay?: number } = {}
 ): ScenarioList {
-  return createStressTestScenario(exec, target, iterationDuration, rampUpNFR, phaseDelay, {
-    startRate: 1,
-    timeUnit: '10s',
-    holdTarget: 1,
-    vuFactor: 0.1
-  })
+  const { phaseDelay = 0, spikeDelay = 0, nfrDelay = 0 } = delays
+  return createSpikeTestScenario(
+    exec,
+    target,
+    iterationDuration,
+    phaseDelay,
+    {
+      startRate: 1,
+      timeUnit: '10s',
+      holdTarget: 1,
+      vuFactor: 0.1
+    },
+    rampUpNFR,
+    spikeDelay,
+    nfrDelay
+  )
 }
 
 export function createSpikeTestSignInScenario(
@@ -467,14 +472,31 @@ export function createSpikeTestSignInScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  phaseDelay: number = 0
+  delays: { phaseDelay?: number; spikeDelay?: number; nfrDelay?: number } = {}
 ): ScenarioList {
-  return createStressTestScenario(exec, target, iterationDuration, rampUpNFR, phaseDelay, {
-    startRate: 2,
-    timeUnit: '1s',
-    holdTarget: 2,
-    vuFactor: 1
-  })
+  const { phaseDelay = 0, spikeDelay = 0, nfrDelay = 0 } = delays
+  return createSpikeTestScenario(
+    exec,
+    target,
+    iterationDuration,
+    phaseDelay,
+    {
+      startRate: 2,
+      timeUnit: '1s',
+      holdTarget: 2,
+      vuFactor: 1
+    },
+    rampUpNFR,
+    spikeDelay,
+    nfrDelay
+  )
+}
+
+interface SpikeTestConfig {
+  startRate: number
+  timeUnit: string
+  holdTarget: number
+  vuFactor: number
 }
 
 export function createI3SpikeOLHScenario(

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -416,7 +416,7 @@ export function createSpikeTestScenario(
   const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
   const step = Math.round(target / 3)
   const spikeRamp = Math.round(rampUpNFR / 5)
-  const spike1Delay = phaseDelay > 0 ? Math.round(phaseDelay / 5) : 0
+  const spikeDelay = phaseDelay > 0 ? Math.round(phaseDelay / 5) : 0
 
   list[exec] = {
     executor: 'ramping-arrival-rate',
@@ -427,7 +427,7 @@ export function createSpikeTestScenario(
     stages: [
       { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
       { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(spike1Delay > 0 ? [{ target: step, duration: `${spike1Delay}s` }] : []), // Hold at 33% to sync spike ramp start
+      ...(spikeDelay > 0 ? [{ target: step, duration: `${spikeDelay}s` }] : []), // Hold at 33% to sync spike ramp start
       { target, duration: `${spikeRamp}s` }, // Ramp up to 100% at 5x PERF008 growth rate
       { target, duration: '5m' }, // Maintain steady state at 100% for 5 minutes
       { target: step, duration: '1s' }, // Ramp down to 33% over 1 second

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -409,14 +409,15 @@ export function createSpikeTestScenario(
   iterationDuration: number,
   config: SpikeTestConfig,
   rampUpNFR: number,
-  spike1Delay: number = 0,
-  spike2Delay: number = 0
+  phaseDelay: number = 0
 ): ScenarioList {
   const list: ScenarioList = {}
   const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
   const maxVUs = Math.round(target * config.vuFactor * iterationDuration)
   const step = Math.round(target / 3)
   const spikeRamp = Math.round(rampUpNFR / 5)
+  const spike1Delay = phaseDelay > 0 ? Math.round(phaseDelay / 5) : 0
+
   list[exec] = {
     executor: 'ramping-arrival-rate',
     startRate: config.startRate,
@@ -431,7 +432,7 @@ export function createSpikeTestScenario(
       { target, duration: '5m' }, // Maintain steady state at 100% for 5 minutes
       { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
       { target: step, duration: '5m' }, // Maintain steady state at 33% for 5 minutes
-      ...(spike2Delay > 0 ? [{ target: step, duration: `${spike2Delay}s` }] : []), // Hold at 33% to sync NFR ramp start
+      ...(phaseDelay > 0 ? [{ target: step, duration: `${phaseDelay}s` }] : []), // Hold at 33% to sync NFR ramp start
       { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% at the rate defined in PERF008
       { target, duration: '5m' } // Maintain steady state at 100% for 5 minutes
     ],
@@ -445,22 +446,15 @@ export function createSpikeTestSignUpScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  delays: { spike1Delay?: number; spike2Delay?: number } = {}
+  phaseDelay: number = 0
 ): ScenarioList {
-  const { spike1Delay = 0, spike2Delay = 0 } = delays
   return createSpikeTestScenario(
     exec,
     target,
     iterationDuration,
-    {
-      startRate: 1,
-      timeUnit: '10s',
-      holdTarget: 1,
-      vuFactor: 0.1
-    },
+    { startRate: 1, timeUnit: '10s', holdTarget: 1, vuFactor: 0.1 },
     rampUpNFR,
-    spike1Delay,
-    spike2Delay
+    phaseDelay
   )
 }
 
@@ -469,22 +463,15 @@ export function createSpikeTestSignInScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  delays: { spike1Delay?: number; spike2Delay?: number } = {}
+  phaseDelay: number = 0
 ): ScenarioList {
-  const { spike1Delay = 0, spike2Delay = 0 } = delays
   return createSpikeTestScenario(
     exec,
     target,
     iterationDuration,
-    {
-      startRate: 2,
-      timeUnit: '1s',
-      holdTarget: 2,
-      vuFactor: 1
-    },
+    { startRate: 2, timeUnit: '1s', holdTarget: 2, vuFactor: 1 },
     rampUpNFR,
-    spike1Delay,
-    spike2Delay
+    phaseDelay
   )
 }
 

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -414,7 +414,7 @@ export function createSpikeTestScenario(
   exec: string,
   target: number = 1,
   iterationDuration: number,
-  phaseDelay: number,
+  phaseDelay: 0,
   config: SpikeTestConfig,
   rampUpNFR: number
 ): ScenarioList {
@@ -433,12 +433,12 @@ export function createSpikeTestScenario(
       ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
       { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
       { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
+      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before seocong ramp
       { target, duration: `${spikeRamp}s` }, // Ramp up to 100% target throughput at 5 X PERF008 growth rate
       { target, duration: '5m' }, // Maintain steady state at 100% target throughput for 5 minutes
       { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
       { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
+      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before third ramp
       { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% target throughput at the rate defined in PERF008
       { target, duration: '5m' } // Maintain steady state at 100% target throughput for 5 minutes
     ],

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -414,7 +414,7 @@ export function createSpikeTestScenario(
   exec: string,
   target: number = 1,
   iterationDuration: number,
-  phaseDelay: 0,
+  phaseDelay: number = 0,
   config: SpikeTestConfig,
   rampUpNFR: number
 ): ScenarioList {

--- a/deploy/scripts/src/common/utils/config/load-profiles.ts
+++ b/deploy/scripts/src/common/utils/config/load-profiles.ts
@@ -407,11 +407,10 @@ export function createSpikeTestScenario(
   exec: string,
   target: number,
   iterationDuration: number,
-  phaseDelay: number,
   config: SpikeTestConfig,
   rampUpNFR: number,
-  spikeDelay: number = 0,
-  nfrDelay: number = 0
+  spike1Delay: number = 0,
+  spike2Delay: number = 0
 ): ScenarioList {
   const list: ScenarioList = {}
   const preAllocatedVUs = Math.round((target * config.vuFactor * iterationDuration) / 2)
@@ -425,15 +424,14 @@ export function createSpikeTestScenario(
     preAllocatedVUs,
     maxVUs,
     stages: [
-      ...(phaseDelay > 0 ? [{ target: config.holdTarget, duration: `${phaseDelay}s` }] : []), // Hold before first ramp
       { target: step, duration: '4m' }, // Ramp up to 33% target throughput over 4 minutes
       { target: step, duration: '5m' }, // Maintain steady state at 33% target throughput for 5 minutes
-      ...(spikeDelay > 0 ? [{ target: step, duration: `${spikeDelay}s` }] : []), // Hold at 33% to sync spike ramp start
+      ...(spike1Delay > 0 ? [{ target: step, duration: `${spike1Delay}s` }] : []), // Hold at 33% to sync spike ramp start
       { target, duration: `${spikeRamp}s` }, // Ramp up to 100% at 5x PERF008 growth rate
       { target, duration: '5m' }, // Maintain steady state at 100% for 5 minutes
       { target: step, duration: '1s' }, // Ramp down to 33% over 1 second
       { target: step, duration: '5m' }, // Maintain steady state at 33% for 5 minutes
-      ...(nfrDelay > 0 ? [{ target: step, duration: `${nfrDelay}s` }] : []), // Hold at 33% to sync NFR ramp start
+      ...(spike2Delay > 0 ? [{ target: step, duration: `${spike2Delay}s` }] : []), // Hold at 33% to sync NFR ramp start
       { target, duration: `${rampUpNFR}s` }, // Ramp up to 100% at the rate defined in PERF008
       { target, duration: '5m' } // Maintain steady state at 100% for 5 minutes
     ],
@@ -447,14 +445,13 @@ export function createSpikeTestSignUpScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  delays: { phaseDelay?: number; spikeDelay?: number; nfrDelay?: number } = {}
+  delays: { spike1Delay?: number; spike2Delay?: number } = {}
 ): ScenarioList {
-  const { phaseDelay = 0, spikeDelay = 0, nfrDelay = 0 } = delays
+  const { spike1Delay = 0, spike2Delay = 0 } = delays
   return createSpikeTestScenario(
     exec,
     target,
     iterationDuration,
-    phaseDelay,
     {
       startRate: 1,
       timeUnit: '10s',
@@ -462,8 +459,8 @@ export function createSpikeTestSignUpScenario(
       vuFactor: 0.1
     },
     rampUpNFR,
-    spikeDelay,
-    nfrDelay
+    spike1Delay,
+    spike2Delay
   )
 }
 
@@ -472,14 +469,13 @@ export function createSpikeTestSignInScenario(
   target: number,
   iterationDuration: number,
   rampUpNFR: number,
-  delays: { phaseDelay?: number; spikeDelay?: number; nfrDelay?: number } = {}
+  delays: { spike1Delay?: number; spike2Delay?: number } = {}
 ): ScenarioList {
-  const { phaseDelay = 0, spikeDelay = 0, nfrDelay = 0 } = delays
+  const { spike1Delay = 0, spike2Delay = 0 } = delays
   return createSpikeTestScenario(
     exec,
     target,
     iterationDuration,
-    phaseDelay,
     {
       startRate: 2,
       timeUnit: '1s',
@@ -487,8 +483,8 @@ export function createSpikeTestSignInScenario(
       vuFactor: 1
     },
     rampUpNFR,
-    spikeDelay,
-    nfrDelay
+    spike1Delay,
+    spike2Delay
   )
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -15,7 +15,9 @@ import {
   createStressTestSignUpScenario,
   createStressTestSignInScenario,
   createSoakTestSignUpScenario,
-  createSoakTestSignInScenario
+  createSoakTestSignInScenario,
+  createSpikeTestSignUpScenario,
+  createSpikeTestSignInScenario
 } from '../common/utils/config/load-profiles'
 import { timeGroup } from '../common/utils/request/timing'
 import { passportPayload, addressPayloadP, kbvPayloadP, fraudPayloadP } from './data/passportData'
@@ -424,6 +426,10 @@ const profiles: ProfileList = {
   perf006Iteration10PeakTest: {
     ...createI4PeakTestSignUpScenario('identity', 200, 42, 201),
     ...createI4PeakTestSignInScenario('idReuse', 267, 6, 122, 79)
+  },
+  perf006Iteration10SpikeTest: {
+    ...createSpikeTestSignUpScenario('identity', 960, 42, 961),
+    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, 687)
   }
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -429,7 +429,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10SpikeTest: {
     ...createSpikeTestSignUpScenario('identity', 960, 42, 961),
-    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, { spike1Delay: 137, spike2Delay: 687 })
+    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, 687)
   }
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -429,7 +429,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10SpikeTest: {
     ...createSpikeTestSignUpScenario('identity', 960, 42, 961),
-    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, 687)
+    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, { spikeDelay: 137, nfrDelay: 687 })
   }
 }
 

--- a/deploy/scripts/src/ipv-core/test.ts
+++ b/deploy/scripts/src/ipv-core/test.ts
@@ -429,7 +429,7 @@ const profiles: ProfileList = {
   },
   perf006Iteration10SpikeTest: {
     ...createSpikeTestSignUpScenario('identity', 960, 42, 961),
-    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, { spikeDelay: 137, nfrDelay: 687 })
+    ...createSpikeTestSignInScenario('idReuse', 601, 6, 274, { spike1Delay: 137, spike2Delay: 687 })
   }
 }
 


### PR DESCRIPTION
## QA-1801 <!--Jira Ticket Number-->

### What?
 create spike test load profile function to fit the phase delay and to add I10 spike test profile for IPV Core

#### Changes:
- Created Spike Test Load test profile function to fit the Phase delay

-  Added I10 Load profile as below for IPV Core 
  -- Identity: 96 journeys/sec
  -- IdReuse: 601 journeys/sec


---

### Why?
Why are these changes being made?

---

### Related:
- [Smoke Test Executed locally and Spike Profile executed for a minue
<img width="1088" height="366" alt="image" src="https://github.com/user-attachments/assets/a8c792e4-5821-452b-8504-745259feefe1" />

